### PR TITLE
eliminate repeated code patterns in enums

### DIFF
--- a/src/CynanBot/chatBand/chatBandInstrument.py
+++ b/src/CynanBot/chatBand/chatBandInstrument.py
@@ -1,9 +1,9 @@
-from enum import Enum, auto
+from enum import auto
 
-import CynanBot.misc.utils as utils
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 
 
-class ChatBandInstrument(Enum):
+class ChatBandInstrument(EnumWithToFromStr):
 
     BASS = auto()
     DRUMS = auto()
@@ -14,53 +14,3 @@ class ChatBandInstrument(Enum):
     TRUMPET = auto()
     VIOLIN = auto()
     WHISTLE = auto()
-
-    @classmethod
-    def fromStr(cls, text: str):
-        if not utils.isValidStr(text):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-
-        text = text.lower()
-
-        if text == 'bass':
-            return ChatBandInstrument.BASS
-        elif text == 'drums':
-            return ChatBandInstrument.DRUMS
-        elif text == 'guitar':
-            return ChatBandInstrument.GUITAR
-        elif text == 'magic':
-            return ChatBandInstrument.MAGIC
-        elif text == 'piano':
-            return ChatBandInstrument.PIANO
-        elif text == 'synth':
-            return ChatBandInstrument.SYNTH
-        elif text == 'trumpet':
-            return ChatBandInstrument.TRUMPET
-        elif text == 'violin':
-            return ChatBandInstrument.VIOLIN
-        elif text == 'whistle':
-            return ChatBandInstrument.WHISTLE
-        else:
-            raise ValueError(f'unknown ChatBandInstrument: \"{text}\"')
-
-    def toStr(self) -> str:
-        if self is ChatBandInstrument.BASS:
-            return 'bass'
-        elif self is ChatBandInstrument.DRUMS:
-            return 'drums'
-        elif self is ChatBandInstrument.GUITAR:
-            return 'guitar'
-        elif self is ChatBandInstrument.MAGIC:
-            return 'magic'
-        elif self is ChatBandInstrument.PIANO:
-            return 'piano'
-        elif self is ChatBandInstrument.SYNTH:
-            return 'synth'
-        elif self is ChatBandInstrument.TRUMPET:
-            return 'trumpet'
-        elif self is ChatBandInstrument.VIOLIN:
-            return 'violin'
-        elif self is ChatBandInstrument.WHISTLE:
-            return 'whistle'
-        else:
-            raise RuntimeError(f'unknown ChatBandInstrument: \"{self}\"')

--- a/src/CynanBot/cheerActions/cheerActionRequirement.py
+++ b/src/CynanBot/cheerActions/cheerActionRequirement.py
@@ -1,31 +1,9 @@
-from enum import Enum, auto
+from enum import auto
 
-import CynanBot.misc.utils as utils
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 
 
-class CheerActionRequirement(Enum):
+class CheerActionRequirement(EnumWithToFromStr):
 
     EXACT = auto()
     GREATER_THAN_OR_EQUAL_TO = auto()
-
-    @classmethod
-    def fromStr(cls, text: str):
-        if not utils.isValidStr(text):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-
-        text = text.lower()
-
-        if text == 'exact':
-            return CheerActionRequirement.EXACT
-        elif text == 'greater_than_or_equal_to':
-            return CheerActionRequirement.GREATER_THAN_OR_EQUAL_TO
-        else:
-            raise ValueError(f'unknown CheerActionRequirement: \"{text}\"')
-
-    def toStr(self) -> str:
-        if self is CheerActionRequirement.EXACT:
-            return 'exact'
-        elif self is CheerActionRequirement.GREATER_THAN_OR_EQUAL_TO:
-            return 'greater_than_or_equal_to'
-        else:
-            raise RuntimeError(f'unknown CheerActionRequirement: \"{self}\"')

--- a/src/CynanBot/cheerActions/cheerActionType.py
+++ b/src/CynanBot/cheerActions/cheerActionType.py
@@ -1,26 +1,8 @@
-from enum import Enum, auto
+from enum import auto
 
