### PR TITLE
remove numbers module

### DIFF
--- a/src/CynanBot/misc/utils.py
+++ b/src/CynanBot/misc/utils.py
@@ -4,7 +4,6 @@ import os
 import random
 import re
 from datetime import datetime
-from numbers import Number
 from typing import Any, Dict, Generator, List, Optional, Pattern
 from urllib.parse import urlparse
 
@@ -152,7 +151,7 @@ def getBoolFromDict(d: Optional[Dict[str, Any]], key: str, fallback: Optional[bo
         raise KeyError(f'there is no fallback and key \"{key}\" doesn\'t exist in d: \"{d}\"')
 
     if not isValidBool(value):
-        if isinstance(value, Number):
+        if isinstance(value, (float, int)):
             value = numToBool(value)
         elif isinstance(value, str):
             value = strToBool(value)
@@ -337,11 +336,11 @@ def hasItems(l: Optional[Any]) -> bool:
 def isValidBool(b: Optional[bool]) -> bool:
     return b is not None and isinstance(b, bool)
 
-def isValidInt(i: Optional[Number]) -> bool:
+def isValidInt(i: Optional[float]) -> bool:
     return isValidNum(i) and isinstance(i, int)
 
-def isValidNum(n: Optional[Number]) -> bool:
-    return n is not None and isinstance(n, Number) and math.isfinite(n)
+def isValidNum(n: Optional[float]) -> bool:
+    return n is not None and isinstance(n, (float, int)) and math.isfinite(n)
 
 def isValidStr(s: Optional[str]) -> bool:
     return s is not None and isinstance(s, str) and len(s) >= 1 and not s.isspace()
@@ -358,7 +357,7 @@ def isValidUrl(s: Optional[str]) -> bool:
 
     return False
 
-def numToBool(n: Optional[Number]) -> bool:
+def numToBool(n: Optional[float]) -> bool:
     if not isValidNum(n):
         raise ValueError(f'n argument is malformed: \"{n}\"')
 


### PR DESCRIPTION
PEP https://peps.python.org/pep-0484/#the-numeric-tower
says there are issues with this numbers module.
In less formal places you can find python core maintainers (including Guido, the inventor of Python) saying that the numbers module was a mistake and you shouldn't use it.

You can always put an instance of `int` where a `float` belongs. So in most cases, you can use `float` for typing instead of `numbers.Number`.
For `isinstance`, it won't see an `int` as a `float`, so you can `isinstance(n, (float, int))`
If you find some other use case where that doesn't work, the official recommendation is to make a `typing.Protocol` specific for your use case.

for more information:
https://github.com/python/typing/issues/272
https://github.com/python/mypy/issues/3186
https://github.com/microsoft/pyright/issues/1575