### PR TITLE
fix typing for compileTextAnswersList

### DIFF
--- a/src/CynanBot/trivia/triviaAnswerCompiler.py
+++ b/src/CynanBot/trivia/triviaAnswerCompiler.py
@@ -1,6 +1,6 @@
 import re
 import traceback
-from typing import List, Optional, Pattern, Set
+from typing import Collection, List, Optional, Pattern, Set
 
 import roman
 from num2words import num2words
@@ -117,7 +117,7 @@ class TriviaAnswerCompiler():
 
     async def compileTextAnswersList(
         self,
-        answers: Optional[List[Optional[str]]],
+        answers: Optional[Collection[Optional[str]]],
         expandParentheses: bool = True
     ) -> List[str]:
         if not utils.isValidBool(expandParentheses):


### PR DESCRIPTION
If you have a function like this:
```python
def f(a: List[Optional[str]]) -> None:
    ...
```

You might think that this should be ok:
```python
my_list: List[str] = ["a", "b"]

f(my_list)
```

until you think about what that function might do:
```python
def f(a: List[Optional[str]]) -> None:
    a.append(None)  # this is valid


my_list: List[str] = ["a", "b"]

f(my_list)

# is my_list still List[str] ??
```

That's why it's not safe to pass a `List[str]` to a parameter that takes `List[Optional[str]]`.

That's why type checker is not ok with this: https://github.com/charlesmadere/CynanBot/blob/ed55fdabcfa71b46f364bca4066207c068272b09/src/CynanBot/trivia/triviaRepositories/jServiceTriviaQuestionRepository.py#L124-L134
(and other places)

`cleanedCorrectAnswers: List[str]` doesn't fit in
```python
    def compileTextAnswersList(answers: Optional[List[Optional[str]]])
```

You might be tempted to make the parameter typing more specific, but that can break things in other places and require reworks...

It's better to make parameter typing as general as possible. And that's actually the problem here. The parameter typing isn't too general, it's too specific!

Do we really need `answers` to be a `List` (if it's not `None`)? Let's look at the implementation and see what we need from `answers`...

```python
        if not utils.hasItems(answers):
```
Does this require `answers` to be a `list`? No, all that requires is that it have a size. (https://github.com/charlesmadere/CynanBot/pull/16)

```python
        for answer in answers:
            if not utils.isValidStr(answer):
```
Does this require `answers` to be a `list`? No, all that requires is that we can iterate through it and get `Optional[str]`.

So we don't need a `list`. All we really need is something that has a size, and we can iterate through it.

In `collection.abc` and in `typing`, there are interfaces for things you commonly need from collection types.
https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes

We need `__iter__` and `__len__` - `Collection` is the simplest interface for that.

Do you know what `Collection` _doesn't_ have?
It doesn't have `.append()` - so we can't `answers.append(None)`
It doesn't have `__setitem__` - so we can't `answers[0] = None`

So it solves the problem that we started with. It's safe to pass `List[str]` to a function that takes `Collection[Optional[str]]`.