-import CynanBot.misc.utils as utils
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 
 
-class CheerActionType(Enum):
+class CheerActionType(EnumWithToFromStr):
 
     TIMEOUT = auto()
-
-    @classmethod
-    def fromStr(cls, text: str):
-        if not utils.isValidStr(text):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-
-        text = text.lower()
-
-        if text == 'timeout':
-            return CheerActionType.TIMEOUT
-        else:
-            raise ValueError(f'unknown CheerActionType: \"{text}\"')
-
-    def toStr(self) -> str:
-        if self is CheerActionType.TIMEOUT:
-            return 'timeout'
-        else:
-            raise RuntimeError(f'unknown CheerActionType: \"{self}\"')

--- a/src/CynanBot/misc/enumWithToFromStr.py
+++ b/src/CynanBot/misc/enumWithToFromStr.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+from typing_extensions import Self
+
+from CynanBot.misc import utils
+
+
+class EnumWithToFromStr(Enum):
+    """ Enum with `fromStr` and `toStr` methods attached """
+
+    @classmethod
+    def fromStr(cls, text: str) -> Self:
+        if not utils.isValidStr(text):
+            raise ValueError(f'text argument is malformed: "{text}"')
+
+        try:
+            return cls[text.upper()]
+        except KeyError:
+            raise ValueError(f'unknown {cls.__name__}: "{text}"')
+
+    def toStr(self) -> str:
+        return self.name.lower()

--- a/src/CynanBot/network/networkClientType.py
+++ b/src/CynanBot/network/networkClientType.py
@@ -1,23 +1,9 @@
-from enum import Enum, auto
+from enum import auto
 
-import CynanBot.misc.utils as utils
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 
 
-class NetworkClientType(Enum):
+class NetworkClientType(EnumWithToFromStr):
 
     AIOHTTP = auto()
     REQUESTS = auto()
-
-    @classmethod
-    def fromStr(cls, text: str):
-        if not utils.isValidStr(text):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-
-        text = text.lower()
-
-        if text == 'aiohttp':
-            return NetworkClientType.AIOHTTP
-        elif text == 'requests':
-            return NetworkClientType.REQUESTS
-        else:
-            raise ValueError(f'unknown NetworkClientType: \"{text}\"')

--- a/src/CynanBot/pkmn/pokepediaContestType.py
+++ b/src/CynanBot/pkmn/pokepediaContestType.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from enum import Enum, auto
 from typing import Optional
 
@@ -13,7 +14,7 @@ class PokepediaContestType(Enum):
     TOUGH = auto()
 
     @classmethod
-    def fromStr(cls, text: Optional[str]):
+    def fromStr(cls, text: Optional[str]) -> Optional[PokepediaContestType]:
         if not utils.isValidStr(text):
             return None
 

--- a/src/CynanBot/pkmn/pokepediaDamageClass.py
+++ b/src/CynanBot/pkmn/pokepediaDamageClass.py
@@ -1,31 +1,17 @@
-from enum import Enum, auto
+from __future__ import annotations
+from enum import auto
 from typing import Set
+from typing_extensions import override
 
-import CynanBot.misc.utils as utils
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 from CynanBot.pkmn.pokepediaElementType import PokepediaElementType
 
 
-class PokepediaDamageClass(Enum):
+class PokepediaDamageClass(EnumWithToFromStr):
 
     PHYSICAL = auto()
     SPECIAL = auto()
     STATUS = auto()
-
-    @classmethod
-    def fromStr(cls, text: str):
-        if not utils.isValidStr(text):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-
-        text = text.lower()
-
-        if text == 'physical':
-            return PokepediaDamageClass.PHYSICAL
-        elif text == 'special':
-            return PokepediaDamageClass.SPECIAL
-        elif text == 'status':
-            return PokepediaDamageClass.STATUS
-        else:
-            raise ValueError(f'unknown PokepediaDamageClass: \"{text}\"')
 
     # gen 1-3 have damage classes based off element type
     @classmethod
