### PR TITLE
fix broken return value in unit test

### DIFF
--- a/src/CynanBot/misc/tests/test_simpleDateTime.py
+++ b/src/CynanBot/misc/tests/test_simpleDateTime.py
@@ -74,7 +74,7 @@ class TestSimpleDateTime():
     def test__repr(self):
         someDate = utils.getDateTimeFromStr('2023-08-25T04:55:21+00:00')
         sdt = SimpleDateTime(someDate)
-        return str(someDate) == str(sdt)
+        assert str(someDate) == str(sdt)
 
     def test_sub(self):
         someDate = utils.getDateTimeFromStr('2023-08-25T04:55:21+00:00')


### PR DESCRIPTION
> ``TestSimpleDateTime::test__repr returned True, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?``