### PR TITLE
remove unused initialization

### DIFF
--- a/src/CynanBot/trivia/compilers/triviaAnswerCompiler.py
+++ b/src/CynanBot/trivia/compilers/triviaAnswerCompiler.py
@@ -266,7 +266,7 @@ class TriviaAnswerCompiler(TriviaAnswerCompilerInterface):
             self.__timber.log('TriviaAnswerChecker', f'Unable to convert either usDollarAmount (\"{usDollarAmount}\") into float (raw match group: \"{match.group()}\")', e, traceback.format_exc())
             return None
 
-        cleanedUsDollarAmount: Optional[str] = None
+        cleanedUsDollarAmount: str
 
         if usDollarFloat.is_integer():
             cleanedUsDollarAmount = str(int(usDollarFloat))


### PR DESCRIPTION
`cleanedUsDollarAmount: str`
This will make sure that all branches assign a string before it's used.

For example, something like this:
```python3
        cleanedUsDollarAmount: str

        if usDollarFloat.is_integer():
            cleanedUsDollarAmount = str(int(usDollarFloat))
        elif usDollarFloat < 3.5:
            cleanedUsDollarAmount = '{:.2f}'.format(usDollarFloat)

        return [
            f'{match.group(1)} usd',
            cleanedUsDollarAmount
        ]
```
would make a type checking error, because not all possible branches assign a `str` to `cleanedUsDollarAmount`