### PR TITLE
better type variable name

### DIFF
--- a/src/CynanBot/misc/utils.py
+++ b/src/CynanBot/misc/utils.py
@@ -338,9 +338,9 @@ def getStrFromDict(
 
     return value
 
-T_Container = TypeVar("T_Container", bound=Sized)
+T_Sized = TypeVar("T_Sized", bound=Sized)
 
-def hasItems(l: Optional[T_Container]) -> TypeGuard[T_Container]:
+def hasItems(l: Optional[T_Sized]) -> TypeGuard[T_Sized]:
     return l is not None and len(l) >= 1
 
 def isValidBool(b: Optional[bool]) -> TypeGuard[bool]:


### PR DESCRIPTION
All that the `hasItems` function requires from its parameter (if not `None`), is that it has a size. So we can use a better type variable name to indicate that requirement.

We could consider something like `HasLen` because Python uses `len` to get the size, but the Python standard library has chosen the name `Sized` for this interface in `typing.Sized` and `collections.abc.Sized`.