@@ -52,12 +38,6 @@ class PokepediaDamageClass(Enum):
         else:
             raise ValueError(f'unknown PokepediaElementType: \"{elementType}\"')
 
+    @override
     def toStr(self) -> str:
-        if self is PokepediaDamageClass.PHYSICAL:
-            return 'Physical'
-        elif self is PokepediaDamageClass.SPECIAL:
-            return 'Special'
-        elif self is PokepediaDamageClass.STATUS:
-            return 'Status'
-        else:
-            raise RuntimeError(f'unknown PokepediaDamageClass: \"{self}\"')
+        return super().toStr().title()

--- a/src/CynanBot/pkmn/pokepediaElementType.py
+++ b/src/CynanBot/pkmn/pokepediaElementType.py
@@ -1,10 +1,13 @@
-from enum import Enum, auto
+from enum import auto
 from typing import Optional
 
+from typing_extensions import override
+
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 import CynanBot.misc.utils as utils
 
 
-class PokepediaElementType(Enum):
+class PokepediaElementType(EnumWithToFromStr):
 
     BUG = auto()
     DARK = auto()
@@ -26,53 +29,12 @@ class PokepediaElementType(Enum):
     UNKNOWN = auto()
     WATER = auto()
 
+    @override
     @classmethod
     def fromStr(cls, text: str):
-        if not utils.isValidStr(text):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-
-        text = text.lower()
-
-        if text == 'bug':
-            return PokepediaElementType.BUG
-        elif text == 'dark':
-            return PokepediaElementType.DARK
-        elif text == 'dragon':
-            return PokepediaElementType.DRAGON
-        elif text == 'electric':
-            return PokepediaElementType.ELECTRIC
-        elif text == 'fairy':
-            return PokepediaElementType.FAIRY
-        elif text == 'fighting':
-            return PokepediaElementType.FIGHTING
-        elif text == 'fire':
-            return PokepediaElementType.FIRE
-        elif text == 'flying':
-            return PokepediaElementType.FLYING
-        elif text == 'ghost':
-            return PokepediaElementType.GHOST
-        elif text == 'grass':
-            return PokepediaElementType.GRASS
-        elif text == 'ground':
-            return PokepediaElementType.GROUND
-        elif text == 'ice':
-            return PokepediaElementType.ICE
-        elif text == 'normal':
-            return PokepediaElementType.NORMAL
-        elif text == 'poison':
-            return PokepediaElementType.POISON
-        elif text == 'psychic':
-            return PokepediaElementType.PSYCHIC
-        elif text == 'rock':
-            return PokepediaElementType.ROCK
-        elif text == 'steel':
-            return PokepediaElementType.STEEL
-        elif text in ('unknown', '???'):
+        if text == '???':
             return PokepediaElementType.UNKNOWN
-        elif text == 'water':
-            return PokepediaElementType.WATER
-        else:
-            raise ValueError(f'unknown PokepediaElementType: \"{text}\"')
+        return super().fromStr(text)
 
     def getEmoji(self) -> Optional[str]:
         if self is PokepediaElementType.BUG:
@@ -110,44 +72,6 @@ class PokepediaElementType(Enum):
         else:
             return self.toStr()
 
+    @override
     def toStr(self) -> str:
