### PR TITLE
typing for LRU

### DIFF
--- a/src/CynanBot/mostRecentChat/mostRecentChatsRepository.py
+++ b/src/CynanBot/mostRecentChat/mostRecentChatsRepository.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from collections import defaultdict
 from typing import Dict, Optional
 
@@ -33,7 +34,7 @@ class MostRecentChatsRepository(MostRecentChatsRepositoryInterface):
         self.__timber: TimberInterface = timber
 
         self.__isDatabaseReady: bool = False
-        self.__caches: Dict[str, LRU] = defaultdict(lambda: LRU(cacheSize))
+        self.__caches: Dict[str, LRU[str, Optional[MostRecentChat]]] = defaultdict(lambda: LRU(cacheSize))
 
     async def clearCaches(self):
         self.__caches.clear()


### PR DESCRIPTION
The new lru-dict library that you brought in, supports good generic typing.

You can specify the types that are in it with `LRU[KeyType, ValueType]`
 - If the type checker is in strict mode, it can complain if you don't have this information.
 - This requires Python 3.9 or `from __future__ import annotations`
    - In Python 3.8 and without `from __future__ import annotations`, it will say `TypeError: 'type' object is not subscriptable` at run time.
    - I recommend not supporting Python 3.8 if you can drop it, because 3.9 brings in a bunch of good typing features like this. And the type checker doesn't help you remember the import, so you don't see the error until run time.