-        if self is PokepediaElementType.BUG:
-            return 'Bug'
-        elif self is PokepediaElementType.DARK:
-            return 'Dark'
-        elif self is PokepediaElementType.DRAGON:
-            return 'Dragon'
-        elif self is PokepediaElementType.ELECTRIC:
-            return 'Electric'
-        elif self is PokepediaElementType.FAIRY:
-            return 'Fairy'
-        elif self is PokepediaElementType.FIGHTING:
-            return 'Fighting'
-        elif self is PokepediaElementType.FIRE:
-            return 'Fire'
-        elif self is PokepediaElementType.FLYING:
-            return 'Flying'
-        elif self is PokepediaElementType.GHOST:
-            return 'Ghost'
-        elif self is PokepediaElementType.GRASS:
-            return 'Grass'
-        elif self is PokepediaElementType.GROUND:
-            return 'Ground'
-        elif self is PokepediaElementType.ICE:
-            return 'Ice'
-        elif self is PokepediaElementType.NORMAL:
-            return 'Normal'
-        elif self is PokepediaElementType.POISON:
-            return 'Poison'
-        elif self is PokepediaElementType.PSYCHIC:
-            return 'Psychic'
-        elif self is PokepediaElementType.ROCK:
-            return 'Rock'
-        elif self is PokepediaElementType.STEEL:
-            return 'Steel'
-        elif self is PokepediaElementType.UNKNOWN:
-            return 'Unknown'
-        elif self is PokepediaElementType.WATER:
-            return 'Water'
-        else:
-            raise RuntimeError(f'unknown PokepediaElementType: \"{self}\"')
+        return super().toStr().title()

--- a/src/CynanBot/pkmn/pokepediaMachineType.py
+++ b/src/CynanBot/pkmn/pokepediaMachineType.py
@@ -1,29 +1,15 @@
-from enum import Enum, auto
+from enum import auto
 
-import CynanBot.misc.utils as utils
+from typing_extensions import override
+
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 
 
-class PokepediaMachineType(Enum):
+class PokepediaMachineType(EnumWithToFromStr):
 
     HM = auto()
     TM = auto()
     TR = auto()
-
-    @classmethod
-    def fromStr(cls, text: str):
-        if not utils.isValidStr(text):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-
-        text = text.lower()
-
-        if text.startswith('hm'):
-            return PokepediaMachineType.HM
-        elif text.startswith('tm'):
-            return PokepediaMachineType.TM
-        elif text.startswith('tr'):
-            return PokepediaMachineType.TR
-        else:
-            raise ValueError(f'unknown PokepediaMachineType: \"{text}\"')
 
     def getMaxMachineNumber(self) -> int:
         if self is PokepediaMachineType.HM:
@@ -35,12 +21,6 @@ class PokepediaMachineType(Enum):
         else:
             raise RuntimeError(f'unknown PokepediaMachineType: \"{self}\"')
 
+    @override
     def toStr(self) -> str:
-        if self is PokepediaMachineType.HM:
-            return 'HM'
-        elif self is PokepediaMachineType.TM:
-            return 'TM'
-        elif self is PokepediaMachineType.TR:
-            return 'TR'
-        else:
-            raise RuntimeError(f'unknown PokepediaMachineType: \"{self}\"')
+        return super().toStr().upper()

--- a/src/CynanBot/storage/databaseType.py
+++ b/src/CynanBot/storage/databaseType.py
@@ -1,13 +1,18 @@
-from enum import Enum, auto
+from enum import auto
+
+from typing_extensions import override
+
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 
 import CynanBot.misc.utils as utils
 
 
-class DatabaseType(Enum):
+class DatabaseType(EnumWithToFromStr):
 
     POSTGRESQL = auto()
     SQLITE = auto()
 
+    @override
     @classmethod
     def fromStr(cls, text: str):
         if not utils.isValidStr(text):
@@ -15,9 +20,6 @@ class DatabaseType(Enum):
 
         text = text.lower()
 
-        if text in ('postgres', 'postgresql'):
+        if text == 'postgres':
             return DatabaseType.POSTGRESQL
-        elif text == 'sqlite':
-            return DatabaseType.SQLITE
-        else:
-            raise ValueError(f'unknown DatabaseType: \"{text}\"')
+        return super().fromStr(text)

--- a/src/CynanBot/trivia/triviaSource.py
+++ b/src/CynanBot/trivia/triviaSource.py
@@ -1,9 +1,12 @@
-from enum import Enum, auto
+from enum import auto
 
+from typing_extensions import override
+
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 import CynanBot.misc.utils as utils
 
 
-class TriviaSource(Enum):
+class TriviaSource(EnumWithToFromStr):
 
     BONGO = auto()
     FUNTOON = auto()
@@ -20,6 +23,7 @@ class TriviaSource(Enum):
     WILL_FRY_TRIVIA = auto()
     WWTBAM = auto()
 
+    @override
     @classmethod
     def fromStr(cls, text: str):
         if not utils.isValidStr(text):
@@ -27,36 +31,11 @@ class TriviaSource(Enum):
 
         text = text.lower()
 
-        if text == 'bongo':
-            return TriviaSource.BONGO
-        elif text == 'funtoon':
-            return TriviaSource.FUNTOON
-        elif text == 'joke_trivia_repository':
-            return TriviaSource.JOKE_TRIVIA_REPOSITORY
-        elif text == 'j_service':
-            return TriviaSource.J_SERVICE
-        elif text == 'lord_of_the_rings':
-            return TriviaSource.LORD_OF_THE_RINGS
-        elif text == 'millionaire':
-            return TriviaSource.MILLIONAIRE
-        elif text in ('open_trivia', 'open_trivia_database'):
+        if text == 'open_trivia':
             return TriviaSource.OPEN_TRIVIA_DATABASE
-        elif text == 'open_trivia_qa':
-            return TriviaSource.OPEN_TRIVIA_QA
-        elif text == 'poke_api':
-            return TriviaSource.POKE_API
-        elif text == 'quiz_api':
-            return TriviaSource.QUIZ_API
-        elif text == 'the_question_co':
-            return TriviaSource.THE_QUESTION_CO
-        elif text == 'trivia_database':
-            return TriviaSource.TRIVIA_DATABASE
-        elif text in ('will_fry_trivia', 'will_fry_trivia_api'):
+        elif text == 'will_fry_trivia_api':
             return TriviaSource.WILL_FRY_TRIVIA
-        elif text == 'wwtbam':
-            return TriviaSource.WWTBAM
-        else:
-            raise ValueError(f'unknown TriviaSource: \"{text}\"')
+        return super().fromStr(text)
 
     def isLocal(self) -> bool:
         if self is TriviaSource.BONGO:
@@ -88,34 +67,6 @@ class TriviaSource(Enum):
         else:
             raise RuntimeError(f'unknown TriviaSource: \"{self}\"')
 
+    @override
     def toStr(self) -> str:
-        if self is TriviaSource.BONGO:
-            return 'BONGO'
-        elif self is TriviaSource.FUNTOON:
-            return 'FUNTOON'
-        elif self is TriviaSource.JOKE_TRIVIA_REPOSITORY:
-            return 'JOKE_TRIVIA_REPOSITORY'
-        elif self is TriviaSource.J_SERVICE:
-            return 'J_SERVICE'
-        elif self is TriviaSource.LORD_OF_THE_RINGS:
-            return 'LORD_OF_THE_RINGS'
-        elif self is TriviaSource.MILLIONAIRE:
-            return 'MILLIONAIRE'
-        elif self is TriviaSource.OPEN_TRIVIA_DATABASE:
-            return 'OPEN_TRIVIA_DATABASE'
-        elif self is TriviaSource.OPEN_TRIVIA_QA:
-            return 'OPEN_TRIVIA_QA'
-        elif self is TriviaSource.POKE_API:
-            return 'POKE_API'
-        elif self is TriviaSource.QUIZ_API:
-            return 'QUIZ_API'
-        elif self is TriviaSource.THE_QUESTION_CO:
-            return 'THE_QUESTION_CO'
-        elif self is TriviaSource.TRIVIA_DATABASE:
-            return 'TRIVIA_DATABASE'
-        elif self is TriviaSource.WILL_FRY_TRIVIA:
-            return 'WILL_FRY_TRIVIA'
-        elif self is TriviaSource.WWTBAM:
-            return 'WWTBAM'
-        else:
-            raise RuntimeError(f'unknown TriviaSource: \"{self}\"')
+        return super().toStr().upper()

--- a/src/CynanBot/twitch/twitchThemeMode.py
+++ b/src/CynanBot/twitch/twitchThemeMode.py
@@ -1,23 +1,8 @@
-from enum import Enum, auto
+from enum import auto
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 
-import CynanBot.misc.utils as utils
 
-
-class TwitchThemeMode(Enum):
+class TwitchThemeMode(EnumWithToFromStr):
 
     DARK = auto()
     LIGHT = auto()
-
-    @classmethod
-    def fromStr(cls, text: str):
-        if not utils.isValidStr(text):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-
-        text = text.lower()
-
-        if text == 'dark':
-            return TwitchThemeMode.DARK
-        elif text == 'light':
-            return TwitchThemeMode.LIGHT
-        else:
-            raise ValueError(f'unknown TwitchThemeMode: \"{text}\"')

--- a/src/CynanBot/twitch/websocket/websocketOutcomeColor.py
+++ b/src/CynanBot/twitch/websocket/websocketOutcomeColor.py
@@ -1,23 +1,9 @@
-from enum import Enum, auto
+from enum import auto
 
-import CynanBot.misc.utils as utils
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 
 
-class WebsocketOutcomeColor(Enum):
+class WebsocketOutcomeColor(EnumWithToFromStr):
 
     BLUE = auto()
     PINK = auto()
-
-    @classmethod
-    def fromStr(cls, text: str):
-        if not utils.isValidStr(text):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-
-        text = text.lower()
-
-        if text == 'blue':
-            return WebsocketOutcomeColor.BLUE
-        elif text == 'pink':
-            return WebsocketOutcomeColor.PINK
-        else:
-            raise ValueError(f'unknown WebsocketOutcomeColor: \"{text}\"')

--- a/src/CynanBot/users/pkmnCatchType.py
+++ b/src/CynanBot/users/pkmnCatchType.py
@@ -1,29 +1,13 @@
-from enum import Enum, auto
+from enum import auto
 
-import CynanBot.misc.utils as utils
+from CynanBot.misc.enumWithToFromStr import EnumWithToFromStr
 
 
-class PkmnCatchType(Enum):
+class PkmnCatchType(EnumWithToFromStr):
 
     GREAT = auto()
     NORMAL = auto()
     ULTRA = auto()
-
-    @classmethod
-    def fromStr(cls, text: str):
-        if not utils.isValidStr(text):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-
-        text = text.lower()
-
-        if text == 'great':
-            return PkmnCatchType.GREAT
-        elif text == 'normal':
-            return PkmnCatchType.NORMAL
-        elif text == 'ultra':
-            return PkmnCatchType.ULTRA
-        else:
-            raise ValueError(f'unknown PkmnCatchType: \"{text}\"')
 
     def getSortOrder(self) -> int:
         if self is PkmnCatchType.GREAT:
@@ -32,15 +16,5 @@ class PkmnCatchType(Enum):
             return 0
         elif self is PkmnCatchType.ULTRA:
             return 2
-        else:
-            raise RuntimeError(f'unknown PkmnCatchType: \"{self}\"')
-
-    def toStr(self) -> str:
-        if self is PkmnCatchType.GREAT:
-            return 'great'
-        elif self is PkmnCatchType.NORMAL:
-            return 'normal'
-        elif self is PkmnCatchType.ULTRA:
-            return 'ultra'
         else:
             raise RuntimeError(f'unknown PkmnCatchType: \"{self}\"')


### PR DESCRIPTION
class `EnumWithToFromStr` has a generic `fromStr` method and `toStr` that can be inherited in other enums

`fromStr` needs the enum members to be uppercase
`toStr` returns them in lowercase

For some special cases that don't match this, I've used overrides.
Some enums had a lot of special behavior, so I didn't use this new class.
There might be other enums that I just didn't find.

tested with unit tests

---

`@override` is new in Python 3.12, but is available before 3.12 with `typing_extensions`

---

`from __future__ import annotations` is a feature that allows type annotations with symbols that are not defined (or not fully defined) until later in the file.
