### PR TITLE
assert type checking

### DIFF
--- a/src/CynanBot/administratorProvider.py
+++ b/src/CynanBot/administratorProvider.py
@@ -17,12 +17,9 @@ class AdministratorProvider(AdministratorProviderInterface):
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise TypeError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__twitchTokensRepository: TwitchTokensRepositoryInterface = twitchTokensRepository

--- a/src/CynanBot/administratorProvider.py
+++ b/src/CynanBot/administratorProvider.py
@@ -17,9 +17,12 @@ class AdministratorProvider(AdministratorProviderInterface):
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise TypeError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__twitchTokensRepository: TwitchTokensRepositoryInterface = twitchTokensRepository

--- a/src/CynanBot/aniv/anivContentScanner.py
+++ b/src/CynanBot/aniv/anivContentScanner.py
@@ -18,10 +18,8 @@ class AnivContentScanner(AnivContentScannerInterface):
         contentScanner: ContentScannerInterface,
         timber: TimberInterface
     ):
-        if not isinstance(contentScanner, ContentScannerInterface):
-            raise ValueError(f'contentScanner argument is malformed: \"{contentScanner}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(contentScanner, ContentScannerInterface), f"malformed {contentScanner=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__contentScanner: ContentScannerInterface = contentScanner
         self.__timber: TimberInterface = timber
@@ -43,9 +41,8 @@ class AnivContentScanner(AnivContentScannerInterface):
         characterPairs: Dict[str, str],
         message: str
     ) -> bool:
-        if not isinstance(characterPairs, Dict):
-            raise ValueError(f'characterPairs argument is malformed: \"{characterPairs}\"')
-        elif not utils.isValidStr(message):
+        assert isinstance(characterPairs, Dict), f"malformed {characterPairs=}"
+        if not utils.isValidStr(message):
             raise ValueError(f'message argument is malformed: \"{message}\"')
 
         stack: Stack[str] = Stack()
@@ -67,7 +64,7 @@ class AnivContentScanner(AnivContentScannerInterface):
 
                     if not isinstance(startCharacter, str):
                         raise RuntimeError(f'Unable to find corresponding start character for end character \"{character}\"')
-                    elif stack.top() == startCharacter:
+                    if stack.top() == startCharacter:
                         stack.pop()
                     else:
                         self.__timber.log('AnivContentScanner', f'Discovered mismatching character pairs within aniv message ({message=}) ({stack=})')

--- a/src/CynanBot/aniv/anivContentScanner.py
+++ b/src/CynanBot/aniv/anivContentScanner.py
@@ -18,8 +18,10 @@ class AnivContentScanner(AnivContentScannerInterface):
         contentScanner: ContentScannerInterface,
         timber: TimberInterface
     ):
-        assert isinstance(contentScanner, ContentScannerInterface), f"malformed {contentScanner=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(contentScanner, ContentScannerInterface):
+            raise ValueError(f'contentScanner argument is malformed: \"{contentScanner}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__contentScanner: ContentScannerInterface = contentScanner
         self.__timber: TimberInterface = timber
@@ -41,8 +43,9 @@ class AnivContentScanner(AnivContentScannerInterface):
         characterPairs: Dict[str, str],
         message: str
     ) -> bool:
-        assert isinstance(characterPairs, Dict), f"malformed {characterPairs=}"
-        if not utils.isValidStr(message):
+        if not isinstance(characterPairs, Dict):
+            raise ValueError(f'characterPairs argument is malformed: \"{characterPairs}\"')
+        elif not utils.isValidStr(message):
             raise ValueError(f'message argument is malformed: \"{message}\"')
 
         stack: Stack[str] = Stack()
@@ -64,7 +67,7 @@ class AnivContentScanner(AnivContentScannerInterface):
 
                     if not isinstance(startCharacter, str):
                         raise RuntimeError(f'Unable to find corresponding start character for end character \"{character}\"')
-                    if stack.top() == startCharacter:
+                    elif stack.top() == startCharacter:
                         stack.pop()
                     else:
                         self.__timber.log('AnivContentScanner', f'Discovered mismatching character pairs within aniv message ({message=}) ({stack=})')

--- a/src/CynanBot/authRepository.py
+++ b/src/CynanBot/authRepository.py
@@ -12,8 +12,7 @@ from CynanBot.twitch.twitchHandleProviderInterface import \
 class AuthRepository(Clearable, TwitchCredentialsProviderInterface, TwitchHandleProviderInterface):
 
     def __init__(self, authJsonReader: JsonReaderInterface):
-        if not isinstance(authJsonReader, JsonReaderInterface):
-            raise ValueError(f'authJsonReader argument is malformed: \"{authJsonReader}\"')
+        assert isinstance(authJsonReader, JsonReaderInterface), f"malformed {authJsonReader=}"
 
         self.__authJsonReader: JsonReaderInterface = authJsonReader
 
@@ -66,7 +65,7 @@ class AuthRepository(Clearable, TwitchCredentialsProviderInterface, TwitchHandle
 
         if jsonContents is None:
             raise IOError(f'Error reading from Auth Repository file: \"{self.__authJsonReader}\"')
-        elif len(jsonContents) == 0:
+        if len(jsonContents) == 0:
             raise ValueError(f'JSON contents of Auth Repository file \"{self.__authJsonReader}\" is empty')
 
         return jsonContents
@@ -79,7 +78,7 @@ class AuthRepository(Clearable, TwitchCredentialsProviderInterface, TwitchHandle
 
         if jsonContents is None:
             raise IOError(f'Error reading from Auth Repository file: \"{self.__authJsonReader}\"')
-        elif len(jsonContents) == 0:
+        if len(jsonContents) == 0:
             raise ValueError(f'JSON contents of Auth Repository file \"{self.__authJsonReader}\" is empty')
 
         return jsonContents

--- a/src/CynanBot/authRepository.py
+++ b/src/CynanBot/authRepository.py
@@ -12,7 +12,8 @@ from CynanBot.twitch.twitchHandleProviderInterface import \
 class AuthRepository(Clearable, TwitchCredentialsProviderInterface, TwitchHandleProviderInterface):
 
     def __init__(self, authJsonReader: JsonReaderInterface):
-        assert isinstance(authJsonReader, JsonReaderInterface), f"malformed {authJsonReader=}"
+        if not isinstance(authJsonReader, JsonReaderInterface):
+            raise ValueError(f'authJsonReader argument is malformed: \"{authJsonReader}\"')
 
         self.__authJsonReader: JsonReaderInterface = authJsonReader
 
@@ -65,7 +66,7 @@ class AuthRepository(Clearable, TwitchCredentialsProviderInterface, TwitchHandle
 
         if jsonContents is None:
             raise IOError(f'Error reading from Auth Repository file: \"{self.__authJsonReader}\"')
-        if len(jsonContents) == 0:
+        elif len(jsonContents) == 0:
             raise ValueError(f'JSON contents of Auth Repository file \"{self.__authJsonReader}\" is empty')
 
         return jsonContents
@@ -78,7 +79,7 @@ class AuthRepository(Clearable, TwitchCredentialsProviderInterface, TwitchHandle
 
         if jsonContents is None:
             raise IOError(f'Error reading from Auth Repository file: \"{self.__authJsonReader}\"')
-        if len(jsonContents) == 0:
+        elif len(jsonContents) == 0:
             raise ValueError(f'JSON contents of Auth Repository file \"{self.__authJsonReader}\" is empty')
 
         return jsonContents

--- a/src/CynanBot/backgroundTaskHelper.py
+++ b/src/CynanBot/backgroundTaskHelper.py
@@ -5,8 +5,7 @@ from typing import Any, Coroutine, Set
 class BackgroundTaskHelper():
 
     def __init__(self, eventLoop: AbstractEventLoop):
-        if not isinstance(eventLoop, AbstractEventLoop):
-            raise ValueError(f'eventLoop argument is malformed: \"{eventLoop}\"')
+        assert isinstance(eventLoop, AbstractEventLoop), f"malformed {eventLoop=}"
 
         self.__eventLoop: AbstractEventLoop = eventLoop
         self.__backgroundTasks: Set[Any] = set()

--- a/src/CynanBot/backgroundTaskHelper.py
+++ b/src/CynanBot/backgroundTaskHelper.py
@@ -5,7 +5,8 @@ from typing import Any, Coroutine, Set
 class BackgroundTaskHelper():
 
     def __init__(self, eventLoop: AbstractEventLoop):
-        assert isinstance(eventLoop, AbstractEventLoop), f"malformed {eventLoop=}"
+        if not isinstance(eventLoop, AbstractEventLoop):
+            raise ValueError(f'eventLoop argument is malformed: \"{eventLoop}\"')
 
         self.__eventLoop: AbstractEventLoop = eventLoop
         self.__backgroundTasks: Set[Any] = set()

--- a/src/CynanBot/channelPointRedemptions/casualGamePollRedemption.py
+++ b/src/CynanBot/channelPointRedemptions/casualGamePollRedemption.py
@@ -19,10 +19,8 @@ class CasualGamePollRedemption(AbsChannelPointRedemption):
         twitchUtils: TwitchUtilsInterface,
         cooldown: timedelta = timedelta(seconds = 30)
     ):
-        if not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils

--- a/src/CynanBot/channelPointRedemptions/casualGamePollRedemption.py
+++ b/src/CynanBot/channelPointRedemptions/casualGamePollRedemption.py
@@ -19,8 +19,10 @@ class CasualGamePollRedemption(AbsChannelPointRedemption):
         twitchUtils: TwitchUtilsInterface,
         cooldown: timedelta = timedelta(seconds = 30)
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils

--- a/src/CynanBot/chatActions/anivCheckChatAction.py
+++ b/src/CynanBot/chatActions/anivCheckChatAction.py
@@ -38,25 +38,17 @@ class AnivCheckChatAction(AbsChatAction):
         userIdsRepository: UserIdsRepositoryInterface,
         timeoutDurationSeconds: int = 60
     ):
-        if not isinstance(anivContentScanner, AnivContentScannerInterface):
-            raise TypeError(f'anivContentScanner argument is malformed: \"{anivContentScanner}\"')
-        elif not isinstance(anivUserIdProvider, AnivUserIdProviderInterface):
-            raise TypeError(f'anivUserIdProvider argument is malformed: \"{anivUserIdProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
-            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
-        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
-            raise TypeError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not utils.isValidInt(timeoutDurationSeconds):
+        assert isinstance(anivContentScanner, AnivContentScannerInterface), f"malformed {anivContentScanner=}"
+        assert isinstance(anivUserIdProvider, AnivUserIdProviderInterface), f"malformed {anivUserIdProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
+        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not utils.isValidInt(timeoutDurationSeconds):
             raise TypeError(f'timeoutDurationSeconds argument is malformed: \"{timeoutDurationSeconds}\"')
-        elif timeoutDurationSeconds < 1 or timeoutDurationSeconds > 1209600:
+        if timeoutDurationSeconds < 1 or timeoutDurationSeconds > 1209600:
             raise ValueError(f'timeoutDurationSeconds argument is out of bounds: {timeoutDurationSeconds}')
 
         self.__anivContentScanner: AnivContentScannerInterface = anivContentScanner

--- a/src/CynanBot/chatActions/anivCheckChatAction.py
+++ b/src/CynanBot/chatActions/anivCheckChatAction.py
@@ -38,17 +38,25 @@ class AnivCheckChatAction(AbsChatAction):
         userIdsRepository: UserIdsRepositoryInterface,
         timeoutDurationSeconds: int = 60
     ):
-        assert isinstance(anivContentScanner, AnivContentScannerInterface), f"malformed {anivContentScanner=}"
-        assert isinstance(anivUserIdProvider, AnivUserIdProviderInterface), f"malformed {anivUserIdProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
-        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        if not utils.isValidInt(timeoutDurationSeconds):
+        if not isinstance(anivContentScanner, AnivContentScannerInterface):
+            raise TypeError(f'anivContentScanner argument is malformed: \"{anivContentScanner}\"')
+        elif not isinstance(anivUserIdProvider, AnivUserIdProviderInterface):
+            raise TypeError(f'anivUserIdProvider argument is malformed: \"{anivUserIdProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
+            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
+        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
+            raise TypeError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not utils.isValidInt(timeoutDurationSeconds):
             raise TypeError(f'timeoutDurationSeconds argument is malformed: \"{timeoutDurationSeconds}\"')
-        if timeoutDurationSeconds < 1 or timeoutDurationSeconds > 1209600:
+        elif timeoutDurationSeconds < 1 or timeoutDurationSeconds > 1209600:
             raise ValueError(f'timeoutDurationSeconds argument is out of bounds: {timeoutDurationSeconds}')
 
         self.__anivContentScanner: AnivContentScannerInterface = anivContentScanner

--- a/src/CynanBot/chatActions/catJamChatAction.py
+++ b/src/CynanBot/chatActions/catJamChatAction.py
@@ -22,16 +22,12 @@ class CatJamChatAction(AbsChatAction):
         catJamMessage: str = 'catJAM',
         cooldown: timedelta = timedelta(minutes = 20)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not utils.isValidStr(catJamMessage):
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not utils.isValidStr(catJamMessage):
             raise ValueError(f'catJamMessage argument is malformed: \"{catJamMessage}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/chatActions/catJamChatAction.py
+++ b/src/CynanBot/chatActions/catJamChatAction.py
@@ -22,12 +22,16 @@ class CatJamChatAction(AbsChatAction):
         catJamMessage: str = 'catJAM',
         cooldown: timedelta = timedelta(minutes = 20)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        if not utils.isValidStr(catJamMessage):
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not utils.isValidStr(catJamMessage):
             raise ValueError(f'catJamMessage argument is malformed: \"{catJamMessage}\"')
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/chatActions/chatActionsManager.py
+++ b/src/CynanBot/chatActions/chatActionsManager.py
@@ -42,32 +42,19 @@ class ChatActionsManager(ChatActionsManagerInterface):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if anivCheckChatAction is not None and not isinstance(anivCheckChatAction, AnivCheckChatAction):
-            raise ValueError(f'anivCheckChatAction argument is malformed: \"{anivCheckChatAction}\"')
-        elif catJamChatAction is not None and not isinstance(catJamChatAction, CatJamChatAction):
-            raise ValueError(f'catJamChatAction argument is malformed: \"{catJamChatAction}\"')
-        elif chatLoggerChatAction is not None and not isinstance(chatLoggerChatAction, ChatLoggerChatAction):
-            raise ValueError(f'chatLoggerChatAction argument is malformed: \"{chatLoggerChatAction}\"')
-        elif deerForceChatAction is not None and not isinstance(deerForceChatAction, DeerForceChatAction):
-            raise ValueError(f'deerForceChatAction argument is malformed: \"{deerForceChatAction}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface):
-            raise ValueError(f'mostRecentChatsRepository argument is malformed: \"{mostRecentChatsRepository}\"')
-        elif persistAllUsersChatAction is not None and not isinstance(persistAllUsersChatAction, PersistAllUsersChatAction):
-            raise ValueError(f'persistAllUsersChatAction argument is malformed: \"{persistAllUsersChatAction}\"')
-        elif schubertWalkChatAction is not None and not isinstance(schubertWalkChatAction, SchubertWalkChatAction):
-            raise ValueError(f'schubertWalkChatAction argument is malformed: \"{schubertWalkChatAction}\"')
-        elif supStreamerChatAction is not None and not isinstance(supStreamerChatAction, SupStreamerChatAction):
-            raise ValueError(f'supStreamerChatAction argument is malformed: \"{supStreamerChatAction}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert anivCheckChatAction is None or isinstance(anivCheckChatAction, AnivCheckChatAction), f"malformed {anivCheckChatAction=}"
+        assert catJamChatAction is None or isinstance(catJamChatAction, CatJamChatAction), f"malformed {catJamChatAction=}"
+        assert chatLoggerChatAction is None or isinstance(chatLoggerChatAction, ChatLoggerChatAction), f"malformed {chatLoggerChatAction=}"
+        assert deerForceChatAction is None or isinstance(deerForceChatAction, DeerForceChatAction), f"malformed {deerForceChatAction=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface), f"malformed {mostRecentChatsRepository=}"
+        assert persistAllUsersChatAction is None or isinstance(persistAllUsersChatAction, PersistAllUsersChatAction), f"malformed {persistAllUsersChatAction=}"
+        assert schubertWalkChatAction is None or isinstance(schubertWalkChatAction, SchubertWalkChatAction), f"malformed {schubertWalkChatAction=}"
+        assert supStreamerChatAction is None or isinstance(supStreamerChatAction, SupStreamerChatAction), f"malformed {supStreamerChatAction=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__anivCheckChatAction: Optional[AbsChatAction] = anivCheckChatAction
         self.__catJamChatAction: Optional[AbsChatAction] = catJamChatAction
@@ -82,8 +69,7 @@ class ChatActionsManager(ChatActionsManagerInterface):
         self.__usersRepository: UsersRepositoryInterface = usersRepository
 
     async def handleMessage(self, message: TwitchMessage):
-        if not isinstance(message, TwitchMessage):
-            raise ValueError(f'message argument is malformed: \"{message}\"')
+        assert isinstance(message, TwitchMessage), f"malformed {message=}"
 
         mostRecentChat = await self.__mostRecentChatsRepository.get(
             chatterUserId = message.getAuthorId(),
@@ -143,12 +129,9 @@ class ChatActionsManager(ChatActionsManagerInterface):
         message: TwitchMessage,
         user: UserInterface
     ):
-        if mostRecentChat is not None and not isinstance(mostRecentChat, MostRecentChat):
-            raise ValueError(f'mostRecentChat argument is malformed: \"{mostRecentChat}\"')
-        elif not isinstance(message, TwitchMessage):
-            raise ValueError(f'message argument is malformed: \"{message}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert mostRecentChat is None or isinstance(mostRecentChat, MostRecentChat), f"malformed {mostRecentChat=}"
+        assert isinstance(message, TwitchMessage), f"malformed {message=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         if self.__catJamChatAction is not None and await self.__catJamChatAction.handleChat(
             mostRecentChat = mostRecentChat,

--- a/src/CynanBot/chatActions/chatActionsManager.py
+++ b/src/CynanBot/chatActions/chatActionsManager.py
@@ -42,19 +42,32 @@ class ChatActionsManager(ChatActionsManagerInterface):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert anivCheckChatAction is None or isinstance(anivCheckChatAction, AnivCheckChatAction), f"malformed {anivCheckChatAction=}"
-        assert catJamChatAction is None or isinstance(catJamChatAction, CatJamChatAction), f"malformed {catJamChatAction=}"
-        assert chatLoggerChatAction is None or isinstance(chatLoggerChatAction, ChatLoggerChatAction), f"malformed {chatLoggerChatAction=}"
-        assert deerForceChatAction is None or isinstance(deerForceChatAction, DeerForceChatAction), f"malformed {deerForceChatAction=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface), f"malformed {mostRecentChatsRepository=}"
-        assert persistAllUsersChatAction is None or isinstance(persistAllUsersChatAction, PersistAllUsersChatAction), f"malformed {persistAllUsersChatAction=}"
-        assert schubertWalkChatAction is None or isinstance(schubertWalkChatAction, SchubertWalkChatAction), f"malformed {schubertWalkChatAction=}"
-        assert supStreamerChatAction is None or isinstance(supStreamerChatAction, SupStreamerChatAction), f"malformed {supStreamerChatAction=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if anivCheckChatAction is not None and not isinstance(anivCheckChatAction, AnivCheckChatAction):
+            raise ValueError(f'anivCheckChatAction argument is malformed: \"{anivCheckChatAction}\"')
+        elif catJamChatAction is not None and not isinstance(catJamChatAction, CatJamChatAction):
+            raise ValueError(f'catJamChatAction argument is malformed: \"{catJamChatAction}\"')
+        elif chatLoggerChatAction is not None and not isinstance(chatLoggerChatAction, ChatLoggerChatAction):
+            raise ValueError(f'chatLoggerChatAction argument is malformed: \"{chatLoggerChatAction}\"')
+        elif deerForceChatAction is not None and not isinstance(deerForceChatAction, DeerForceChatAction):
+            raise ValueError(f'deerForceChatAction argument is malformed: \"{deerForceChatAction}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface):
+            raise ValueError(f'mostRecentChatsRepository argument is malformed: \"{mostRecentChatsRepository}\"')
+        elif persistAllUsersChatAction is not None and not isinstance(persistAllUsersChatAction, PersistAllUsersChatAction):
+            raise ValueError(f'persistAllUsersChatAction argument is malformed: \"{persistAllUsersChatAction}\"')
+        elif schubertWalkChatAction is not None and not isinstance(schubertWalkChatAction, SchubertWalkChatAction):
+            raise ValueError(f'schubertWalkChatAction argument is malformed: \"{schubertWalkChatAction}\"')
+        elif supStreamerChatAction is not None and not isinstance(supStreamerChatAction, SupStreamerChatAction):
+            raise ValueError(f'supStreamerChatAction argument is malformed: \"{supStreamerChatAction}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__anivCheckChatAction: Optional[AbsChatAction] = anivCheckChatAction
         self.__catJamChatAction: Optional[AbsChatAction] = catJamChatAction
@@ -69,7 +82,8 @@ class ChatActionsManager(ChatActionsManagerInterface):
         self.__usersRepository: UsersRepositoryInterface = usersRepository
 
     async def handleMessage(self, message: TwitchMessage):
-        assert isinstance(message, TwitchMessage), f"malformed {message=}"
+        if not isinstance(message, TwitchMessage):
+            raise ValueError(f'message argument is malformed: \"{message}\"')
 
         mostRecentChat = await self.__mostRecentChatsRepository.get(
             chatterUserId = message.getAuthorId(),
@@ -129,9 +143,12 @@ class ChatActionsManager(ChatActionsManagerInterface):
         message: TwitchMessage,
         user: UserInterface
     ):
-        assert mostRecentChat is None or isinstance(mostRecentChat, MostRecentChat), f"malformed {mostRecentChat=}"
-        assert isinstance(message, TwitchMessage), f"malformed {message=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if mostRecentChat is not None and not isinstance(mostRecentChat, MostRecentChat):
+            raise ValueError(f'mostRecentChat argument is malformed: \"{mostRecentChat}\"')
+        elif not isinstance(message, TwitchMessage):
+            raise ValueError(f'message argument is malformed: \"{message}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         if self.__catJamChatAction is not None and await self.__catJamChatAction.handleChat(
             mostRecentChat = mostRecentChat,

--- a/src/CynanBot/chatActions/chatLoggerChatAction.py
+++ b/src/CynanBot/chatActions/chatLoggerChatAction.py
@@ -14,8 +14,7 @@ class ChatLoggerChatAction(AbsChatAction):
         self,
         chatLogger: ChatLoggerInterface
     ):
-        if not isinstance(chatLogger, ChatLoggerInterface):
-            raise ValueError(f'chatLogger argument is malformed: \"{chatLogger}\"')
+        assert isinstance(chatLogger, ChatLoggerInterface), f"malformed {chatLogger=}"
 
         self.__chatLogger: ChatLoggerInterface = chatLogger
 

--- a/src/CynanBot/chatActions/chatLoggerChatAction.py
+++ b/src/CynanBot/chatActions/chatLoggerChatAction.py
@@ -14,7 +14,8 @@ class ChatLoggerChatAction(AbsChatAction):
         self,
         chatLogger: ChatLoggerInterface
     ):
-        assert isinstance(chatLogger, ChatLoggerInterface), f"malformed {chatLogger=}"
+        if not isinstance(chatLogger, ChatLoggerInterface):
+            raise ValueError(f'chatLogger argument is malformed: \"{chatLogger}\"')
 
         self.__chatLogger: ChatLoggerInterface = chatLogger
 

--- a/src/CynanBot/chatActions/deerForceChatAction.py
+++ b/src/CynanBot/chatActions/deerForceChatAction.py
@@ -22,16 +22,12 @@ class DeerForceChatAction(AbsChatAction):
         deerForceMessage: str = 'D e e R F o r C e',
         cooldown: timedelta = timedelta(minutes = 20)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not utils.isValidStr(deerForceMessage):
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not utils.isValidStr(deerForceMessage):
             raise ValueError(f'deerForceMessage argument is malformed: \"{deerForceMessage}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/chatActions/deerForceChatAction.py
+++ b/src/CynanBot/chatActions/deerForceChatAction.py
@@ -22,12 +22,16 @@ class DeerForceChatAction(AbsChatAction):
         deerForceMessage: str = 'D e e R F o r C e',
         cooldown: timedelta = timedelta(minutes = 20)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        if not utils.isValidStr(deerForceMessage):
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not utils.isValidStr(deerForceMessage):
             raise ValueError(f'deerForceMessage argument is malformed: \"{deerForceMessage}\"')
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/chatActions/persistAllUsersChatAction.py
+++ b/src/CynanBot/chatActions/persistAllUsersChatAction.py
@@ -16,10 +16,8 @@ class PersistAllUsersChatAction(AbsChatAction):
         generalSettingsRepository: GeneralSettingsRepository,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__userIdsRepository: UserIdsRepositoryInterface = userIdsRepository

--- a/src/CynanBot/chatActions/persistAllUsersChatAction.py
+++ b/src/CynanBot/chatActions/persistAllUsersChatAction.py
@@ -16,8 +16,10 @@ class PersistAllUsersChatAction(AbsChatAction):
         generalSettingsRepository: GeneralSettingsRepository,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__userIdsRepository: UserIdsRepositoryInterface = userIdsRepository

--- a/src/CynanBot/chatActions/schubertWalkChatAction.py
+++ b/src/CynanBot/chatActions/schubertWalkChatAction.py
@@ -22,16 +22,12 @@ class SchubertWalkChatAction(AbsChatAction):
         schubertWalkMessage: str = 'SchubertWalk',
         cooldown: timedelta = timedelta(minutes = 20)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not utils.isValidStr(schubertWalkMessage):
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not utils.isValidStr(schubertWalkMessage):
             raise ValueError(f'schubertWalkMessage argument is malformed: \"{schubertWalkMessage}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/chatActions/schubertWalkChatAction.py
+++ b/src/CynanBot/chatActions/schubertWalkChatAction.py
@@ -22,12 +22,16 @@ class SchubertWalkChatAction(AbsChatAction):
         schubertWalkMessage: str = 'SchubertWalk',
         cooldown: timedelta = timedelta(minutes = 20)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        if not utils.isValidStr(schubertWalkMessage):
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not utils.isValidStr(schubertWalkMessage):
             raise ValueError(f'schubertWalkMessage argument is malformed: \"{schubertWalkMessage}\"')
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/chatActions/supStreamerChatAction.py
+++ b/src/CynanBot/chatActions/supStreamerChatAction.py
@@ -23,14 +23,10 @@ class SupStreamerChatAction(AbsChatAction):
         cooldown: timedelta = timedelta(hours = 6),
         timeZone: tzinfo = timezone.utc
     ):
-        if streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
-            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise TypeError(f'cooldown argument is malformed: \"{cooldown}\"')
-        elif not isinstance(timeZone, tzinfo):
-            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
 
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/chatActions/supStreamerChatAction.py
+++ b/src/CynanBot/chatActions/supStreamerChatAction.py
@@ -23,10 +23,14 @@ class SupStreamerChatAction(AbsChatAction):
         cooldown: timedelta = timedelta(hours = 6),
         timeZone: tzinfo = timezone.utc
     ):
-        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
-        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
+        if streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
+            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise TypeError(f'cooldown argument is malformed: \"{cooldown}\"')
+        elif not isinstance(timeZone, tzinfo):
+            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/chatBand/chatBandManager.py
+++ b/src/CynanBot/chatBand/chatBandManager.py
@@ -23,18 +23,13 @@ class ChatBandManager(ChatBandManagerInterface):
         eventCooldown: timedelta = timedelta(minutes = 5),
         memberCacheTimeToLive: timedelta = timedelta(minutes = 15)
     ):
-        if not isinstance(settingsJsonReader, JsonReaderInterface):
-            raise ValueError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(websocketConnectionServer, WebsocketConnectionServerInterface):
-            raise ValueError(f'websocketConnectionServer argument is malformed: \"{websocketConnectionServer}\"')
-        elif not utils.isValidStr(websocketEventType):
+        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(websocketConnectionServer, WebsocketConnectionServerInterface), f"malformed {websocketConnectionServer=}"
+        if not utils.isValidStr(websocketEventType):
             raise ValueError(f'websocketEventType argument is malformed: \"{websocketEventType}\"')
-        elif not isinstance(eventCooldown, timedelta):
-            raise ValueError(f'eventCooldown argument is malformed: \"{eventCooldown}\"')
-        elif not isinstance(memberCacheTimeToLive, timedelta):
-            raise ValueError(f'memberCacheTimeToLive argument is malformed: \"{memberCacheTimeToLive}\"')
+        assert isinstance(eventCooldown, timedelta), f"malformed {eventCooldown=}"
+        assert isinstance(memberCacheTimeToLive, timedelta), f"malformed {memberCacheTimeToLive=}"
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
         self.__timber: TimberInterface = timber
@@ -66,9 +61,9 @@ class ChatBandManager(ChatBandManagerInterface):
     ) -> Optional[ChatBandMember]:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(author):
+        if not utils.isValidStr(author):
             raise ValueError(f'author argument is malformed: \"{author}\"')
-        elif not utils.isValidStr(message):
+        if not utils.isValidStr(message):
             raise ValueError(f'message argument is malformed: \"{message}\"')
 
         isDebugLoggingEnabled = await self.__isDebugLoggingEnabled()
@@ -110,7 +105,7 @@ class ChatBandManager(ChatBandManagerInterface):
     def __getCooldownKey(self, twitchChannel: str, author: str) -> str:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(author):
+        if not utils.isValidStr(author):
             raise ValueError(f'author argument is malformed: \"{author}\"')
 
         return f'{twitchChannel.lower()}:{author.lower()}'
@@ -122,9 +117,9 @@ class ChatBandManager(ChatBandManagerInterface):
     async def playInstrumentForMessage(self, twitchChannel: str, author: str, message: str) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(author):
+        if not utils.isValidStr(author):
             raise ValueError(f'author argument is malformed: \"{author}\"')
-        elif not utils.isValidStr(message):
+        if not utils.isValidStr(message):
             raise ValueError(f'message argument is malformed: \"{message}\"')
 
         chatBandMember = await self.__findChatBandMember(
@@ -164,7 +159,7 @@ class ChatBandManager(ChatBandManagerInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from Chat Band file: \"{self.__settingsJsonReader}\"')
-        elif len(jsonContents) == 0:
+        if len(jsonContents) == 0:
             raise ValueError(f'JSON contents of Chat Band file \"{self.__settingsJsonReader}\" is empty')
 
         self.__jsonCache = jsonContents
@@ -188,8 +183,7 @@ class ChatBandManager(ChatBandManagerInterface):
         return None
 
     def __toEventData(self, chatBandMember: ChatBandMember) -> Dict[str, Any]:
-        if not isinstance(chatBandMember, ChatBandMember):
-            raise ValueError(f'chatBandMember argument is malformed: \"{chatBandMember}\"')
+        assert isinstance(chatBandMember, ChatBandMember), f"malformed {chatBandMember=}"
 
         return {
             'author': chatBandMember.getAuthor(),

--- a/src/CynanBot/chatBand/chatBandManager.py
+++ b/src/CynanBot/chatBand/chatBandManager.py
@@ -23,13 +23,18 @@ class ChatBandManager(ChatBandManagerInterface):
         eventCooldown: timedelta = timedelta(minutes = 5),
         memberCacheTimeToLive: timedelta = timedelta(minutes = 15)
     ):
-        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(websocketConnectionServer, WebsocketConnectionServerInterface), f"malformed {websocketConnectionServer=}"
-        if not utils.isValidStr(websocketEventType):
+        if not isinstance(settingsJsonReader, JsonReaderInterface):
+            raise ValueError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(websocketConnectionServer, WebsocketConnectionServerInterface):
+            raise ValueError(f'websocketConnectionServer argument is malformed: \"{websocketConnectionServer}\"')
+        elif not utils.isValidStr(websocketEventType):
             raise ValueError(f'websocketEventType argument is malformed: \"{websocketEventType}\"')
-        assert isinstance(eventCooldown, timedelta), f"malformed {eventCooldown=}"
-        assert isinstance(memberCacheTimeToLive, timedelta), f"malformed {memberCacheTimeToLive=}"
+        elif not isinstance(eventCooldown, timedelta):
+            raise ValueError(f'eventCooldown argument is malformed: \"{eventCooldown}\"')
+        elif not isinstance(memberCacheTimeToLive, timedelta):
+            raise ValueError(f'memberCacheTimeToLive argument is malformed: \"{memberCacheTimeToLive}\"')
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
         self.__timber: TimberInterface = timber
@@ -61,9 +66,9 @@ class ChatBandManager(ChatBandManagerInterface):
     ) -> Optional[ChatBandMember]:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(author):
+        elif not utils.isValidStr(author):
             raise ValueError(f'author argument is malformed: \"{author}\"')
-        if not utils.isValidStr(message):
+        elif not utils.isValidStr(message):
             raise ValueError(f'message argument is malformed: \"{message}\"')
 
         isDebugLoggingEnabled = await self.__isDebugLoggingEnabled()
@@ -105,7 +110,7 @@ class ChatBandManager(ChatBandManagerInterface):
     def __getCooldownKey(self, twitchChannel: str, author: str) -> str:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(author):
+        elif not utils.isValidStr(author):
             raise ValueError(f'author argument is malformed: \"{author}\"')
 
         return f'{twitchChannel.lower()}:{author.lower()}'
@@ -117,9 +122,9 @@ class ChatBandManager(ChatBandManagerInterface):
     async def playInstrumentForMessage(self, twitchChannel: str, author: str, message: str) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(author):
+        elif not utils.isValidStr(author):
             raise ValueError(f'author argument is malformed: \"{author}\"')
-        if not utils.isValidStr(message):
+        elif not utils.isValidStr(message):
             raise ValueError(f'message argument is malformed: \"{message}\"')
 
         chatBandMember = await self.__findChatBandMember(
@@ -159,7 +164,7 @@ class ChatBandManager(ChatBandManagerInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from Chat Band file: \"{self.__settingsJsonReader}\"')
-        if len(jsonContents) == 0:
+        elif len(jsonContents) == 0:
             raise ValueError(f'JSON contents of Chat Band file \"{self.__settingsJsonReader}\" is empty')
 
         self.__jsonCache = jsonContents
@@ -183,7 +188,8 @@ class ChatBandManager(ChatBandManagerInterface):
         return None
 
     def __toEventData(self, chatBandMember: ChatBandMember) -> Dict[str, Any]:
-        assert isinstance(chatBandMember, ChatBandMember), f"malformed {chatBandMember=}"
+        if not isinstance(chatBandMember, ChatBandMember):
+            raise ValueError(f'chatBandMember argument is malformed: \"{chatBandMember}\"')
 
         return {
             'author': chatBandMember.getAuthor(),

--- a/src/CynanBot/chatBand/chatBandMember.py
+++ b/src/CynanBot/chatBand/chatBandMember.py
@@ -13,11 +13,10 @@ class ChatBandMember():
     ):
         if not utils.isValidBool(isEnabled):
             raise ValueError(f'isEnabled argument is malformed: \"{isEnabled}\"')
-        elif not isinstance(instrument, ChatBandInstrument):
-            raise ValueError(f'instrument argument is malformed: \"{instrument}\"')
-        elif not utils.isValidStr(author):
+        assert isinstance(instrument, ChatBandInstrument), f"malformed {instrument=}"
+        if not utils.isValidStr(author):
             raise ValueError(f'author argument is malformed: \"{author}\"')
-        elif not utils.isValidStr(keyPhrase):
+        if not utils.isValidStr(keyPhrase):
             raise ValueError(f'keyPhrase argument is malformed: \"{keyPhrase}\"')
 
         self.__isEnabled: bool = isEnabled

--- a/src/CynanBot/chatBand/chatBandMember.py
+++ b/src/CynanBot/chatBand/chatBandMember.py
@@ -13,10 +13,11 @@ class ChatBandMember():
     ):
         if not utils.isValidBool(isEnabled):
             raise ValueError(f'isEnabled argument is malformed: \"{isEnabled}\"')
-        assert isinstance(instrument, ChatBandInstrument), f"malformed {instrument=}"
-        if not utils.isValidStr(author):
+        elif not isinstance(instrument, ChatBandInstrument):
+            raise ValueError(f'instrument argument is malformed: \"{instrument}\"')
+        elif not utils.isValidStr(author):
             raise ValueError(f'author argument is malformed: \"{author}\"')
-        if not utils.isValidStr(keyPhrase):
+        elif not utils.isValidStr(keyPhrase):
             raise ValueError(f'keyPhrase argument is malformed: \"{keyPhrase}\"')
 
         self.__isEnabled: bool = isEnabled

--- a/src/CynanBot/chatCommands/addCheerActionCommand.py
+++ b/src/CynanBot/chatCommands/addCheerActionCommand.py
@@ -34,18 +34,12 @@ class AddCheerActionCommand(AbsChatCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
-            raise TypeError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__cheerActionsRepository: CheerActionsRepositoryInterface = cheerActionsRepository
@@ -55,8 +49,7 @@ class AddCheerActionCommand(AbsChatCommand):
         self.__usersRepository: UsersRepositoryInterface = usersRepository
 
     async def __actionToStr(self, action: CheerAction) -> str:
-        if not isinstance(action, CheerAction):
-            raise TypeError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(action, CheerAction), f"malformed {action=}"
 
         cheerActionString = f'id={action.getActionId()}, amount={action.getAmount()}, duration={action.getDurationSeconds()}, streamStatus={action.getStreamStatusRequirement()}'
         return f'ⓘ Your new cheer action — {cheerActionString}'

--- a/src/CynanBot/chatCommands/addCheerActionCommand.py
+++ b/src/CynanBot/chatCommands/addCheerActionCommand.py
@@ -34,12 +34,18 @@ class AddCheerActionCommand(AbsChatCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
+            raise TypeError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__cheerActionsRepository: CheerActionsRepositoryInterface = cheerActionsRepository
@@ -49,7 +55,8 @@ class AddCheerActionCommand(AbsChatCommand):
         self.__usersRepository: UsersRepositoryInterface = usersRepository
 
     async def __actionToStr(self, action: CheerAction) -> str:
-        assert isinstance(action, CheerAction), f"malformed {action=}"
+        if not isinstance(action, CheerAction):
+            raise TypeError(f'action argument is malformed: \"{action}\"')
 
         cheerActionString = f'id={action.getActionId()}, amount={action.getAmount()}, duration={action.getDurationSeconds()}, streamStatus={action.getStreamStatusRequirement()}'
         return f'ⓘ Your new cheer action — {cheerActionString}'

--- a/src/CynanBot/chatCommands/addRecurringActionCommand.py
+++ b/src/CynanBot/chatCommands/addRecurringActionCommand.py
@@ -25,20 +25,13 @@ class AddRecurringActionCommand(AbsChatCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
-            raise TypeError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
-        elif not isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface):
-            raise TypeError(f'recurringActionsRepository argument is malformed: \"{recurringActionsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
+        assert isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface), f"malformed {recurringActionsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository

--- a/src/CynanBot/chatCommands/addRecurringActionCommand.py
+++ b/src/CynanBot/chatCommands/addRecurringActionCommand.py
@@ -25,13 +25,20 @@ class AddRecurringActionCommand(AbsChatCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
-        assert isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface), f"malformed {recurringActionsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
+            raise TypeError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
+        elif not isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface):
+            raise TypeError(f'recurringActionsRepository argument is malformed: \"{recurringActionsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository

--- a/src/CynanBot/chatCommands/superAnswerChatCommand.py
+++ b/src/CynanBot/chatCommands/superAnswerChatCommand.py
@@ -22,16 +22,11 @@ class SuperAnswerChatCommand(AbsChatCommand):
         triviaIdGenerator: TriviaIdGeneratorInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
-            raise TypeError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise TypeError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/chatCommands/superAnswerChatCommand.py
+++ b/src/CynanBot/chatCommands/superAnswerChatCommand.py
@@ -22,11 +22,16 @@ class SuperAnswerChatCommand(AbsChatCommand):
         triviaIdGenerator: TriviaIdGeneratorInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
+            raise TypeError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise TypeError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/chatLogger/absChatMessage.py
+++ b/src/CynanBot/chatLogger/absChatMessage.py
@@ -12,9 +12,8 @@ class AbsChatMessage(ABC):
         chatEventType: ChatEventType,
         twitchChannel: str
     ):
-        if not isinstance(chatEventType, ChatEventType):
-            raise ValueError(f'chatEventType argument is malformed: \"{chatEventType}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert isinstance(chatEventType, ChatEventType), f"malformed {chatEventType=}"
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__chatEventType: ChatEventType = chatEventType

--- a/src/CynanBot/chatLogger/absChatMessage.py
+++ b/src/CynanBot/chatLogger/absChatMessage.py
@@ -12,8 +12,9 @@ class AbsChatMessage(ABC):
         chatEventType: ChatEventType,
         twitchChannel: str
     ):
-        assert isinstance(chatEventType, ChatEventType), f"malformed {chatEventType=}"
-        if not utils.isValidStr(twitchChannel):
+        if not isinstance(chatEventType, ChatEventType):
+            raise ValueError(f'chatEventType argument is malformed: \"{chatEventType}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__chatEventType: ChatEventType = chatEventType

--- a/src/CynanBot/chatLogger/chatLogger.py
+++ b/src/CynanBot/chatLogger/chatLogger.py
@@ -27,15 +27,13 @@ class ChatLogger(ChatLoggerInterface):
         sleepTimeSeconds: float = 15,
         logRootDirectory: str = 'logs/chatLogger'
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidNum(sleepTimeSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        elif sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
+        if sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        elif not utils.isValidStr(logRootDirectory):
+        if not utils.isValidStr(logRootDirectory):
             raise ValueError(f'logRootDirectory argument is malformed: \"{logRootDirectory}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -47,8 +45,7 @@ class ChatLogger(ChatLoggerInterface):
         self.__messageQueue: SimpleQueue[AbsChatMessage] = SimpleQueue()
 
     def __getLogStatement(self, message: AbsChatMessage) -> str:
-        if not isinstance(message, AbsChatMessage):
-            raise ValueError(f'message argument is malformed: \"{message}\"')
+        assert isinstance(message, AbsChatMessage), f"malformed {message=}"
 
         logStatement: str = f'{message.getSimpleDateTime().getDateAndTimeStr(True)} —'
 
@@ -66,11 +63,11 @@ class ChatLogger(ChatLoggerInterface):
     def logMessage(self, msg: str, twitchChannel: str, userId: str, userName: str):
         if not utils.isValidStr(msg):
             raise ValueError(f'msg argument is malformed: \"{msg}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         chatMessage: AbsChatMessage = ChatMessage(
@@ -85,11 +82,11 @@ class ChatLogger(ChatLoggerInterface):
     def logRaid(self, raidSize: int, fromWho: str, twitchChannel: str):
         if not utils.isValidInt(raidSize):
             raise ValueError(f'raidSize argument is malformed: \"{raidSize}\"')
-        elif raidSize < 0 or raidSize > utils.getIntMaxSafeSize():
+        if raidSize < 0 or raidSize > utils.getIntMaxSafeSize():
             raise ValueError(f'raidSize argument is out of bounds: {raidSize}')
-        elif not utils.isValidStr(fromWho):
+        if not utils.isValidStr(fromWho):
             raise ValueError(f'fromWho argument is malformed: \"{fromWho}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         raidMessage: AbsChatMessage = RaidMessage(

--- a/src/CynanBot/chatLogger/chatLogger.py
+++ b/src/CynanBot/chatLogger/chatLogger.py
@@ -27,13 +27,15 @@ class ChatLogger(ChatLoggerInterface):
         sleepTimeSeconds: float = 15,
         logRootDirectory: str = 'logs/chatLogger'
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidNum(sleepTimeSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        if sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
+        elif sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        if not utils.isValidStr(logRootDirectory):
+        elif not utils.isValidStr(logRootDirectory):
             raise ValueError(f'logRootDirectory argument is malformed: \"{logRootDirectory}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -45,7 +47,8 @@ class ChatLogger(ChatLoggerInterface):
         self.__messageQueue: SimpleQueue[AbsChatMessage] = SimpleQueue()
 
     def __getLogStatement(self, message: AbsChatMessage) -> str:
-        assert isinstance(message, AbsChatMessage), f"malformed {message=}"
+        if not isinstance(message, AbsChatMessage):
+            raise ValueError(f'message argument is malformed: \"{message}\"')
 
         logStatement: str = f'{message.getSimpleDateTime().getDateAndTimeStr(True)} —'
 
@@ -63,11 +66,11 @@ class ChatLogger(ChatLoggerInterface):
     def logMessage(self, msg: str, twitchChannel: str, userId: str, userName: str):
         if not utils.isValidStr(msg):
             raise ValueError(f'msg argument is malformed: \"{msg}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         chatMessage: AbsChatMessage = ChatMessage(
@@ -82,11 +85,11 @@ class ChatLogger(ChatLoggerInterface):
     def logRaid(self, raidSize: int, fromWho: str, twitchChannel: str):
         if not utils.isValidInt(raidSize):
             raise ValueError(f'raidSize argument is malformed: \"{raidSize}\"')
-        if raidSize < 0 or raidSize > utils.getIntMaxSafeSize():
+        elif raidSize < 0 or raidSize > utils.getIntMaxSafeSize():
             raise ValueError(f'raidSize argument is out of bounds: {raidSize}')
-        if not utils.isValidStr(fromWho):
+        elif not utils.isValidStr(fromWho):
             raise ValueError(f'fromWho argument is malformed: \"{fromWho}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         raidMessage: AbsChatMessage = RaidMessage(

--- a/src/CynanBot/cheerActions/cheerAction.py
+++ b/src/CynanBot/cheerActions/cheerAction.py
@@ -24,27 +24,24 @@ class CheerAction():
         userId: str,
         userName: str
     ):
-        if not isinstance(bitRequirement, CheerActionBitRequirement):
-            raise TypeError(f'bitRequirement argument is malformed: \"{bitRequirement}\"')
-        elif not isinstance(streamStatusRequirement, CheerActionStreamStatusRequirement):
-            raise TypeError(f'streamStatusRequirement argument is malformed: \"{streamStatusRequirement}\"')
-        elif not isinstance(actionType, CheerActionType):
-            raise TypeError(f'actionType argument is malformed: \"{actionType}\"')
-        elif not utils.isValidInt(amount):
+        assert isinstance(bitRequirement, CheerActionBitRequirement), f"malformed {bitRequirement=}"
+        assert isinstance(streamStatusRequirement, CheerActionStreamStatusRequirement), f"malformed {streamStatusRequirement=}"
+        assert isinstance(actionType, CheerActionType), f"malformed {actionType=}"
+        if not utils.isValidInt(amount):
             raise TypeError(f'amount argument is malformed: \"{amount}\"')
-        elif amount < 1 or amount > utils.getIntMaxSafeSize():
+        if amount < 1 or amount > utils.getIntMaxSafeSize():
             raise ValueError(f'amount argument is out of bounds: {amount}')
-        elif not utils.isValidInt(durationSeconds):
+        if not utils.isValidInt(durationSeconds):
             raise TypeError(f'durationSeconds argument is malformed: \"{durationSeconds}\"')
-        elif durationSeconds < 1:
+        if durationSeconds < 1:
             raise ValueError(f'durationSeconds argument is out of bounds: {durationSeconds}')
-        elif durationSeconds > 1209600:
+        if durationSeconds > 1209600:
             raise TimeoutDurationSecondsTooLongException(f'durationSeconds argument is out of bounds: {durationSeconds}')
-        elif not utils.isValidStr(actionId):
+        if not utils.isValidStr(actionId):
             raise TypeError(f'actionId argument is malformed: \"{actionId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         self.__bitRequirement: CheerActionBitRequirement = bitRequirement

--- a/src/CynanBot/cheerActions/cheerAction.py
+++ b/src/CynanBot/cheerActions/cheerAction.py
@@ -24,24 +24,27 @@ class CheerAction():
         userId: str,
         userName: str
     ):
-        assert isinstance(bitRequirement, CheerActionBitRequirement), f"malformed {bitRequirement=}"
-        assert isinstance(streamStatusRequirement, CheerActionStreamStatusRequirement), f"malformed {streamStatusRequirement=}"
-        assert isinstance(actionType, CheerActionType), f"malformed {actionType=}"
-        if not utils.isValidInt(amount):
+        if not isinstance(bitRequirement, CheerActionBitRequirement):
+            raise TypeError(f'bitRequirement argument is malformed: \"{bitRequirement}\"')
+        elif not isinstance(streamStatusRequirement, CheerActionStreamStatusRequirement):
+            raise TypeError(f'streamStatusRequirement argument is malformed: \"{streamStatusRequirement}\"')
+        elif not isinstance(actionType, CheerActionType):
+            raise TypeError(f'actionType argument is malformed: \"{actionType}\"')
+        elif not utils.isValidInt(amount):
             raise TypeError(f'amount argument is malformed: \"{amount}\"')
-        if amount < 1 or amount > utils.getIntMaxSafeSize():
+        elif amount < 1 or amount > utils.getIntMaxSafeSize():
             raise ValueError(f'amount argument is out of bounds: {amount}')
-        if not utils.isValidInt(durationSeconds):
+        elif not utils.isValidInt(durationSeconds):
             raise TypeError(f'durationSeconds argument is malformed: \"{durationSeconds}\"')
-        if durationSeconds < 1:
+        elif durationSeconds < 1:
             raise ValueError(f'durationSeconds argument is out of bounds: {durationSeconds}')
-        if durationSeconds > 1209600:
+        elif durationSeconds > 1209600:
             raise TimeoutDurationSecondsTooLongException(f'durationSeconds argument is out of bounds: {durationSeconds}')
-        if not utils.isValidStr(actionId):
+        elif not utils.isValidStr(actionId):
             raise TypeError(f'actionId argument is malformed: \"{actionId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         self.__bitRequirement: CheerActionBitRequirement = bitRequirement

--- a/src/CynanBot/cheerActions/cheerActionHelper.py
+++ b/src/CynanBot/cheerActions/cheerActionHelper.py
@@ -59,30 +59,18 @@ class CheerActionHelper(CheerActionHelperInterface):
         minimumFollowDuration: timedelta = timedelta(weeks = 1),
         timeZone: tzinfo = timezone.utc
     ):
-        if not isinstance(cheerActionRemodHelper, CheerActionRemodHelperInterface):
-            raise TypeError(f'cheerActionRemodHelper argument is malformed: \"{cheerActionRemodHelper}\"')
-        elif not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
-            raise TypeError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
-        elif not isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface):
-            raise TypeError(f'isLiveOnTwitchRepository argument is malformed: \"{isLiveOnTwitchRepository}\"')
-        elif streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
-            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
-            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
-        elif not isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface):
-            raise TypeError(f'twitchFollowerRepository argument is malformed: \"{twitchFollowerRepository}\"')
-        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
-            raise TypeError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(minimumFollowDuration, timedelta):
-            raise TypeError(f'minimumFollowDuration argument is malformed: \"{minimumFollowDuration}\"')
-        elif not isinstance(timeZone, tzinfo):
-            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(cheerActionRemodHelper, CheerActionRemodHelperInterface), f"malformed {cheerActionRemodHelper=}"
+        assert isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
+        assert isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface), f"malformed {isLiveOnTwitchRepository=}"
+        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
+        assert isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface), f"malformed {twitchFollowerRepository=}"
+        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(minimumFollowDuration, timedelta), f"malformed {minimumFollowDuration=}"
+        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
 
         self.__cheerActionRemodHelper: CheerActionRemodHelperInterface = cheerActionRemodHelper
         self.__cheerActionsRepository: CheerActionsRepositoryInterface = cheerActionsRepository
@@ -116,16 +104,15 @@ class CheerActionHelper(CheerActionHelperInterface):
     ) -> bool:
         if not utils.isValidInt(bits):
             raise TypeError(f'bits argument is malformed: \"{bits}\"')
-        elif bits < 0 or bits > utils.getIntMaxSafeSize():
+        if bits < 0 or bits > utils.getIntMaxSafeSize():
             raise ValueError(f'bits argument is out of bounds: {bits}')
-        elif not utils.isValidStr(cheerUserId):
+        if not utils.isValidStr(cheerUserId):
             raise TypeError(f'cheerUserId argument is malformed: \"{cheerUserId}\"')
-        elif not utils.isValidStr(cheerUserName):
+        if not utils.isValidStr(cheerUserName):
             raise TypeError(f'cheerUserName argument is malformed: \"{cheerUserName}\"')
-        elif not utils.isValidStr(message):
+        if not utils.isValidStr(message):
             raise TypeError(f'message argument is malformed: \"{message}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         moderatorTwitchAccessToken = await self.__getTwitchAccessToken(
             twitchChannel = await self.__twitchHandleProvider.getTwitchHandle()
@@ -171,9 +158,9 @@ class CheerActionHelper(CheerActionHelperInterface):
     ) -> bool:
         if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif not utils.isValidStr(twitchAccessToken):
+        if not utils.isValidStr(twitchAccessToken):
             raise TypeError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.isValidStr(userIdToTimeout):
+        if not utils.isValidStr(userIdToTimeout):
             raise TypeError(f'userIdToTimeout argument is malformed: \"{userIdToTimeout}\"')
 
         moderatorInfo: Optional[TwitchModUser] = None
@@ -204,26 +191,24 @@ class CheerActionHelper(CheerActionHelperInterface):
     ) -> bool:
         if not utils.isValidInt(bits):
             raise TypeError(f'bits argument is malformed: \"{bits}\"')
-        elif bits < 0 or bits > utils.getIntMaxSafeSize():
+        if bits < 0 or bits > utils.getIntMaxSafeSize():
             raise ValueError(f'bits argument is out of bounds: {bits}')
-        elif not isinstance(actions, List):
-            raise TypeError(f'actions argument is malformed: \"{actions}\"')
-        elif not utils.isValidStr(broadcasterUserId):
+        assert isinstance(actions, List), f"malformed {actions=}"
+        if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif not utils.isValidStr(cheerUserId):
+        if not utils.isValidStr(cheerUserId):
             raise TypeError(f'cheerUserId argument is malformed: \"{cheerUserId}\"')
-        elif not utils.isValidStr(cheerUserName):
+        if not utils.isValidStr(cheerUserName):
             raise TypeError(f'cheerUserName argument is malformed: \"{cheerUserName}\"')
-        elif not utils.isValidStr(message):
+        if not utils.isValidStr(message):
             raise TypeError(f'message argument is malformed: \"{message}\"')
-        elif not utils.isValidStr(moderatorTwitchAccessToken):
+        if not utils.isValidStr(moderatorTwitchAccessToken):
             raise TypeError(f'moderatorTwitchAccessToken argument is malformed: \"{moderatorTwitchAccessToken}\"')
-        elif not utils.isValidStr(moderatorUserId):
+        if not utils.isValidStr(moderatorUserId):
             raise TypeError(f'moderatorUserId argument is malformed: \"{moderatorUserId}\"')
-        elif not utils.isValidStr(userTwitchAccessToken):
+        if not utils.isValidStr(userTwitchAccessToken):
             raise TypeError(f'userTwitchAccessToken argument is malformed: \"{userTwitchAccessToken}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         timeoutActions: List[CheerAction] = list()
 
@@ -303,26 +288,24 @@ class CheerActionHelper(CheerActionHelperInterface):
         userTwitchAccessToken: str,
         user: UserInterface
     ) -> bool:
-        if not isinstance(action, CheerAction):
-            raise TypeError(f'action argument is malformed: \"{action}\"')
-        elif not utils.isValidInt(bits):
+        assert isinstance(action, CheerAction), f"malformed {action=}"
+        if not utils.isValidInt(bits):
             raise TypeError(f'bits argument is malformed: \"{bits}\"')
-        elif not utils.isValidStr(broadcasterUserId):
+        if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif not utils.isValidStr(cheerUserId):
+        if not utils.isValidStr(cheerUserId):
             raise TypeError(f'cheerUserId argument is malformed: \"{cheerUserId}\"')
-        elif not utils.isValidStr(cheerUserName):
+        if not utils.isValidStr(cheerUserName):
             raise TypeError(f'cheerUserName argument is malformed: \"{cheerUserName}\"')
-        elif not utils.isValidStr(moderatorTwitchAccessToken):
+        if not utils.isValidStr(moderatorTwitchAccessToken):
             raise TypeError(f'moderatorTwitchAccessToken argument is malformed: \"{moderatorTwitchAccessToken}\"')
-        elif not utils.isValidStr(moderatorUserId):
+        if not utils.isValidStr(moderatorUserId):
             raise TypeError(f'moderatorUserId argument is malformed: \"{moderatorUserId}\"')
-        elif not utils.isValidStr(userIdToTimeout):
+        if not utils.isValidStr(userIdToTimeout):
             raise TypeError(f'userIdToTimeout argument is malformed: \"{userIdToTimeout}\"')
-        elif not utils.isValidStr(userTwitchAccessToken):
+        if not utils.isValidStr(userTwitchAccessToken):
             raise TypeError(f'userTwitchAccessToken argument is malformed: \"{userTwitchAccessToken}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         if not await self.__verifyUserCanBeTimedOut(
             broadcasterUserId = broadcasterUserId,
@@ -395,10 +378,8 @@ class CheerActionHelper(CheerActionHelperInterface):
         timeoutAction: CheerAction,
         user: UserInterface
     ) -> bool:
-        if not isinstance(timeoutAction, CheerAction):
-            raise TypeError(f'timeoutAction argument is malformed: \"{timeoutAction}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(timeoutAction, CheerAction), f"malformed {timeoutAction=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         requirement = timeoutAction.getStreamStatusRequirement()
 
@@ -419,9 +400,9 @@ class CheerActionHelper(CheerActionHelperInterface):
     ) -> bool:
         if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif not utils.isValidStr(twitchAccessToken):
+        if not utils.isValidStr(twitchAccessToken):
             raise TypeError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.isValidStr(userIdToTimeout):
+        if not utils.isValidStr(userIdToTimeout):
             raise TypeError(f'userIdToTimeout argument is malformed: \"{userIdToTimeout}\"')
 
         try:

--- a/src/CynanBot/cheerActions/cheerActionHelper.py
+++ b/src/CynanBot/cheerActions/cheerActionHelper.py
@@ -59,18 +59,30 @@ class CheerActionHelper(CheerActionHelperInterface):
         minimumFollowDuration: timedelta = timedelta(weeks = 1),
         timeZone: tzinfo = timezone.utc
     ):
-        assert isinstance(cheerActionRemodHelper, CheerActionRemodHelperInterface), f"malformed {cheerActionRemodHelper=}"
-        assert isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
-        assert isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface), f"malformed {isLiveOnTwitchRepository=}"
-        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
-        assert isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface), f"malformed {twitchFollowerRepository=}"
-        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(minimumFollowDuration, timedelta), f"malformed {minimumFollowDuration=}"
-        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
+        if not isinstance(cheerActionRemodHelper, CheerActionRemodHelperInterface):
+            raise TypeError(f'cheerActionRemodHelper argument is malformed: \"{cheerActionRemodHelper}\"')
+        elif not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
+            raise TypeError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
+        elif not isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface):
+            raise TypeError(f'isLiveOnTwitchRepository argument is malformed: \"{isLiveOnTwitchRepository}\"')
+        elif streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
+            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
+            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
+        elif not isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface):
+            raise TypeError(f'twitchFollowerRepository argument is malformed: \"{twitchFollowerRepository}\"')
+        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
+            raise TypeError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(minimumFollowDuration, timedelta):
+            raise TypeError(f'minimumFollowDuration argument is malformed: \"{minimumFollowDuration}\"')
+        elif not isinstance(timeZone, tzinfo):
+            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__cheerActionRemodHelper: CheerActionRemodHelperInterface = cheerActionRemodHelper
         self.__cheerActionsRepository: CheerActionsRepositoryInterface = cheerActionsRepository
@@ -104,15 +116,16 @@ class CheerActionHelper(CheerActionHelperInterface):
     ) -> bool:
         if not utils.isValidInt(bits):
             raise TypeError(f'bits argument is malformed: \"{bits}\"')
-        if bits < 0 or bits > utils.getIntMaxSafeSize():
+        elif bits < 0 or bits > utils.getIntMaxSafeSize():
             raise ValueError(f'bits argument is out of bounds: {bits}')
-        if not utils.isValidStr(cheerUserId):
+        elif not utils.isValidStr(cheerUserId):
             raise TypeError(f'cheerUserId argument is malformed: \"{cheerUserId}\"')
-        if not utils.isValidStr(cheerUserName):
+        elif not utils.isValidStr(cheerUserName):
             raise TypeError(f'cheerUserName argument is malformed: \"{cheerUserName}\"')
-        if not utils.isValidStr(message):
+        elif not utils.isValidStr(message):
             raise TypeError(f'message argument is malformed: \"{message}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
 
         moderatorTwitchAccessToken = await self.__getTwitchAccessToken(
             twitchChannel = await self.__twitchHandleProvider.getTwitchHandle()
@@ -158,9 +171,9 @@ class CheerActionHelper(CheerActionHelperInterface):
     ) -> bool:
         if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        if not utils.isValidStr(twitchAccessToken):
+        elif not utils.isValidStr(twitchAccessToken):
             raise TypeError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.isValidStr(userIdToTimeout):
+        elif not utils.isValidStr(userIdToTimeout):
             raise TypeError(f'userIdToTimeout argument is malformed: \"{userIdToTimeout}\"')
 
         moderatorInfo: Optional[TwitchModUser] = None
@@ -191,24 +204,26 @@ class CheerActionHelper(CheerActionHelperInterface):
     ) -> bool:
         if not utils.isValidInt(bits):
             raise TypeError(f'bits argument is malformed: \"{bits}\"')
-        if bits < 0 or bits > utils.getIntMaxSafeSize():
+        elif bits < 0 or bits > utils.getIntMaxSafeSize():
             raise ValueError(f'bits argument is out of bounds: {bits}')
-        assert isinstance(actions, List), f"malformed {actions=}"
-        if not utils.isValidStr(broadcasterUserId):
+        elif not isinstance(actions, List):
+            raise TypeError(f'actions argument is malformed: \"{actions}\"')
+        elif not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        if not utils.isValidStr(cheerUserId):
+        elif not utils.isValidStr(cheerUserId):
             raise TypeError(f'cheerUserId argument is malformed: \"{cheerUserId}\"')
-        if not utils.isValidStr(cheerUserName):
+        elif not utils.isValidStr(cheerUserName):
             raise TypeError(f'cheerUserName argument is malformed: \"{cheerUserName}\"')
-        if not utils.isValidStr(message):
+        elif not utils.isValidStr(message):
             raise TypeError(f'message argument is malformed: \"{message}\"')
-        if not utils.isValidStr(moderatorTwitchAccessToken):
+        elif not utils.isValidStr(moderatorTwitchAccessToken):
             raise TypeError(f'moderatorTwitchAccessToken argument is malformed: \"{moderatorTwitchAccessToken}\"')
-        if not utils.isValidStr(moderatorUserId):
+        elif not utils.isValidStr(moderatorUserId):
             raise TypeError(f'moderatorUserId argument is malformed: \"{moderatorUserId}\"')
-        if not utils.isValidStr(userTwitchAccessToken):
+        elif not utils.isValidStr(userTwitchAccessToken):
             raise TypeError(f'userTwitchAccessToken argument is malformed: \"{userTwitchAccessToken}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
 
         timeoutActions: List[CheerAction] = list()
 
@@ -288,24 +303,26 @@ class CheerActionHelper(CheerActionHelperInterface):
         userTwitchAccessToken: str,
         user: UserInterface
     ) -> bool:
-        assert isinstance(action, CheerAction), f"malformed {action=}"
-        if not utils.isValidInt(bits):
+        if not isinstance(action, CheerAction):
+            raise TypeError(f'action argument is malformed: \"{action}\"')
+        elif not utils.isValidInt(bits):
             raise TypeError(f'bits argument is malformed: \"{bits}\"')
-        if not utils.isValidStr(broadcasterUserId):
+        elif not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        if not utils.isValidStr(cheerUserId):
+        elif not utils.isValidStr(cheerUserId):
             raise TypeError(f'cheerUserId argument is malformed: \"{cheerUserId}\"')
-        if not utils.isValidStr(cheerUserName):
+        elif not utils.isValidStr(cheerUserName):
             raise TypeError(f'cheerUserName argument is malformed: \"{cheerUserName}\"')
-        if not utils.isValidStr(moderatorTwitchAccessToken):
+        elif not utils.isValidStr(moderatorTwitchAccessToken):
             raise TypeError(f'moderatorTwitchAccessToken argument is malformed: \"{moderatorTwitchAccessToken}\"')
-        if not utils.isValidStr(moderatorUserId):
+        elif not utils.isValidStr(moderatorUserId):
             raise TypeError(f'moderatorUserId argument is malformed: \"{moderatorUserId}\"')
-        if not utils.isValidStr(userIdToTimeout):
+        elif not utils.isValidStr(userIdToTimeout):
             raise TypeError(f'userIdToTimeout argument is malformed: \"{userIdToTimeout}\"')
-        if not utils.isValidStr(userTwitchAccessToken):
+        elif not utils.isValidStr(userTwitchAccessToken):
             raise TypeError(f'userTwitchAccessToken argument is malformed: \"{userTwitchAccessToken}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
 
         if not await self.__verifyUserCanBeTimedOut(
             broadcasterUserId = broadcasterUserId,
@@ -378,8 +395,10 @@ class CheerActionHelper(CheerActionHelperInterface):
         timeoutAction: CheerAction,
         user: UserInterface
     ) -> bool:
-        assert isinstance(timeoutAction, CheerAction), f"malformed {timeoutAction=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if not isinstance(timeoutAction, CheerAction):
+            raise TypeError(f'timeoutAction argument is malformed: \"{timeoutAction}\"')
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
 
         requirement = timeoutAction.getStreamStatusRequirement()
 
@@ -400,9 +419,9 @@ class CheerActionHelper(CheerActionHelperInterface):
     ) -> bool:
         if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        if not utils.isValidStr(twitchAccessToken):
+        elif not utils.isValidStr(twitchAccessToken):
             raise TypeError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.isValidStr(userIdToTimeout):
+        elif not utils.isValidStr(userIdToTimeout):
             raise TypeError(f'userIdToTimeout argument is malformed: \"{userIdToTimeout}\"')
 
         try:

--- a/src/CynanBot/cheerActions/cheerActionRemodData.py
+++ b/src/CynanBot/cheerActions/cheerActionRemodData.py
@@ -13,13 +13,12 @@ class CheerActionRemodData():
         broadcasterUserName: str,
         userId: str
     ):
-        if not isinstance(remodDateTime, SimpleDateTime):
-            raise TypeError(f'remodDateTime argument is malformed: \"{remodDateTime}\"')
-        elif not utils.isValidStr(broadcasterUserId):
+        assert isinstance(remodDateTime, SimpleDateTime), f"malformed {remodDateTime=}"
+        if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif not utils.isValidStr(broadcasterUserName):
+        if not utils.isValidStr(broadcasterUserName):
             raise TypeError(f'broadcasterUserName argument is malformed: \"{broadcasterUserName}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         self.__remodDateTime: SimpleDateTime = remodDateTime

--- a/src/CynanBot/cheerActions/cheerActionRemodData.py
+++ b/src/CynanBot/cheerActions/cheerActionRemodData.py
@@ -13,12 +13,13 @@ class CheerActionRemodData():
         broadcasterUserName: str,
         userId: str
     ):
-        assert isinstance(remodDateTime, SimpleDateTime), f"malformed {remodDateTime=}"
-        if not utils.isValidStr(broadcasterUserId):
+        if not isinstance(remodDateTime, SimpleDateTime):
+            raise TypeError(f'remodDateTime argument is malformed: \"{remodDateTime}\"')
+        elif not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        if not utils.isValidStr(broadcasterUserName):
+        elif not utils.isValidStr(broadcasterUserName):
             raise TypeError(f'broadcasterUserName argument is malformed: \"{broadcasterUserName}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         self.__remodDateTime: SimpleDateTime = remodDateTime

--- a/src/CynanBot/cheerActions/cheerActionRemodHelper.py
+++ b/src/CynanBot/cheerActions/cheerActionRemodHelper.py
@@ -26,19 +26,14 @@ class CheerActionRemodHelper(CheerActionRemodHelperInterface):
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         queueSleepTimeSeconds: float = 3
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(cheerActionRemodRepository, CheerActionRemodRepositoryInterface):
-            raise TypeError(f'cheerActionRemodRepository argument is malformed: \"{cheerActionRemodRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
-            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not utils.isValidInt(queueSleepTimeSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(cheerActionRemodRepository, CheerActionRemodRepositoryInterface), f"malformed {cheerActionRemodRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        if not utils.isValidInt(queueSleepTimeSeconds):
             raise TypeError(f'queueSleepTimeSeconds argument is malformed: \"{queueSleepTimeSeconds}\"')
-        elif queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 10:
+        if queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 10:
             raise ValueError(f'queueSleepTimeSeconds argument is out of bounds: {queueSleepTimeSeconds}')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -101,7 +96,6 @@ class CheerActionRemodHelper(CheerActionRemodHelperInterface):
             await asyncio.sleep(self.__queueSleepTimeSeconds)
 
     async def submitRemodData(self, data: CheerActionRemodData):
-        if not isinstance(data, CheerActionRemodData):
-            raise TypeError(f'data argument is malformed: \"{data}\"')
+        assert isinstance(data, CheerActionRemodData), f"malformed {data=}"
 
         await self.__cheerActionRemodRepository.add(data)

--- a/src/CynanBot/cheerActions/cheerActionRemodHelper.py
+++ b/src/CynanBot/cheerActions/cheerActionRemodHelper.py
@@ -26,14 +26,19 @@ class CheerActionRemodHelper(CheerActionRemodHelperInterface):
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         queueSleepTimeSeconds: float = 3
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(cheerActionRemodRepository, CheerActionRemodRepositoryInterface), f"malformed {cheerActionRemodRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        if not utils.isValidInt(queueSleepTimeSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(cheerActionRemodRepository, CheerActionRemodRepositoryInterface):
+            raise TypeError(f'cheerActionRemodRepository argument is malformed: \"{cheerActionRemodRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
+            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not utils.isValidInt(queueSleepTimeSeconds):
             raise TypeError(f'queueSleepTimeSeconds argument is malformed: \"{queueSleepTimeSeconds}\"')
-        if queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 10:
+        elif queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 10:
             raise ValueError(f'queueSleepTimeSeconds argument is out of bounds: {queueSleepTimeSeconds}')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -96,6 +101,7 @@ class CheerActionRemodHelper(CheerActionRemodHelperInterface):
             await asyncio.sleep(self.__queueSleepTimeSeconds)
 
     async def submitRemodData(self, data: CheerActionRemodData):
-        assert isinstance(data, CheerActionRemodData), f"malformed {data=}"
+        if not isinstance(data, CheerActionRemodData):
+            raise TypeError(f'data argument is malformed: \"{data}\"')
 
         await self.__cheerActionRemodRepository.add(data)

--- a/src/CynanBot/cheerActions/cheerActionRemodRepository.py
+++ b/src/CynanBot/cheerActions/cheerActionRemodRepository.py
@@ -20,12 +20,9 @@ class CheerActionRemodRepository(CheerActionRemodRepositoryInterface):
         timber: TimberInterface,
         remodTimeBuffer: timedelta = timedelta(seconds = 2)
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise TypeError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(remodTimeBuffer, timedelta):
-            raise TypeError(f'remodTimeBuffer argument is malformed: \"{remodTimeBuffer}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(remodTimeBuffer, timedelta), f"malformed {remodTimeBuffer=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -34,8 +31,7 @@ class CheerActionRemodRepository(CheerActionRemodRepositoryInterface):
         self.__isDatabaseReady: bool = False
 
     async def add(self, data: CheerActionRemodData):
-        if not isinstance(data, CheerActionRemodData):
-            raise TypeError(f'data argument is malformed: \"{data}\"')
+        assert isinstance(data, CheerActionRemodData), f"malformed {data=}"
 
         connection = await self.__getDatabaseConnection()
         await connection.execute(
@@ -52,7 +48,7 @@ class CheerActionRemodRepository(CheerActionRemodRepositoryInterface):
     async def delete(self, broadcasterUserId: str, userId: str):
         if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         connection = await self.__getDatabaseConnection()

--- a/src/CynanBot/cheerActions/cheerActionRemodRepository.py
+++ b/src/CynanBot/cheerActions/cheerActionRemodRepository.py
@@ -20,9 +20,12 @@ class CheerActionRemodRepository(CheerActionRemodRepositoryInterface):
         timber: TimberInterface,
         remodTimeBuffer: timedelta = timedelta(seconds = 2)
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(remodTimeBuffer, timedelta), f"malformed {remodTimeBuffer=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise TypeError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(remodTimeBuffer, timedelta):
+            raise TypeError(f'remodTimeBuffer argument is malformed: \"{remodTimeBuffer}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -31,7 +34,8 @@ class CheerActionRemodRepository(CheerActionRemodRepositoryInterface):
         self.__isDatabaseReady: bool = False
 
     async def add(self, data: CheerActionRemodData):
-        assert isinstance(data, CheerActionRemodData), f"malformed {data=}"
+        if not isinstance(data, CheerActionRemodData):
+            raise TypeError(f'data argument is malformed: \"{data}\"')
 
         connection = await self.__getDatabaseConnection()
         await connection.execute(
@@ -48,7 +52,7 @@ class CheerActionRemodRepository(CheerActionRemodRepositoryInterface):
     async def delete(self, broadcasterUserId: str, userId: str):
         if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         connection = await self.__getDatabaseConnection()

--- a/src/CynanBot/cheerActions/cheerActionsRepository.py
+++ b/src/CynanBot/cheerActions/cheerActionsRepository.py
@@ -29,15 +29,12 @@ class CheerActionsRepository(CheerActionsRepositoryInterface):
         timber: TimberInterface,
         maximumPerUser: int = 5
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise TypeError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface):
-            raise TypeError(f'cheerActionIdGenerator argument is malformed: \"{cheerActionIdGenerator}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidInt(maximumPerUser):
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface), f"malformed {cheerActionIdGenerator=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidInt(maximumPerUser):
             raise TypeError(f'maximumPerUser argument is malformed: \"{maximumPerUser}\"')
-        elif maximumPerUser < 1 or maximumPerUser > 16:
+        if maximumPerUser < 1 or maximumPerUser > 16:
             raise ValueError(f'maximumPerUser argument is out of bounds: {maximumPerUser}')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
@@ -57,23 +54,20 @@ class CheerActionsRepository(CheerActionsRepositoryInterface):
         durationSeconds: int,
         userId: str
     ) -> CheerAction:
-        if not isinstance(bitRequirement, CheerActionBitRequirement):
-            raise TypeError(f'actionRequirement argument is malformed: \"{bitRequirement}\"')
-        elif not isinstance(streamStatusRequirement, CheerActionStreamStatusRequirement):
-            raise TypeError(f'streamStatusRequirement argument is malformed: \"{streamStatusRequirement}\"')
-        elif not isinstance(actionType, CheerActionType):
-            raise TypeError(f'cheerActionType argument is malformed: \"{actionType}\"')
-        elif not utils.isValidInt(amount):
+        assert isinstance(bitRequirement, CheerActionBitRequirement), f"malformed {bitRequirement=}"
+        assert isinstance(streamStatusRequirement, CheerActionStreamStatusRequirement), f"malformed {streamStatusRequirement=}"
+        assert isinstance(actionType, CheerActionType), f"malformed {actionType=}"
+        if not utils.isValidInt(amount):
             raise TypeError(f'amount argument is malformed: \"{amount}\"')
-        elif amount < 1 or amount > utils.getIntMaxSafeSize():
+        if amount < 1 or amount > utils.getIntMaxSafeSize():
             raise ValueError(f'amount argument is out of bounds: {amount}')
-        elif not utils.isValidInt(durationSeconds):
+        if not utils.isValidInt(durationSeconds):
             raise TypeError(f'durationSeconds argument is malformed: \"{durationSeconds}\"')
-        elif durationSeconds < 1:
+        if durationSeconds < 1:
             raise ValueError(f'durationSeconds argument is out of bounds: {durationSeconds}')
-        elif durationSeconds > 1209600:
+        if durationSeconds > 1209600:
             raise TimeoutDurationSecondsTooLongException(f'durationSeconds argument is out of bounds: {durationSeconds}')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         actions = await self.getActions(userId)
@@ -125,7 +119,7 @@ class CheerActionsRepository(CheerActionsRepositoryInterface):
     async def deleteAction(self, actionId: str, userId: str) -> Optional[CheerAction]:
         if not utils.isValidStr(actionId):
             raise ValueError(f'actionId argument is malformed: \"{actionId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         action = await self.getAction(
@@ -155,7 +149,7 @@ class CheerActionsRepository(CheerActionsRepositoryInterface):
     async def getAction(self, actionId: str, userId: str) -> Optional[CheerAction]:
         if not utils.isValidStr(actionId):
             raise ValueError(f'actionId argument is malformed: \"{actionId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         actions = await self.getActions(userId)

--- a/src/CynanBot/cheerActions/cheerActionsRepository.py
+++ b/src/CynanBot/cheerActions/cheerActionsRepository.py
@@ -29,12 +29,15 @@ class CheerActionsRepository(CheerActionsRepositoryInterface):
         timber: TimberInterface,
         maximumPerUser: int = 5
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface), f"malformed {cheerActionIdGenerator=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidInt(maximumPerUser):
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise TypeError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface):
+            raise TypeError(f'cheerActionIdGenerator argument is malformed: \"{cheerActionIdGenerator}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidInt(maximumPerUser):
             raise TypeError(f'maximumPerUser argument is malformed: \"{maximumPerUser}\"')
-        if maximumPerUser < 1 or maximumPerUser > 16:
+        elif maximumPerUser < 1 or maximumPerUser > 16:
             raise ValueError(f'maximumPerUser argument is out of bounds: {maximumPerUser}')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
@@ -54,20 +57,23 @@ class CheerActionsRepository(CheerActionsRepositoryInterface):
         durationSeconds: int,
         userId: str
     ) -> CheerAction:
-        assert isinstance(bitRequirement, CheerActionBitRequirement), f"malformed {bitRequirement=}"
-        assert isinstance(streamStatusRequirement, CheerActionStreamStatusRequirement), f"malformed {streamStatusRequirement=}"
-        assert isinstance(actionType, CheerActionType), f"malformed {actionType=}"
-        if not utils.isValidInt(amount):
+        if not isinstance(bitRequirement, CheerActionBitRequirement):
+            raise TypeError(f'actionRequirement argument is malformed: \"{bitRequirement}\"')
+        elif not isinstance(streamStatusRequirement, CheerActionStreamStatusRequirement):
+            raise TypeError(f'streamStatusRequirement argument is malformed: \"{streamStatusRequirement}\"')
+        elif not isinstance(actionType, CheerActionType):
+            raise TypeError(f'cheerActionType argument is malformed: \"{actionType}\"')
+        elif not utils.isValidInt(amount):
             raise TypeError(f'amount argument is malformed: \"{amount}\"')
-        if amount < 1 or amount > utils.getIntMaxSafeSize():
+        elif amount < 1 or amount > utils.getIntMaxSafeSize():
             raise ValueError(f'amount argument is out of bounds: {amount}')
-        if not utils.isValidInt(durationSeconds):
+        elif not utils.isValidInt(durationSeconds):
             raise TypeError(f'durationSeconds argument is malformed: \"{durationSeconds}\"')
-        if durationSeconds < 1:
+        elif durationSeconds < 1:
             raise ValueError(f'durationSeconds argument is out of bounds: {durationSeconds}')
-        if durationSeconds > 1209600:
+        elif durationSeconds > 1209600:
             raise TimeoutDurationSecondsTooLongException(f'durationSeconds argument is out of bounds: {durationSeconds}')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         actions = await self.getActions(userId)
@@ -119,7 +125,7 @@ class CheerActionsRepository(CheerActionsRepositoryInterface):
     async def deleteAction(self, actionId: str, userId: str) -> Optional[CheerAction]:
         if not utils.isValidStr(actionId):
             raise ValueError(f'actionId argument is malformed: \"{actionId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         action = await self.getAction(
@@ -149,7 +155,7 @@ class CheerActionsRepository(CheerActionsRepositoryInterface):
     async def getAction(self, actionId: str, userId: str) -> Optional[CheerAction]:
         if not utils.isValidStr(actionId):
             raise ValueError(f'actionId argument is malformed: \"{actionId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         actions = await self.getActions(userId)

--- a/src/CynanBot/commands.py
+++ b/src/CynanBot/commands.py
@@ -153,16 +153,11 @@ class AddBannedTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface):
-            raise ValueError(f'bannedTriviaGameControllersRepository argument is malformed: \"{timber}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface), f"malformed {bannedTriviaGameControllersRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__bannedTriviaGameControllersRepository: BannedTriviaGameControllersRepositoryInterface = bannedTriviaGameControllersRepository
@@ -218,16 +213,11 @@ class AddGlobalTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface):
-            raise ValueError(f'triviaGameGlobalControllersRepository argument is malformed: \"{triviaGameGlobalControllersRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface), f"malformed {triviaGameGlobalControllersRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -287,24 +277,15 @@ class AddTriviaAnswerCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         answerDelimiter: str = ', '
     ):
-        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
-            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
-            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
-        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
-            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
-        elif not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(answerDelimiter, str):
-            raise ValueError(f'answerDelimiter argument is malformed: \"{answerDelimiter}\"')
+        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
+        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
+        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(answerDelimiter, str), f"malformed {answerDelimiter=}"
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -399,18 +380,12 @@ class AddTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface):
-            raise ValueError(f'triviaGameControllersRepository argument is malformed: \"{triviaGameControllersRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface), f"malformed {triviaGameControllersRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -477,20 +452,13 @@ class AddUserCommand(AbsCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(modifyUserDataHelper, ModifyUserDataHelper):
-            raise ValueError(f'modifyUserDataHelper argument is malformed: \"{modifyUserDataHelper}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(modifyUserDataHelper, ModifyUserDataHelper), f"malformed {modifyUserDataHelper=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__modifyUserDataHelper: ModifyUserDataHelper = modifyUserDataHelper
@@ -555,16 +523,11 @@ class AnswerCommand(AbsCommand):
         triviaIdGenerator: TriviaIdGeneratorInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
-            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -612,22 +575,14 @@ class BanTriviaQuestionCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaBanHelper, TriviaBanHelperInterface):
-            raise ValueError(f'triviaBanHelper argument is malformed: \"{triviaBanHelper}\"')
-        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
-            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
-        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
-            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
-        elif not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaBanHelper, TriviaBanHelperInterface), f"malformed {triviaBanHelper=}"
+        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
+        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
+        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -714,52 +669,29 @@ class ClearCachesCommand(AbsCommand):
         websocketConnectionServer: Optional[WebsocketConnectionServerInterface],
         wordOfTheDayRepository: Optional[WordOfTheDayRepositoryInterface]
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(authRepository, AuthRepository):
-            raise ValueError(f'authRepository argument is malformed: \"{authRepository}\"')
-        elif bannedWordsRepository is not None and not isinstance(bannedWordsRepository, BannedWordsRepositoryInterface):
-            raise ValueError(f'bannedWordsRepository argument is malformed: \"{bannedWordsRepository}\"')
-        elif cheerActionsRepository is not None and not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
-            raise ValueError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
-        elif funtoonTokensRepository is not None and not isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface):
-            raise ValueError(f'funtoonTokensRepository argument is malformed: \"{funtoonTokensRepository}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif isLiveOnTwitchRepository is not None and not isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface):
-            raise ValueError(f'isLiveOnTwitchRepository argument is malformed: \"{isLiveOnTwitchRepository}\"')
-        elif locationsRepository is not None and not isinstance(locationsRepository, LocationsRepositoryInterface):
-            raise ValueError(f'locationsRepository argument is malformed: \"{locationsRepository}\"')
-        elif not isinstance(modifyUserDataHelper, ModifyUserDataHelper):
-            raise ValueError(f'modifyUserDataHelper argument is malformed: \"{modifyUserDataHelper}\"')
-        elif mostRecentChatsRepository is not None and not isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface):
-            raise ValueError(f'mostRecentChatsRepository argument is malformed: \"{mostRecentChatsRepository}\"')
-        elif openTriviaDatabaseTriviaQuestionRepository is not None and not isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository):
-            raise ValueError(f'openTriviaDatabaseTriviaQuestionRepository argument is malformed: \"{openTriviaDatabaseTriviaQuestionRepository}\"')
-        elif soundPlayerSettingsRepository is not None and not isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface):
-            raise ValueError(f'soundPlayerSettingsRepository argument is malformed: \"{soundPlayerSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif triviaSettingsRepository is not None and not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
-        elif ttsSettingsRepository is not None and not isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface):
-            raise ValueError(f'ttsSettingsRepository argument is malformed: \"{ttsSettingsRepository}\"')
-        elif twitchFollowerRepository is not None and not isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface):
-            raise TypeError(f'twitchFollowerRepository argument is malformed: \"{twitchFollowerRepository}\"')
-        elif twitchTokensRepository is not None and not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif weatherRepository is not None and not isinstance(weatherRepository, WeatherRepositoryInterface):
-            raise ValueError(f'weatherRepository argument is malformed: \"{weatherRepository}\"')
-        elif websocketConnectionServer is not None and not isinstance(websocketConnectionServer, WebsocketConnectionServerInterface):
-            raise ValueError(f'websocketConnectionServer argument is malformed: \"{websocketConnectionServer}\"')
-        elif wordOfTheDayRepository is not None and not isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface):
-            raise ValueError(f'wordOfTheDayRepository argument is malformed: \"{wordOfTheDayRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(authRepository, AuthRepository), f"malformed {authRepository=}"
+        assert bannedWordsRepository is None or isinstance(bannedWordsRepository, BannedWordsRepositoryInterface), f"malformed {bannedWordsRepository=}"
+        assert cheerActionsRepository is None or isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
+        assert funtoonTokensRepository is None or isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface), f"malformed {funtoonTokensRepository=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isLiveOnTwitchRepository is None or isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface), f"malformed {isLiveOnTwitchRepository=}"
+        assert locationsRepository is None or isinstance(locationsRepository, LocationsRepositoryInterface), f"malformed {locationsRepository=}"
+        assert isinstance(modifyUserDataHelper, ModifyUserDataHelper), f"malformed {modifyUserDataHelper=}"
+        assert mostRecentChatsRepository is None or isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface), f"malformed {mostRecentChatsRepository=}"
+        assert openTriviaDatabaseTriviaQuestionRepository is None or isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository), f"malformed {openTriviaDatabaseTriviaQuestionRepository=}"
+        assert soundPlayerSettingsRepository is None or isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface), f"malformed {soundPlayerSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert triviaSettingsRepository is None or isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        assert ttsSettingsRepository is None or isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface), f"malformed {ttsSettingsRepository=}"
+        assert twitchFollowerRepository is None or isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface), f"malformed {twitchFollowerRepository=}"
+        assert twitchTokensRepository is None or isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert weatherRepository is None or isinstance(weatherRepository, WeatherRepositoryInterface), f"malformed {weatherRepository=}"
+        assert websocketConnectionServer is None or isinstance(websocketConnectionServer, WebsocketConnectionServerInterface), f"malformed {websocketConnectionServer=}"
+        assert wordOfTheDayRepository is None or isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface), f"malformed {wordOfTheDayRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -816,18 +748,12 @@ class ClearSuperTriviaQueueCommand(AbsCommand):
         triviaUtils: TriviaUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
-            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -872,20 +798,13 @@ class CommandsCommand(AbsCommand):
         delimiter: str = ', ',
         cooldown: timedelta = timedelta(seconds = 30)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif triviaUtils is not None and not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert triviaUtils is None or isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -900,10 +819,8 @@ class CommandsCommand(AbsCommand):
         generalSettings: GeneralSettingsRepositorySnapshot,
         user: UserInterface
     ) -> List[str]:
-        if not isinstance(generalSettings, GeneralSettingsRepositorySnapshot):
-            raise ValueError(f'generalSettings argument is malformed: \"{generalSettings}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(generalSettings, GeneralSettingsRepositorySnapshot), f"malformed {generalSettings=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         commands: List[str] = list()
 
@@ -923,10 +840,8 @@ class CommandsCommand(AbsCommand):
         generalSettings: GeneralSettingsRepositorySnapshot,
         user: UserInterface
     ) -> List[str]:
-        if not isinstance(generalSettings, GeneralSettingsRepositorySnapshot):
-            raise ValueError(f'generalSettings argument is malformed: \"{generalSettings}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(generalSettings, GeneralSettingsRepositorySnapshot), f"malformed {generalSettings=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         commands: List[str] = list()
 
@@ -946,14 +861,12 @@ class CommandsCommand(AbsCommand):
     ) -> List[str]:
         if not utils.isValidBool(isMod):
             raise ValueError(f'isMod argument is malformed: \"{isMod}\"')
-        elif not isinstance(generalSettings, GeneralSettingsRepositorySnapshot):
-            raise ValueError(f'generalSettings argument is malformed: \"{generalSettings}\"')
-        elif not utils.isValidStr(userId):
+        assert isinstance(generalSettings, GeneralSettingsRepositorySnapshot), f"malformed {generalSettings=}"
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         isPrivilegedTriviaUser = self.__triviaUtils is not None and await self.__triviaUtils.isPrivilegedTriviaUser(
             twitchChannel = user.getHandle(),
@@ -1055,16 +968,11 @@ class ConfirmCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(modifyUserDataHelper, ModifyUserDataHelper):
-            raise ValueError(f'modifyUserDataHelper argument is malformed: \"{modifyUserDataHelper}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(modifyUserDataHelper, ModifyUserDataHelper), f"malformed {modifyUserDataHelper=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__modifyUserDataHelper: ModifyUserDataHelper = modifyUserDataHelper
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
@@ -1110,22 +1018,14 @@ class CutenessCommand(AbsCommand):
         delimiter: str = ', ',
         cooldown: timedelta = timedelta(seconds = 2)
     ):
-        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
-            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
-        elif not isinstance(cutenessUtils, CutenessUtilsInterface):
-            raise ValueError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
+        assert isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__cutenessUtils: CutenessUtilsInterface = cutenessUtils
@@ -1137,8 +1037,7 @@ class CutenessCommand(AbsCommand):
         self.__lastMessageTimes: TimedDict = TimedDict(cooldown)
 
     def __cutenessLeaderboardResultToStr(self, result: CutenessLeaderboardResult) -> str:
-        if not isinstance(result, CutenessLeaderboardResult):
-            raise ValueError(f'result argument is malformed: \"{result}\"')
+        assert isinstance(result, CutenessLeaderboardResult), f"malformed {result=}"
 
         entries = result.getEntries()
 
@@ -1164,8 +1063,7 @@ class CutenessCommand(AbsCommand):
             return f'{result.getCutenessDate().getHumanString()} Leaderboard {leaderboard} ✨'
 
     def __cutenessResultToStr(self, result: CutenessResult) -> str:
-        if not isinstance(result, CutenessResult):
-            raise ValueError(f'result argument is malformed: \"{result}\"')
+        assert isinstance(result, CutenessResult), f"malformed {result=}"
 
         cuteness = result.getCuteness()
 
@@ -1229,20 +1127,13 @@ class CutenessChampionsCommand(AbsCommand):
         delimiter: str = ', ',
         cooldown: timedelta = timedelta(seconds = 15)
     ):
-        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
-            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
-        elif not isinstance(cutenessUtils, CutenessUtilsInterface):
-            raise ValueError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
+        assert isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__cutenessUtils: CutenessUtilsInterface = cutenessUtils
@@ -1282,24 +1173,15 @@ class CutenessHistoryCommand(AbsCommand):
         leaderboardDelimiter: str = ' — ',
         cooldown: timedelta = timedelta(seconds = 2)
     ):
-        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
-            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
-        elif not isinstance(cutenessUtils, CutenessUtilsInterface):
-            raise ValueError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(entryDelimiter, str):
-            raise ValueError(f'entryDelimiter argument is malformed: \"{entryDelimiter}\"')
-        elif not isinstance(leaderboardDelimiter, str):
-            raise ValueError(f'leaderboardDelimiter argument is malformed: \"{leaderboardDelimiter}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
+        assert isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(entryDelimiter, str), f"malformed {entryDelimiter=}"
+        assert isinstance(leaderboardDelimiter, str), f"malformed {leaderboardDelimiter=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__cutenessUtils: CutenessUtilsInterface = cutenessUtils
@@ -1364,14 +1246,10 @@ class CynanSourceCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 1)
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -1402,20 +1280,13 @@ class DeleteCheerActionCommand(AbsCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface):
-            raise ValueError(f'cheerActionIdGenerator argument is malformed: \"{cheerActionIdGenerator}\"')
-        elif not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
-            raise ValueError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface), f"malformed {cheerActionIdGenerator=}"
+        assert isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__cheerActionIdGenerator: CheerActionIdGeneratorInterface = cheerActionIdGenerator
@@ -1426,8 +1297,7 @@ class DeleteCheerActionCommand(AbsCommand):
         self.__usersRepository: UsersRepositoryInterface = usersRepository
 
     async def __actionToStr(self, action: CheerAction) -> str:
-        if not isinstance(action, CheerAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(action, CheerAction), f"malformed {action=}"
 
         return f'id={action.getActionId()}, amount={action.getAmount()}, duration={action.getDurationSeconds()}'
 
@@ -1480,24 +1350,15 @@ class DeleteTriviaAnswersCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         answerDelimiter: str = ', '
     ):
-        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
-            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
-            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
-        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
-            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
-        elif not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(answerDelimiter, str):
-            raise ValueError(f'answerDelimiter argument is malformed: \"{answerDelimiter}\"')
+        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
+        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
+        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(answerDelimiter, str), f"malformed {answerDelimiter=}"
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -1571,14 +1432,10 @@ class DiscordCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 30)
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -1608,16 +1465,11 @@ class GetBannedTriviaControllersCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface):
-            raise ValueError(f'bannedTriviaGameControllersRepository argument is malformed: \"{bannedTriviaGameControllersRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface), f"malformed {bannedTriviaGameControllersRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__bannedTriviaGameControllersRepository: BannedTriviaGameControllersRepositoryInterface = bannedTriviaGameControllersRepository
@@ -1653,20 +1505,13 @@ class GetCheerActionsCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         delimiter: str = '; '
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
-            raise ValueError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__cheerActionsRepository: CheerActionsRepositoryInterface = cheerActionsRepository
@@ -1677,8 +1522,7 @@ class GetCheerActionsCommand(AbsCommand):
         self.__delimiter: str = delimiter
 
     async def __actionsToStr(self, actions: List[CheerAction]) -> str:
-        if not isinstance(actions, List):
-            raise ValueError(f'actions argument is malformed: \"{actions}\"')
+        assert isinstance(actions, List), f"malformed {actions=}"
 
         if len(actions) == 0:
             return f'ⓘ You have no cheer actions'
@@ -1718,16 +1562,11 @@ class GetGlobalTriviaControllersCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProviderInterface argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface):
-            raise ValueError(f'triviaGameGlobalControllersRepository argument is malformed: \"{triviaGameGlobalControllersRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface), f"malformed {triviaGameGlobalControllersRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -1765,24 +1604,15 @@ class GetTriviaAnswersCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         answerDelimiter: str = ', '
     ):
-        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
-            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
-            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
-        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
-            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
-        elif not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(answerDelimiter, str):
-            raise ValueError(f'answerDelimiter argument is malformed: \"{answerDelimiter}\"')
+        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
+        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
+        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(answerDelimiter, str), f"malformed {answerDelimiter=}"
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -1859,18 +1689,12 @@ class GetTriviaControllersCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface):
-            raise ValueError(f'triviaGameControllersRepository argument is malformed: \"{triviaGameControllersRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface), f"malformed {triviaGameControllersRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -1911,18 +1735,12 @@ class GiveCutenessCommand(AbsCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
-            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__timber: TimberInterface = timber
@@ -2001,18 +1819,12 @@ class JishoCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 3)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(jishoHelper, JishoHelperInterface):
-            raise ValueError(f'jishoHelper argument is malformed: \"{jishoHelper}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(jishoHelper, JishoHelperInterface), f"malformed {jishoHelper=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__jishoHelper: JishoHelperInterface = jishoHelper
@@ -2060,12 +1872,9 @@ class LoremIpsumCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -2102,22 +1911,14 @@ class MyCutenessHistoryCommand(AbsCommand):
         delimiter: str = ', ',
         cooldown: timedelta = timedelta(seconds = 3)
     ):
-        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
-            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
-        elif not isinstance(cutenessUtils, CutenessUtilsInterface):
-            raise ValueError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
+        assert isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__cutenessUtils: CutenessUtilsInterface = cutenessUtils
@@ -2172,14 +1973,10 @@ class PbsCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 1)
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -2209,18 +2006,12 @@ class PkMonCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 10)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(pokepediaRepository, PokepediaRepository):
-            raise ValueError(f'pokepediaRepository argument is malformed: \"{pokepediaRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(pokepediaRepository, PokepediaRepository), f"malformed {pokepediaRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__pokepediaRepository: PokepediaRepository = pokepediaRepository
@@ -2270,18 +2061,12 @@ class PkMoveCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 10)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(pokepediaRepository, PokepediaRepository):
-            raise ValueError(f'pokepediaRepository argument is malformed: \"{pokepediaRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(pokepediaRepository, PokepediaRepository), f"malformed {pokepediaRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__pokepediaRepository: PokepediaRepository = pokepediaRepository
@@ -2329,14 +2114,10 @@ class RaceCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 1)
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -2369,18 +2150,12 @@ class RecurringActionCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
-            raise ValueError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
-        elif not isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface):
-            raise ValueError(f'recurringActionsRepository argument is malformed: \"{recurringActionsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
+        assert isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface), f"malformed {recurringActionsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository
@@ -2395,12 +2170,9 @@ class RecurringActionCommand(AbsCommand):
         user: UserInterface,
         actionType: RecurringActionType
     ):
-        if not isinstance(ctx, TwitchContext):
-            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(actionType, RecurringActionType):
-            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
+        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(actionType, RecurringActionType), f"malformed {actionType=}"
 
         if actionType is RecurringActionType.SUPER_TRIVIA:
             await self.__disableSuperTriviaRecurringAction(
@@ -2425,10 +2197,8 @@ class RecurringActionCommand(AbsCommand):
         ctx: TwitchContext,
         user: UserInterface
     ):
-        if not isinstance(ctx, TwitchContext):
-            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         recurringAction = SuperTriviaRecurringAction(
             enabled = False,
@@ -2443,10 +2213,8 @@ class RecurringActionCommand(AbsCommand):
         ctx: TwitchContext,
         user: UserInterface
     ):
-        if not isinstance(ctx, TwitchContext):
-            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         recurringAction = WeatherRecurringAction(
             enabled = False,
@@ -2461,10 +2229,8 @@ class RecurringActionCommand(AbsCommand):
         ctx: TwitchContext,
         user: UserInterface
     ):
-        if not isinstance(ctx, TwitchContext):
-            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         recurringAction = WordOfTheDayRecurringAction(
             enabled = False,
@@ -2480,11 +2246,9 @@ class RecurringActionCommand(AbsCommand):
         user: UserInterface,
         splits: List[str]
     ):
-        if not isinstance(ctx, TwitchContext):
-            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not utils.hasItems(splits):
+        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if not utils.hasItems(splits):
             raise ValueError(f'splits argument is malformed: \"{splits}\"')
 
         minutesBetween = await self.__parseMinutesBetween(
@@ -2507,11 +2271,9 @@ class RecurringActionCommand(AbsCommand):
         user: UserInterface,
         splits: List[str]
     ):
-        if not isinstance(ctx, TwitchContext):
-            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not utils.hasItems(splits):
+        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if not utils.hasItems(splits):
             raise ValueError(f'splits argument is malformed: \"{splits}\"')
 
         minutesBetween = await self.__parseMinutesBetween(
@@ -2534,11 +2296,9 @@ class RecurringActionCommand(AbsCommand):
         user: UserInterface,
         splits: List[str]
     ):
-        if not isinstance(ctx, TwitchContext):
-            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not utils.hasItems(splits):
+        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if not utils.hasItems(splits):
             raise ValueError(f'splits argument is malformed: \"{splits}\"')
 
         minutesBetween = await self.__parseMinutesBetween(
@@ -2638,9 +2398,8 @@ class RecurringActionCommand(AbsCommand):
         return False
 
     async def __parseMinutesBetween(self, actionType: RecurringActionType, splits: List[str]) -> int:
-        if not isinstance(actionType, RecurringActionType):
-            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
-        elif not utils.hasItems(splits):
+        assert isinstance(actionType, RecurringActionType), f"malformed {actionType=}"
+        if not utils.hasItems(splits):
             raise ValueError(f'splits argument is malformed: \"{splits}\"')
 
         if len(splits) < 3:
@@ -2675,18 +2434,12 @@ class RecurringActionsCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         delimiter: str = ', '
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface):
-            raise ValueError(f'recurringActionsRepository argument is malformed: \"{recurringActionsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface), f"malformed {recurringActionsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__recurringActionsRepository: RecurringActionsRepositoryInterface = recurringActionsRepository
@@ -2729,16 +2482,11 @@ class RemoveBannedTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProviderInterface argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface):
-            raise ValueError(f'bannedTriviaGameControllersRepository argument is malformed: \"{bannedTriviaGameControllersRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface), f"malformed {bannedTriviaGameControllersRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__bannedTriviaGameControllersRepository: BannedTriviaGameControllersRepositoryInterface = bannedTriviaGameControllersRepository
@@ -2792,16 +2540,11 @@ class RemoveGlobalTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface):
-            raise ValueError(f'triviaGameGlobalControllersRepository argument is malformed: \"{triviaGameGlobalControllersRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface), f"malformed {triviaGameGlobalControllersRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -2856,18 +2599,12 @@ class RemoveTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface):
-            raise ValueError(f'triviaGameControllersRepository argument is malformed: \"{triviaGameControllersRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface), f"malformed {triviaGameControllersRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -2932,20 +2669,13 @@ class RemoveUserCommand(AbsCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(modifyUserDataHelper, ModifyUserDataHelper):
-            raise ValueError(f'modifyUserDataHelper argument is malformed: \"{modifyUserDataHelper}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(modifyUserDataHelper, ModifyUserDataHelper), f"malformed {modifyUserDataHelper=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__modifyUserDataHelper: ModifyUserDataHelper = modifyUserDataHelper
@@ -3003,16 +2733,11 @@ class SetFuntoonTokenCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface):
-            raise ValueError(f'funtoonTokensRepository argument is malformed: \"{funtoonTokensRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface), f"malformed {funtoonTokensRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__funtoonTokensRepository: FuntoonTokensRepositoryInterface = funtoonTokensRepository
@@ -3068,16 +2793,11 @@ class SetTwitchCodeCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -3145,22 +2865,14 @@ class SuperTriviaCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
-            raise ValueError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
-        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
-            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
-        elif not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
+        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -3231,16 +2943,11 @@ class SwQuoteCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 30)
     ):
-        if not isinstance(starWarsQuotesRepository, StarWarsQuotesRepositoryInterface):
-            raise ValueError(f'starWarsQuotesRepository argument is malformed: \"{starWarsQuotesRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(starWarsQuotesRepository, StarWarsQuotesRepositoryInterface), f"malformed {starWarsQuotesRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__starWarsQuotesRepository: StarWarsQuotesRepositoryInterface = starWarsQuotesRepository
         self.__timber: TimberInterface = timber
@@ -3287,14 +2994,10 @@ class TimeCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 1)
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -3342,20 +3045,13 @@ class TranslateCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 15)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
-            raise ValueError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(translationHelper, TranslationHelper):
-            raise ValueError(f'translationHelper argument is malformed: \"{translationHelper}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(translationHelper, TranslationHelper), f"malformed {translationHelper=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository
@@ -3422,22 +3118,14 @@ class TriviaInfoCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
-            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
-            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
-        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
-            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
-        elif not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
+        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
+        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -3515,26 +3203,16 @@ class TriviaScoreCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 2)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface):
-            raise ValueError(f'shinyTriviaOccurencesRepository argument is malformed: \"{shinyTriviaOccurencesRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface):
-            raise ValueError(f'toxicTriviaOccurencesRepository argument is malformed: \"{toxicTriviaOccurencesRepository}\"')
-        elif not isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface):
-            raise ValueError(f'triviaScoreRepository argument is malformed: \"{triviaScoreRepository}\"')
-        elif not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface), f"malformed {shinyTriviaOccurencesRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface), f"malformed {toxicTriviaOccurencesRepository=}"
+        assert isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface), f"malformed {triviaScoreRepository=}"
+        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__shinyTriviaOccurencesRepository: ShinyTriviaOccurencesRepositoryInterface = shinyTriviaOccurencesRepository
@@ -3616,16 +3294,11 @@ class TtsCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
-            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__streamAlertsManager: StreamAlertsManagerInterface = streamAlertsManager
@@ -3689,20 +3362,13 @@ class TwitchInfoCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
-            raise ValueError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
-        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
-            raise ValueError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
+        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -3762,8 +3428,7 @@ class TwitchInfoCommand(AbsCommand):
         self.__timber.log('TwitchInfoCommand', f'Handled !twitchinfo command for {ctx.getAuthorName()}:{ctx.getAuthorId()} in {user.getHandle()}')
 
     async def __toStr(self, userInfo: TwitchUserDetails) -> str:
-        if not isinstance(userInfo, TwitchUserDetails):
-            raise ValueError(f'userInfo argument is malformed: \"{userInfo}\"')
+        assert isinstance(userInfo, TwitchUserDetails), f"malformed {userInfo=}"
 
         broadcasterType = userInfo.getBroadcasterType()
         displayName = userInfo.getDisplayName()
@@ -3781,14 +3446,10 @@ class TwitterCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 5)
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -3820,22 +3481,14 @@ class UnbanTriviaQuestionCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaBanHelper, TriviaBanHelperInterface):
-            raise ValueError(f'triviaBanHelper argument is malformed: \"{triviaBanHelper}\"')
-        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
-            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
-        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
-            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
-        elif not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaBanHelper, TriviaBanHelperInterface), f"malformed {triviaBanHelper=}"
+        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
+        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
+        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -3905,20 +3558,13 @@ class WeatherCommand(AbsCommand):
         weatherRepository: WeatherRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 1)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(locationsRepository, LocationsRepositoryInterface):
-            raise ValueError(f'locationsRepository argument is malformed: \"{locationsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(weatherRepository, WeatherRepositoryInterface):
-            raise ValueError(f'weatherRepository argument is malformed: \"{weatherRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(locationsRepository, LocationsRepositoryInterface), f"malformed {locationsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(weatherRepository, WeatherRepositoryInterface), f"malformed {weatherRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__locationsRepository: LocationsRepositoryInterface = locationsRepository
@@ -3967,20 +3613,13 @@ class WordCommand(AbsCommand):
         wordOfTheDayRepository: WordOfTheDayRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 3)
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
-            raise ValueError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface):
-            raise ValueError(f'wordOfTheDayRepository argument is malformed: \"{wordOfTheDayRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface), f"malformed {wordOfTheDayRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository

--- a/src/CynanBot/commands.py
+++ b/src/CynanBot/commands.py
@@ -153,11 +153,16 @@ class AddBannedTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface), f"malformed {bannedTriviaGameControllersRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface):
+            raise ValueError(f'bannedTriviaGameControllersRepository argument is malformed: \"{timber}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__bannedTriviaGameControllersRepository: BannedTriviaGameControllersRepositoryInterface = bannedTriviaGameControllersRepository
@@ -213,11 +218,16 @@ class AddGlobalTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface), f"malformed {triviaGameGlobalControllersRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface):
+            raise ValueError(f'triviaGameGlobalControllersRepository argument is malformed: \"{triviaGameGlobalControllersRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -277,15 +287,24 @@ class AddTriviaAnswerCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         answerDelimiter: str = ', '
     ):
-        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
-        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
-        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(answerDelimiter, str), f"malformed {answerDelimiter=}"
+        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
+            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
+            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
+        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
+            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
+        elif not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(answerDelimiter, str):
+            raise ValueError(f'answerDelimiter argument is malformed: \"{answerDelimiter}\"')
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -380,12 +399,18 @@ class AddTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface), f"malformed {triviaGameControllersRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface):
+            raise ValueError(f'triviaGameControllersRepository argument is malformed: \"{triviaGameControllersRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -452,13 +477,20 @@ class AddUserCommand(AbsCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(modifyUserDataHelper, ModifyUserDataHelper), f"malformed {modifyUserDataHelper=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(modifyUserDataHelper, ModifyUserDataHelper):
+            raise ValueError(f'modifyUserDataHelper argument is malformed: \"{modifyUserDataHelper}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__modifyUserDataHelper: ModifyUserDataHelper = modifyUserDataHelper
@@ -523,11 +555,16 @@ class AnswerCommand(AbsCommand):
         triviaIdGenerator: TriviaIdGeneratorInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
+            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -575,14 +612,22 @@ class BanTriviaQuestionCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaBanHelper, TriviaBanHelperInterface), f"malformed {triviaBanHelper=}"
-        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
-        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
-        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaBanHelper, TriviaBanHelperInterface):
+            raise ValueError(f'triviaBanHelper argument is malformed: \"{triviaBanHelper}\"')
+        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
+            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
+        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
+            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
+        elif not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -669,29 +714,52 @@ class ClearCachesCommand(AbsCommand):
         websocketConnectionServer: Optional[WebsocketConnectionServerInterface],
         wordOfTheDayRepository: Optional[WordOfTheDayRepositoryInterface]
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(authRepository, AuthRepository), f"malformed {authRepository=}"
-        assert bannedWordsRepository is None or isinstance(bannedWordsRepository, BannedWordsRepositoryInterface), f"malformed {bannedWordsRepository=}"
-        assert cheerActionsRepository is None or isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
-        assert funtoonTokensRepository is None or isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface), f"malformed {funtoonTokensRepository=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isLiveOnTwitchRepository is None or isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface), f"malformed {isLiveOnTwitchRepository=}"
-        assert locationsRepository is None or isinstance(locationsRepository, LocationsRepositoryInterface), f"malformed {locationsRepository=}"
-        assert isinstance(modifyUserDataHelper, ModifyUserDataHelper), f"malformed {modifyUserDataHelper=}"
-        assert mostRecentChatsRepository is None or isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface), f"malformed {mostRecentChatsRepository=}"
-        assert openTriviaDatabaseTriviaQuestionRepository is None or isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository), f"malformed {openTriviaDatabaseTriviaQuestionRepository=}"
-        assert soundPlayerSettingsRepository is None or isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface), f"malformed {soundPlayerSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert triviaSettingsRepository is None or isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
-        assert ttsSettingsRepository is None or isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface), f"malformed {ttsSettingsRepository=}"
-        assert twitchFollowerRepository is None or isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface), f"malformed {twitchFollowerRepository=}"
-        assert twitchTokensRepository is None or isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert weatherRepository is None or isinstance(weatherRepository, WeatherRepositoryInterface), f"malformed {weatherRepository=}"
-        assert websocketConnectionServer is None or isinstance(websocketConnectionServer, WebsocketConnectionServerInterface), f"malformed {websocketConnectionServer=}"
-        assert wordOfTheDayRepository is None or isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface), f"malformed {wordOfTheDayRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(authRepository, AuthRepository):
+            raise ValueError(f'authRepository argument is malformed: \"{authRepository}\"')
+        elif bannedWordsRepository is not None and not isinstance(bannedWordsRepository, BannedWordsRepositoryInterface):
+            raise ValueError(f'bannedWordsRepository argument is malformed: \"{bannedWordsRepository}\"')
+        elif cheerActionsRepository is not None and not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
+            raise ValueError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
+        elif funtoonTokensRepository is not None and not isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface):
+            raise ValueError(f'funtoonTokensRepository argument is malformed: \"{funtoonTokensRepository}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif isLiveOnTwitchRepository is not None and not isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface):
+            raise ValueError(f'isLiveOnTwitchRepository argument is malformed: \"{isLiveOnTwitchRepository}\"')
+        elif locationsRepository is not None and not isinstance(locationsRepository, LocationsRepositoryInterface):
+            raise ValueError(f'locationsRepository argument is malformed: \"{locationsRepository}\"')
+        elif not isinstance(modifyUserDataHelper, ModifyUserDataHelper):
+            raise ValueError(f'modifyUserDataHelper argument is malformed: \"{modifyUserDataHelper}\"')
+        elif mostRecentChatsRepository is not None and not isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface):
+            raise ValueError(f'mostRecentChatsRepository argument is malformed: \"{mostRecentChatsRepository}\"')
+        elif openTriviaDatabaseTriviaQuestionRepository is not None and not isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository):
+            raise ValueError(f'openTriviaDatabaseTriviaQuestionRepository argument is malformed: \"{openTriviaDatabaseTriviaQuestionRepository}\"')
+        elif soundPlayerSettingsRepository is not None and not isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface):
+            raise ValueError(f'soundPlayerSettingsRepository argument is malformed: \"{soundPlayerSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif triviaSettingsRepository is not None and not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        elif ttsSettingsRepository is not None and not isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface):
+            raise ValueError(f'ttsSettingsRepository argument is malformed: \"{ttsSettingsRepository}\"')
+        elif twitchFollowerRepository is not None and not isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface):
+            raise TypeError(f'twitchFollowerRepository argument is malformed: \"{twitchFollowerRepository}\"')
+        elif twitchTokensRepository is not None and not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif weatherRepository is not None and not isinstance(weatherRepository, WeatherRepositoryInterface):
+            raise ValueError(f'weatherRepository argument is malformed: \"{weatherRepository}\"')
+        elif websocketConnectionServer is not None and not isinstance(websocketConnectionServer, WebsocketConnectionServerInterface):
+            raise ValueError(f'websocketConnectionServer argument is malformed: \"{websocketConnectionServer}\"')
+        elif wordOfTheDayRepository is not None and not isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface):
+            raise ValueError(f'wordOfTheDayRepository argument is malformed: \"{wordOfTheDayRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -748,12 +816,18 @@ class ClearSuperTriviaQueueCommand(AbsCommand):
         triviaUtils: TriviaUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
+            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -798,13 +872,20 @@ class CommandsCommand(AbsCommand):
         delimiter: str = ', ',
         cooldown: timedelta = timedelta(seconds = 30)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert triviaUtils is None or isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif triviaUtils is not None and not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -819,8 +900,10 @@ class CommandsCommand(AbsCommand):
         generalSettings: GeneralSettingsRepositorySnapshot,
         user: UserInterface
     ) -> List[str]:
-        assert isinstance(generalSettings, GeneralSettingsRepositorySnapshot), f"malformed {generalSettings=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if not isinstance(generalSettings, GeneralSettingsRepositorySnapshot):
+            raise ValueError(f'generalSettings argument is malformed: \"{generalSettings}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         commands: List[str] = list()
 
@@ -840,8 +923,10 @@ class CommandsCommand(AbsCommand):
         generalSettings: GeneralSettingsRepositorySnapshot,
         user: UserInterface
     ) -> List[str]:
-        assert isinstance(generalSettings, GeneralSettingsRepositorySnapshot), f"malformed {generalSettings=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if not isinstance(generalSettings, GeneralSettingsRepositorySnapshot):
+            raise ValueError(f'generalSettings argument is malformed: \"{generalSettings}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         commands: List[str] = list()
 
@@ -861,12 +946,14 @@ class CommandsCommand(AbsCommand):
     ) -> List[str]:
         if not utils.isValidBool(isMod):
             raise ValueError(f'isMod argument is malformed: \"{isMod}\"')
-        assert isinstance(generalSettings, GeneralSettingsRepositorySnapshot), f"malformed {generalSettings=}"
-        if not utils.isValidStr(userId):
+        elif not isinstance(generalSettings, GeneralSettingsRepositorySnapshot):
+            raise ValueError(f'generalSettings argument is malformed: \"{generalSettings}\"')
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         isPrivilegedTriviaUser = self.__triviaUtils is not None and await self.__triviaUtils.isPrivilegedTriviaUser(
             twitchChannel = user.getHandle(),
@@ -968,11 +1055,16 @@ class ConfirmCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(modifyUserDataHelper, ModifyUserDataHelper), f"malformed {modifyUserDataHelper=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(modifyUserDataHelper, ModifyUserDataHelper):
+            raise ValueError(f'modifyUserDataHelper argument is malformed: \"{modifyUserDataHelper}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__modifyUserDataHelper: ModifyUserDataHelper = modifyUserDataHelper
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
@@ -1018,14 +1110,22 @@ class CutenessCommand(AbsCommand):
         delimiter: str = ', ',
         cooldown: timedelta = timedelta(seconds = 2)
     ):
-        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
-        assert isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
+            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
+        elif not isinstance(cutenessUtils, CutenessUtilsInterface):
+            raise ValueError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__cutenessUtils: CutenessUtilsInterface = cutenessUtils
@@ -1037,7 +1137,8 @@ class CutenessCommand(AbsCommand):
         self.__lastMessageTimes: TimedDict = TimedDict(cooldown)
 
     def __cutenessLeaderboardResultToStr(self, result: CutenessLeaderboardResult) -> str:
-        assert isinstance(result, CutenessLeaderboardResult), f"malformed {result=}"
+        if not isinstance(result, CutenessLeaderboardResult):
+            raise ValueError(f'result argument is malformed: \"{result}\"')
 
         entries = result.getEntries()
 
@@ -1063,7 +1164,8 @@ class CutenessCommand(AbsCommand):
             return f'{result.getCutenessDate().getHumanString()} Leaderboard {leaderboard} ✨'
 
     def __cutenessResultToStr(self, result: CutenessResult) -> str:
-        assert isinstance(result, CutenessResult), f"malformed {result=}"
+        if not isinstance(result, CutenessResult):
+            raise ValueError(f'result argument is malformed: \"{result}\"')
 
         cuteness = result.getCuteness()
 
@@ -1127,13 +1229,20 @@ class CutenessChampionsCommand(AbsCommand):
         delimiter: str = ', ',
         cooldown: timedelta = timedelta(seconds = 15)
     ):
-        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
-        assert isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
+            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
+        elif not isinstance(cutenessUtils, CutenessUtilsInterface):
+            raise ValueError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__cutenessUtils: CutenessUtilsInterface = cutenessUtils
@@ -1173,15 +1282,24 @@ class CutenessHistoryCommand(AbsCommand):
         leaderboardDelimiter: str = ' — ',
         cooldown: timedelta = timedelta(seconds = 2)
     ):
-        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
-        assert isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(entryDelimiter, str), f"malformed {entryDelimiter=}"
-        assert isinstance(leaderboardDelimiter, str), f"malformed {leaderboardDelimiter=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
+            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
+        elif not isinstance(cutenessUtils, CutenessUtilsInterface):
+            raise ValueError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(entryDelimiter, str):
+            raise ValueError(f'entryDelimiter argument is malformed: \"{entryDelimiter}\"')
+        elif not isinstance(leaderboardDelimiter, str):
+            raise ValueError(f'leaderboardDelimiter argument is malformed: \"{leaderboardDelimiter}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__cutenessUtils: CutenessUtilsInterface = cutenessUtils
@@ -1246,10 +1364,14 @@ class CynanSourceCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 1)
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -1280,13 +1402,20 @@ class DeleteCheerActionCommand(AbsCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface), f"malformed {cheerActionIdGenerator=}"
-        assert isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface):
+            raise ValueError(f'cheerActionIdGenerator argument is malformed: \"{cheerActionIdGenerator}\"')
+        elif not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
+            raise ValueError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__cheerActionIdGenerator: CheerActionIdGeneratorInterface = cheerActionIdGenerator
@@ -1297,7 +1426,8 @@ class DeleteCheerActionCommand(AbsCommand):
         self.__usersRepository: UsersRepositoryInterface = usersRepository
 
     async def __actionToStr(self, action: CheerAction) -> str:
-        assert isinstance(action, CheerAction), f"malformed {action=}"
+        if not isinstance(action, CheerAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         return f'id={action.getActionId()}, amount={action.getAmount()}, duration={action.getDurationSeconds()}'
 
@@ -1350,15 +1480,24 @@ class DeleteTriviaAnswersCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         answerDelimiter: str = ', '
     ):
-        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
-        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
-        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(answerDelimiter, str), f"malformed {answerDelimiter=}"
+        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
+            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
+            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
+        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
+            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
+        elif not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(answerDelimiter, str):
+            raise ValueError(f'answerDelimiter argument is malformed: \"{answerDelimiter}\"')
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -1432,10 +1571,14 @@ class DiscordCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 30)
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -1465,11 +1608,16 @@ class GetBannedTriviaControllersCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface), f"malformed {bannedTriviaGameControllersRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface):
+            raise ValueError(f'bannedTriviaGameControllersRepository argument is malformed: \"{bannedTriviaGameControllersRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__bannedTriviaGameControllersRepository: BannedTriviaGameControllersRepositoryInterface = bannedTriviaGameControllersRepository
@@ -1505,13 +1653,20 @@ class GetCheerActionsCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         delimiter: str = '; '
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
+            raise ValueError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__cheerActionsRepository: CheerActionsRepositoryInterface = cheerActionsRepository
@@ -1522,7 +1677,8 @@ class GetCheerActionsCommand(AbsCommand):
         self.__delimiter: str = delimiter
 
     async def __actionsToStr(self, actions: List[CheerAction]) -> str:
-        assert isinstance(actions, List), f"malformed {actions=}"
+        if not isinstance(actions, List):
+            raise ValueError(f'actions argument is malformed: \"{actions}\"')
 
         if len(actions) == 0:
             return f'ⓘ You have no cheer actions'
@@ -1562,11 +1718,16 @@ class GetGlobalTriviaControllersCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface), f"malformed {triviaGameGlobalControllersRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProviderInterface argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface):
+            raise ValueError(f'triviaGameGlobalControllersRepository argument is malformed: \"{triviaGameGlobalControllersRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -1604,15 +1765,24 @@ class GetTriviaAnswersCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         answerDelimiter: str = ', '
     ):
-        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
-        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
-        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(answerDelimiter, str), f"malformed {answerDelimiter=}"
+        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
+            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
+            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
+        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
+            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
+        elif not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(answerDelimiter, str):
+            raise ValueError(f'answerDelimiter argument is malformed: \"{answerDelimiter}\"')
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -1689,12 +1859,18 @@ class GetTriviaControllersCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface), f"malformed {triviaGameControllersRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface):
+            raise ValueError(f'triviaGameControllersRepository argument is malformed: \"{triviaGameControllersRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -1735,12 +1911,18 @@ class GiveCutenessCommand(AbsCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
+            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__timber: TimberInterface = timber
@@ -1819,12 +2001,18 @@ class JishoCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 3)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(jishoHelper, JishoHelperInterface), f"malformed {jishoHelper=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(jishoHelper, JishoHelperInterface):
+            raise ValueError(f'jishoHelper argument is malformed: \"{jishoHelper}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__jishoHelper: JishoHelperInterface = jishoHelper
@@ -1872,9 +2060,12 @@ class LoremIpsumCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -1911,14 +2102,22 @@ class MyCutenessHistoryCommand(AbsCommand):
         delimiter: str = ', ',
         cooldown: timedelta = timedelta(seconds = 3)
     ):
-        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
-        assert isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
+            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
+        elif not isinstance(cutenessUtils, CutenessUtilsInterface):
+            raise ValueError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__cutenessUtils: CutenessUtilsInterface = cutenessUtils
@@ -1973,10 +2172,14 @@ class PbsCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 1)
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -2006,12 +2209,18 @@ class PkMonCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 10)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(pokepediaRepository, PokepediaRepository), f"malformed {pokepediaRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(pokepediaRepository, PokepediaRepository):
+            raise ValueError(f'pokepediaRepository argument is malformed: \"{pokepediaRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__pokepediaRepository: PokepediaRepository = pokepediaRepository
@@ -2061,12 +2270,18 @@ class PkMoveCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 10)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(pokepediaRepository, PokepediaRepository), f"malformed {pokepediaRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(pokepediaRepository, PokepediaRepository):
+            raise ValueError(f'pokepediaRepository argument is malformed: \"{pokepediaRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__pokepediaRepository: PokepediaRepository = pokepediaRepository
@@ -2114,10 +2329,14 @@ class RaceCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 1)
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -2150,12 +2369,18 @@ class RecurringActionCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
-        assert isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface), f"malformed {recurringActionsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
+            raise ValueError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
+        elif not isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface):
+            raise ValueError(f'recurringActionsRepository argument is malformed: \"{recurringActionsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository
@@ -2170,9 +2395,12 @@ class RecurringActionCommand(AbsCommand):
         user: UserInterface,
         actionType: RecurringActionType
     ):
-        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(actionType, RecurringActionType), f"malformed {actionType=}"
+        if not isinstance(ctx, TwitchContext):
+            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(actionType, RecurringActionType):
+            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
 
         if actionType is RecurringActionType.SUPER_TRIVIA:
             await self.__disableSuperTriviaRecurringAction(
@@ -2197,8 +2425,10 @@ class RecurringActionCommand(AbsCommand):
         ctx: TwitchContext,
         user: UserInterface
     ):
-        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if not isinstance(ctx, TwitchContext):
+            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         recurringAction = SuperTriviaRecurringAction(
             enabled = False,
@@ -2213,8 +2443,10 @@ class RecurringActionCommand(AbsCommand):
         ctx: TwitchContext,
         user: UserInterface
     ):
-        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if not isinstance(ctx, TwitchContext):
+            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         recurringAction = WeatherRecurringAction(
             enabled = False,
@@ -2229,8 +2461,10 @@ class RecurringActionCommand(AbsCommand):
         ctx: TwitchContext,
         user: UserInterface
     ):
-        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if not isinstance(ctx, TwitchContext):
+            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         recurringAction = WordOfTheDayRecurringAction(
             enabled = False,
@@ -2246,9 +2480,11 @@ class RecurringActionCommand(AbsCommand):
         user: UserInterface,
         splits: List[str]
     ):
-        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        if not utils.hasItems(splits):
+        if not isinstance(ctx, TwitchContext):
+            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not utils.hasItems(splits):
             raise ValueError(f'splits argument is malformed: \"{splits}\"')
 
         minutesBetween = await self.__parseMinutesBetween(
@@ -2271,9 +2507,11 @@ class RecurringActionCommand(AbsCommand):
         user: UserInterface,
         splits: List[str]
     ):
-        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        if not utils.hasItems(splits):
+        if not isinstance(ctx, TwitchContext):
+            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not utils.hasItems(splits):
             raise ValueError(f'splits argument is malformed: \"{splits}\"')
 
         minutesBetween = await self.__parseMinutesBetween(
@@ -2296,9 +2534,11 @@ class RecurringActionCommand(AbsCommand):
         user: UserInterface,
         splits: List[str]
     ):
-        assert isinstance(ctx, TwitchContext), f"malformed {ctx=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        if not utils.hasItems(splits):
+        if not isinstance(ctx, TwitchContext):
+            raise ValueError(f'ctx argument is malformed: \"{ctx}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not utils.hasItems(splits):
             raise ValueError(f'splits argument is malformed: \"{splits}\"')
 
         minutesBetween = await self.__parseMinutesBetween(
@@ -2398,8 +2638,9 @@ class RecurringActionCommand(AbsCommand):
         return False
 
     async def __parseMinutesBetween(self, actionType: RecurringActionType, splits: List[str]) -> int:
-        assert isinstance(actionType, RecurringActionType), f"malformed {actionType=}"
-        if not utils.hasItems(splits):
+        if not isinstance(actionType, RecurringActionType):
+            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
+        elif not utils.hasItems(splits):
             raise ValueError(f'splits argument is malformed: \"{splits}\"')
 
         if len(splits) < 3:
@@ -2434,12 +2675,18 @@ class RecurringActionsCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         delimiter: str = ', '
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface), f"malformed {recurringActionsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface):
+            raise ValueError(f'recurringActionsRepository argument is malformed: \"{recurringActionsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__recurringActionsRepository: RecurringActionsRepositoryInterface = recurringActionsRepository
@@ -2482,11 +2729,16 @@ class RemoveBannedTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface), f"malformed {bannedTriviaGameControllersRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProviderInterface argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface):
+            raise ValueError(f'bannedTriviaGameControllersRepository argument is malformed: \"{bannedTriviaGameControllersRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__bannedTriviaGameControllersRepository: BannedTriviaGameControllersRepositoryInterface = bannedTriviaGameControllersRepository
@@ -2540,11 +2792,16 @@ class RemoveGlobalTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface), f"malformed {triviaGameGlobalControllersRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface):
+            raise ValueError(f'triviaGameGlobalControllersRepository argument is malformed: \"{triviaGameGlobalControllersRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -2599,12 +2856,18 @@ class RemoveTriviaControllerCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface), f"malformed {triviaGameControllersRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface):
+            raise ValueError(f'triviaGameControllersRepository argument is malformed: \"{triviaGameControllersRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -2669,13 +2932,20 @@ class RemoveUserCommand(AbsCommand):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(modifyUserDataHelper, ModifyUserDataHelper), f"malformed {modifyUserDataHelper=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(modifyUserDataHelper, ModifyUserDataHelper):
+            raise ValueError(f'modifyUserDataHelper argument is malformed: \"{modifyUserDataHelper}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__modifyUserDataHelper: ModifyUserDataHelper = modifyUserDataHelper
@@ -2733,11 +3003,16 @@ class SetFuntoonTokenCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface), f"malformed {funtoonTokensRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface):
+            raise ValueError(f'funtoonTokensRepository argument is malformed: \"{funtoonTokensRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__funtoonTokensRepository: FuntoonTokensRepositoryInterface = funtoonTokensRepository
@@ -2793,11 +3068,16 @@ class SetTwitchCodeCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -2865,14 +3145,22 @@ class SuperTriviaCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
-        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
-        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
+            raise ValueError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
+        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
+            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        elif not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -2943,11 +3231,16 @@ class SwQuoteCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 30)
     ):
-        assert isinstance(starWarsQuotesRepository, StarWarsQuotesRepositoryInterface), f"malformed {starWarsQuotesRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(starWarsQuotesRepository, StarWarsQuotesRepositoryInterface):
+            raise ValueError(f'starWarsQuotesRepository argument is malformed: \"{starWarsQuotesRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__starWarsQuotesRepository: StarWarsQuotesRepositoryInterface = starWarsQuotesRepository
         self.__timber: TimberInterface = timber
@@ -2994,10 +3287,14 @@ class TimeCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 1)
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -3045,13 +3342,20 @@ class TranslateCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 15)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(translationHelper, TranslationHelper), f"malformed {translationHelper=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
+            raise ValueError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(translationHelper, TranslationHelper):
+            raise ValueError(f'translationHelper argument is malformed: \"{translationHelper}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository
@@ -3118,14 +3422,22 @@ class TriviaInfoCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
-        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
-        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
+            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
+            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
+        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
+            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
+        elif not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -3203,16 +3515,26 @@ class TriviaScoreCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 2)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface), f"malformed {shinyTriviaOccurencesRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface), f"malformed {toxicTriviaOccurencesRepository=}"
-        assert isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface), f"malformed {triviaScoreRepository=}"
-        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface):
+            raise ValueError(f'shinyTriviaOccurencesRepository argument is malformed: \"{shinyTriviaOccurencesRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface):
+            raise ValueError(f'toxicTriviaOccurencesRepository argument is malformed: \"{toxicTriviaOccurencesRepository}\"')
+        elif not isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface):
+            raise ValueError(f'triviaScoreRepository argument is malformed: \"{triviaScoreRepository}\"')
+        elif not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__shinyTriviaOccurencesRepository: ShinyTriviaOccurencesRepositoryInterface = shinyTriviaOccurencesRepository
@@ -3294,11 +3616,16 @@ class TtsCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
+            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__streamAlertsManager: StreamAlertsManagerInterface = streamAlertsManager
@@ -3362,13 +3689,20 @@ class TwitchInfoCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
-        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
+            raise ValueError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
+        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
+            raise ValueError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber
@@ -3428,7 +3762,8 @@ class TwitchInfoCommand(AbsCommand):
         self.__timber.log('TwitchInfoCommand', f'Handled !twitchinfo command for {ctx.getAuthorName()}:{ctx.getAuthorId()} in {user.getHandle()}')
 
     async def __toStr(self, userInfo: TwitchUserDetails) -> str:
-        assert isinstance(userInfo, TwitchUserDetails), f"malformed {userInfo=}"
+        if not isinstance(userInfo, TwitchUserDetails):
+            raise ValueError(f'userInfo argument is malformed: \"{userInfo}\"')
 
         broadcasterType = userInfo.getBroadcasterType()
         displayName = userInfo.getDisplayName()
@@ -3446,10 +3781,14 @@ class TwitterCommand(AbsCommand):
         usersRepository: UsersRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 5)
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__timber: TimberInterface = timber
         self.__twitchUtils: TwitchUtilsInterface = twitchUtils
@@ -3481,14 +3820,22 @@ class UnbanTriviaQuestionCommand(AbsCommand):
         twitchUtils: TwitchUtilsInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaBanHelper, TriviaBanHelperInterface), f"malformed {triviaBanHelper=}"
-        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
-        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
-        assert isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaBanHelper, TriviaBanHelperInterface):
+            raise ValueError(f'triviaBanHelper argument is malformed: \"{triviaBanHelper}\"')
+        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
+            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
+        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
+            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
+        elif not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise ValueError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -3558,13 +3905,20 @@ class WeatherCommand(AbsCommand):
         weatherRepository: WeatherRepositoryInterface,
         cooldown: timedelta = timedelta(minutes = 1)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(locationsRepository, LocationsRepositoryInterface), f"malformed {locationsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(weatherRepository, WeatherRepositoryInterface), f"malformed {weatherRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(locationsRepository, LocationsRepositoryInterface):
+            raise ValueError(f'locationsRepository argument is malformed: \"{locationsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(weatherRepository, WeatherRepositoryInterface):
+            raise ValueError(f'weatherRepository argument is malformed: \"{weatherRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__locationsRepository: LocationsRepositoryInterface = locationsRepository
@@ -3613,13 +3967,20 @@ class WordCommand(AbsCommand):
         wordOfTheDayRepository: WordOfTheDayRepositoryInterface,
         cooldown: timedelta = timedelta(seconds = 3)
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface), f"malformed {wordOfTheDayRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
+            raise ValueError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface):
+            raise ValueError(f'wordOfTheDayRepository argument is malformed: \"{wordOfTheDayRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository

--- a/src/CynanBot/contentScanner/bannedWordsRepository.py
+++ b/src/CynanBot/contentScanner/bannedWordsRepository.py
@@ -19,10 +19,8 @@ class BannedWordsRepository(BannedWordsRepositoryInterface):
         bannedWordsLinesReader: LinesReaderInterface,
         timber: TimberInterface
     ):
-        if not isinstance(bannedWordsLinesReader, LinesReaderInterface):
-            raise TypeError(f'bannedWordsLinesReader argument is malformed: \"{bannedWordsLinesReader}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(bannedWordsLinesReader, LinesReaderInterface), f"malformed {bannedWordsLinesReader=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__bannedWordsLinesReader: LinesReaderInterface = bannedWordsLinesReader
         self.__timber: TimberInterface = timber
@@ -38,8 +36,7 @@ class BannedWordsRepository(BannedWordsRepositoryInterface):
         self,
         lines: Optional[List[str]]
     ) -> Set[AbsBannedWord]:
-        if lines is not None and not isinstance(lines, List):
-            raise TypeError(f'lines argument is malformed: \"{lines}\"')
+        assert lines is None or isinstance(lines, List), f"malformed {lines=}"
 
         cleanedBannedWords: Set[AbsBannedWord] = set()
 
@@ -99,8 +96,7 @@ class BannedWordsRepository(BannedWordsRepositoryInterface):
         return bannedWords
 
     def __processLine(self, line: Optional[str]) -> Optional[AbsBannedWord]:
-        if line is not None and not isinstance(line, str):
-            raise TypeError(f'line argument is malformed: \"{line}\"')
+        assert line is None or isinstance(line, str), f"malformed {line=}"
 
         if not utils.isValidStr(line):
             return None

--- a/src/CynanBot/contentScanner/bannedWordsRepository.py
+++ b/src/CynanBot/contentScanner/bannedWordsRepository.py
@@ -19,8 +19,10 @@ class BannedWordsRepository(BannedWordsRepositoryInterface):
         bannedWordsLinesReader: LinesReaderInterface,
         timber: TimberInterface
     ):
-        assert isinstance(bannedWordsLinesReader, LinesReaderInterface), f"malformed {bannedWordsLinesReader=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(bannedWordsLinesReader, LinesReaderInterface):
+            raise TypeError(f'bannedWordsLinesReader argument is malformed: \"{bannedWordsLinesReader}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
 
         self.__bannedWordsLinesReader: LinesReaderInterface = bannedWordsLinesReader
         self.__timber: TimberInterface = timber
@@ -36,7 +38,8 @@ class BannedWordsRepository(BannedWordsRepositoryInterface):
         self,
         lines: Optional[List[str]]
     ) -> Set[AbsBannedWord]:
-        assert lines is None or isinstance(lines, List), f"malformed {lines=}"
+        if lines is not None and not isinstance(lines, List):
+            raise TypeError(f'lines argument is malformed: \"{lines}\"')
 
         cleanedBannedWords: Set[AbsBannedWord] = set()
 
@@ -96,7 +99,8 @@ class BannedWordsRepository(BannedWordsRepositoryInterface):
         return bannedWords
 
     def __processLine(self, line: Optional[str]) -> Optional[AbsBannedWord]:
-        assert line is None or isinstance(line, str), f"malformed {line=}"
+        if line is not None and not isinstance(line, str):
+            raise TypeError(f'line argument is malformed: \"{line}\"')
 
         if not utils.isValidStr(line):
             return None

--- a/src/CynanBot/contentScanner/contentScanner.py
+++ b/src/CynanBot/contentScanner/contentScanner.py
@@ -20,10 +20,8 @@ class ContentScanner(ContentScannerInterface):
         bannedWordsRepository: BannedWordsRepositoryInterface,
         timber: TimberInterface
     ):
-        if not isinstance(bannedWordsRepository, BannedWordsRepositoryInterface):
-            raise TypeError(f'bannedWordsRepository argument is malformed: \"{bannedWordsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(bannedWordsRepository, BannedWordsRepositoryInterface), f"malformed {bannedWordsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__bannedWordsRepository: BannedWordsRepositoryInterface = bannedWordsRepository
         self.__timber: TimberInterface = timber
@@ -32,9 +30,8 @@ class ContentScanner(ContentScannerInterface):
         self.__wordRegEx: Pattern = re.compile(r'\w', re.IGNORECASE)
 
     async def scan(self, string: Optional[str]) -> ContentCode:
-        if string is not None and not isinstance(string, str):
-            raise TypeError(f'string argument is malformed: \"{string}\"')
-        elif string is None:
+        assert string is None or isinstance(string, str), f"malformed {string=}"
+        if string is None:
             return ContentCode.IS_NONE
         elif len(string) == 0:
             return ContentCode.IS_EMPTY
@@ -62,10 +59,8 @@ class ContentScanner(ContentScannerInterface):
         phrases: Set[str],
         words: Set[str]
     ) -> ContentCode:
-        if not isinstance(phrases, Set):
-            raise TypeError(f'phrases argument is malformed: \"{phrases}\"')
-        elif not isinstance(words, Set):
-            raise TypeError(f'words argument is malformed: \"{words}\"')
+        assert isinstance(phrases, Set), f"malformed {phrases=}"
+        assert isinstance(words, Set), f"malformed {words=}"
 
         absBannedWords = await self.__bannedWordsRepository.getBannedWordsAsync()
 
@@ -93,8 +88,7 @@ class ContentScanner(ContentScannerInterface):
         phrases: Set[str],
         string: Optional[str]
     ):
-        if not isinstance(phrases, Set):
-            raise TypeError(f'phrases argument is malformed: \"{phrases}\"')
+        assert isinstance(phrases, Set), f"malformed {phrases=}"
 
         if not utils.isValidStr(string):
             return
@@ -113,8 +107,7 @@ class ContentScanner(ContentScannerInterface):
         words: Set[str],
         string: Optional[str]
     ):
-        if not isinstance(words, Set):
-            raise TypeError(f'words argument is malformed: \"{words}\"')
+        assert isinstance(words, Set), f"malformed {words=}"
 
         if not utils.isValidStr(string):
             return

--- a/src/CynanBot/contentScanner/contentScanner.py
+++ b/src/CynanBot/contentScanner/contentScanner.py
@@ -20,8 +20,10 @@ class ContentScanner(ContentScannerInterface):
         bannedWordsRepository: BannedWordsRepositoryInterface,
         timber: TimberInterface
     ):
-        assert isinstance(bannedWordsRepository, BannedWordsRepositoryInterface), f"malformed {bannedWordsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(bannedWordsRepository, BannedWordsRepositoryInterface):
+            raise TypeError(f'bannedWordsRepository argument is malformed: \"{bannedWordsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
 
         self.__bannedWordsRepository: BannedWordsRepositoryInterface = bannedWordsRepository
         self.__timber: TimberInterface = timber
@@ -30,8 +32,9 @@ class ContentScanner(ContentScannerInterface):
         self.__wordRegEx: Pattern = re.compile(r'\w', re.IGNORECASE)
 
     async def scan(self, string: Optional[str]) -> ContentCode:
-        assert string is None or isinstance(string, str), f"malformed {string=}"
-        if string is None:
+        if string is not None and not isinstance(string, str):
+            raise TypeError(f'string argument is malformed: \"{string}\"')
+        elif string is None:
             return ContentCode.IS_NONE
         elif len(string) == 0:
             return ContentCode.IS_EMPTY
@@ -59,8 +62,10 @@ class ContentScanner(ContentScannerInterface):
         phrases: Set[str],
         words: Set[str]
     ) -> ContentCode:
-        assert isinstance(phrases, Set), f"malformed {phrases=}"
-        assert isinstance(words, Set), f"malformed {words=}"
+        if not isinstance(phrases, Set):
+            raise TypeError(f'phrases argument is malformed: \"{phrases}\"')
+        elif not isinstance(words, Set):
+            raise TypeError(f'words argument is malformed: \"{words}\"')
 
         absBannedWords = await self.__bannedWordsRepository.getBannedWordsAsync()
 
@@ -88,7 +93,8 @@ class ContentScanner(ContentScannerInterface):
         phrases: Set[str],
         string: Optional[str]
     ):
-        assert isinstance(phrases, Set), f"malformed {phrases=}"
+        if not isinstance(phrases, Set):
+            raise TypeError(f'phrases argument is malformed: \"{phrases}\"')
 
         if not utils.isValidStr(string):
             return
@@ -107,7 +113,8 @@ class ContentScanner(ContentScannerInterface):
         words: Set[str],
         string: Optional[str]
     ):
-        assert isinstance(words, Set), f"malformed {words=}"
+        if not isinstance(words, Set):
+            raise TypeError(f'words argument is malformed: \"{words}\"')
 
         if not utils.isValidStr(string):
             return

--- a/src/CynanBot/cuteness/cutenessHistoryEntry.py
+++ b/src/CynanBot/cuteness/cutenessHistoryEntry.py
@@ -17,8 +17,7 @@ class CutenessHistoryEntry(CutenessEntry):
             userName = userName
         )
 
-        if not isinstance(cutenessDate, CutenessDate):
-            raise ValueError(f'cutenessDate argument is malformed: \"{cutenessDate}\"')
+        assert isinstance(cutenessDate, CutenessDate), f"malformed {cutenessDate=}"
 
         self.__cutenessDate: CutenessDate = cutenessDate
 

--- a/src/CynanBot/cuteness/cutenessHistoryEntry.py
+++ b/src/CynanBot/cuteness/cutenessHistoryEntry.py
@@ -17,7 +17,8 @@ class CutenessHistoryEntry(CutenessEntry):
             userName = userName
         )
 
-        assert isinstance(cutenessDate, CutenessDate), f"malformed {cutenessDate=}"
+        if not isinstance(cutenessDate, CutenessDate):
+            raise ValueError(f'cutenessDate argument is malformed: \"{cutenessDate}\"')
 
         self.__cutenessDate: CutenessDate = cutenessDate
 

--- a/src/CynanBot/cuteness/cutenessHistoryResult.py
+++ b/src/CynanBot/cuteness/cutenessHistoryResult.py
@@ -17,16 +17,14 @@ class CutenessHistoryResult():
     ):
         if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif bestCuteness is not None and not isinstance(bestCuteness, CutenessHistoryEntry):
-            raise ValueError(f'bestCuteness argument is malformed: \"{bestCuteness}\"')
-        elif totalCuteness is not None and not utils.isValidInt(totalCuteness):
+        assert bestCuteness is None or isinstance(bestCuteness, CutenessHistoryEntry), f"malformed {bestCuteness=}"
+        if totalCuteness is not None and not utils.isValidInt(totalCuteness):
             raise ValueError(f'totalCuteness argument is malformed: \"{totalCuteness}\"')
-        elif totalCuteness is not None and (totalCuteness < 0 or totalCuteness > utils.getLongMaxSafeSize()):
+        if totalCuteness is not None and (totalCuteness < 0 or totalCuteness > utils.getLongMaxSafeSize()):
             raise ValueError(f'totalCuteness argument is out of bounds: {totalCuteness}')
-        elif entries is not None and not isinstance(entries, List):
-            raise ValueError(f'entries argument is malformed: \"{entries}\"')
+        assert entries is None or isinstance(entries, List), f"malformed {entries=}"
 
         self.__userId: str = userId
         self.__userName: str = userName

--- a/src/CynanBot/cuteness/cutenessHistoryResult.py
+++ b/src/CynanBot/cuteness/cutenessHistoryResult.py
@@ -17,14 +17,16 @@ class CutenessHistoryResult():
     ):
         if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert bestCuteness is None or isinstance(bestCuteness, CutenessHistoryEntry), f"malformed {bestCuteness=}"
-        if totalCuteness is not None and not utils.isValidInt(totalCuteness):
+        elif bestCuteness is not None and not isinstance(bestCuteness, CutenessHistoryEntry):
+            raise ValueError(f'bestCuteness argument is malformed: \"{bestCuteness}\"')
+        elif totalCuteness is not None and not utils.isValidInt(totalCuteness):
             raise ValueError(f'totalCuteness argument is malformed: \"{totalCuteness}\"')
-        if totalCuteness is not None and (totalCuteness < 0 or totalCuteness > utils.getLongMaxSafeSize()):
+        elif totalCuteness is not None and (totalCuteness < 0 or totalCuteness > utils.getLongMaxSafeSize()):
             raise ValueError(f'totalCuteness argument is out of bounds: {totalCuteness}')
-        assert entries is None or isinstance(entries, List), f"malformed {entries=}"
+        elif entries is not None and not isinstance(entries, List):
+            raise ValueError(f'entries argument is malformed: \"{entries}\"')
 
         self.__userId: str = userId
         self.__userName: str = userName

--- a/src/CynanBot/cuteness/cutenessLeaderboardResult.py
+++ b/src/CynanBot/cuteness/cutenessLeaderboardResult.py
@@ -14,8 +14,7 @@ class CutenessLeaderboardResult():
         specificLookupCutenessResult: Optional[CutenessResult] = None,
         entries: Optional[List[CutenessLeaderboardEntry]] = None
     ):
-        if not isinstance(cutenessDate, CutenessDate):
-            raise ValueError(f'cutenessDate argument is malformed: \"{cutenessDate}\"')
+        assert isinstance(cutenessDate, CutenessDate), f"malformed {cutenessDate=}"
 
         self.__cutenessDate: CutenessDate = cutenessDate
         self.__specificLookupCutenessResult: Optional[CutenessResult] = specificLookupCutenessResult

--- a/src/CynanBot/cuteness/cutenessLeaderboardResult.py
+++ b/src/CynanBot/cuteness/cutenessLeaderboardResult.py
@@ -14,7 +14,8 @@ class CutenessLeaderboardResult():
         specificLookupCutenessResult: Optional[CutenessResult] = None,
         entries: Optional[List[CutenessLeaderboardEntry]] = None
     ):
-        assert isinstance(cutenessDate, CutenessDate), f"malformed {cutenessDate=}"
+        if not isinstance(cutenessDate, CutenessDate):
+            raise ValueError(f'cutenessDate argument is malformed: \"{cutenessDate}\"')
 
         self.__cutenessDate: CutenessDate = cutenessDate
         self.__specificLookupCutenessResult: Optional[CutenessResult] = specificLookupCutenessResult

--- a/src/CynanBot/cuteness/cutenessRepository.py
+++ b/src/CynanBot/cuteness/cutenessRepository.py
@@ -30,21 +30,19 @@ class CutenessRepository(CutenessRepositoryInterface):
         historySize: int = 5,
         leaderboardSize: int = 10
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not utils.isValidInt(historyLeaderboardSize):
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not utils.isValidInt(historyLeaderboardSize):
             raise ValueError(f'historyLeaderboardSize argument is malformed: \"{historyLeaderboardSize}\"')
-        elif historyLeaderboardSize < 2 or historyLeaderboardSize > 6:
+        if historyLeaderboardSize < 2 or historyLeaderboardSize > 6:
             raise ValueError(f'historyLeaderboardSize argument is out of bounds: {historyLeaderboardSize}')
-        elif not utils.isValidInt(historySize):
+        if not utils.isValidInt(historySize):
             raise ValueError(f'historySize argument is malformed: \"{historySize}\"')
-        elif historySize < 3 or historySize > 12:
+        if historySize < 3 or historySize > 12:
             raise ValueError(f'historySize argument is out of bounds: {historySize}')
-        elif not utils.isValidInt(leaderboardSize):
+        if not utils.isValidInt(leaderboardSize):
             raise ValueError(f'leaderboardSize argument is malformed: \"{leaderboardSize}\"')
-        elif leaderboardSize < 3 or leaderboardSize > 10:
+        if leaderboardSize < 3 or leaderboardSize > 10:
             raise ValueError(f'leaderboardSize argument is out of bounds: {leaderboardSize}')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
@@ -63,11 +61,11 @@ class CutenessRepository(CutenessRepositoryInterface):
     ) -> CutenessResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif userId == '0':
+        if userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         await self.__userIdsRepository.setUser(userId = userId, userName = userName)
@@ -155,9 +153,9 @@ class CutenessRepository(CutenessRepositoryInterface):
     ) -> CutenessHistoryResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         await self.__userIdsRepository.setUser(userId = userId, userName = userName)
@@ -248,15 +246,15 @@ class CutenessRepository(CutenessRepositoryInterface):
     ) -> CutenessResult:
         if not utils.isValidInt(incrementAmount):
             raise ValueError(f'incrementAmount argument is malformed: \"{incrementAmount}\"')
-        elif incrementAmount < utils.getLongMinSafeSize() or incrementAmount > utils.getLongMaxSafeSize():
+        if incrementAmount < utils.getLongMinSafeSize() or incrementAmount > utils.getLongMaxSafeSize():
             raise ValueError(f'incrementAmount argument is out of bounds: {incrementAmount}')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif userId == '0':
+        if userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         await self.__userIdsRepository.setUser(userId = userId, userName = userName)

--- a/src/CynanBot/cuteness/cutenessRepository.py
+++ b/src/CynanBot/cuteness/cutenessRepository.py
@@ -30,19 +30,21 @@ class CutenessRepository(CutenessRepositoryInterface):
         historySize: int = 5,
         leaderboardSize: int = 10
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        if not utils.isValidInt(historyLeaderboardSize):
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not utils.isValidInt(historyLeaderboardSize):
             raise ValueError(f'historyLeaderboardSize argument is malformed: \"{historyLeaderboardSize}\"')
-        if historyLeaderboardSize < 2 or historyLeaderboardSize > 6:
+        elif historyLeaderboardSize < 2 or historyLeaderboardSize > 6:
             raise ValueError(f'historyLeaderboardSize argument is out of bounds: {historyLeaderboardSize}')
-        if not utils.isValidInt(historySize):
+        elif not utils.isValidInt(historySize):
             raise ValueError(f'historySize argument is malformed: \"{historySize}\"')
-        if historySize < 3 or historySize > 12:
+        elif historySize < 3 or historySize > 12:
             raise ValueError(f'historySize argument is out of bounds: {historySize}')
-        if not utils.isValidInt(leaderboardSize):
+        elif not utils.isValidInt(leaderboardSize):
             raise ValueError(f'leaderboardSize argument is malformed: \"{leaderboardSize}\"')
-        if leaderboardSize < 3 or leaderboardSize > 10:
+        elif leaderboardSize < 3 or leaderboardSize > 10:
             raise ValueError(f'leaderboardSize argument is out of bounds: {leaderboardSize}')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
@@ -61,11 +63,11 @@ class CutenessRepository(CutenessRepositoryInterface):
     ) -> CutenessResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if userId == '0':
+        elif userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         await self.__userIdsRepository.setUser(userId = userId, userName = userName)
@@ -153,9 +155,9 @@ class CutenessRepository(CutenessRepositoryInterface):
     ) -> CutenessHistoryResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         await self.__userIdsRepository.setUser(userId = userId, userName = userName)
@@ -246,15 +248,15 @@ class CutenessRepository(CutenessRepositoryInterface):
     ) -> CutenessResult:
         if not utils.isValidInt(incrementAmount):
             raise ValueError(f'incrementAmount argument is malformed: \"{incrementAmount}\"')
-        if incrementAmount < utils.getLongMinSafeSize() or incrementAmount > utils.getLongMaxSafeSize():
+        elif incrementAmount < utils.getLongMinSafeSize() or incrementAmount > utils.getLongMaxSafeSize():
             raise ValueError(f'incrementAmount argument is out of bounds: {incrementAmount}')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if userId == '0':
+        elif userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         await self.__userIdsRepository.setUser(userId = userId, userName = userName)

--- a/src/CynanBot/cuteness/cutenessResult.py
+++ b/src/CynanBot/cuteness/cutenessResult.py
@@ -14,15 +14,14 @@ class CutenessResult():
         userId: str,
         userName: str
     ):
-        if not isinstance(cutenessDate, CutenessDate):
-            raise ValueError(f'cutenessDate argument is malformed: \"{cutenessDate}\"')
-        elif cuteness is not None and not utils.isValidInt(cuteness):
+        assert isinstance(cutenessDate, CutenessDate), f"malformed {cutenessDate=}"
+        if cuteness is not None and not utils.isValidInt(cuteness):
             raise ValueError(f'cuteness argument is malformed: \"{cuteness}\"')
-        elif cuteness is not None and (cuteness < 0 or cuteness > utils.getLongMaxSafeSize()):
+        if cuteness is not None and (cuteness < 0 or cuteness > utils.getLongMaxSafeSize()):
             raise ValueError(f'cuteness argument is out of bounds: {cuteness}')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__cutenessDate: CutenessDate = cutenessDate

--- a/src/CynanBot/cuteness/cutenessResult.py
+++ b/src/CynanBot/cuteness/cutenessResult.py
@@ -14,14 +14,15 @@ class CutenessResult():
         userId: str,
         userName: str
     ):
-        assert isinstance(cutenessDate, CutenessDate), f"malformed {cutenessDate=}"
-        if cuteness is not None and not utils.isValidInt(cuteness):
+        if not isinstance(cutenessDate, CutenessDate):
+            raise ValueError(f'cutenessDate argument is malformed: \"{cutenessDate}\"')
+        elif cuteness is not None and not utils.isValidInt(cuteness):
             raise ValueError(f'cuteness argument is malformed: \"{cuteness}\"')
-        if cuteness is not None and (cuteness < 0 or cuteness > utils.getLongMaxSafeSize()):
+        elif cuteness is not None and (cuteness < 0 or cuteness > utils.getLongMaxSafeSize()):
             raise ValueError(f'cuteness argument is out of bounds: {cuteness}')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__cutenessDate: CutenessDate = cutenessDate

--- a/src/CynanBot/cuteness/cutenessUtils.py
+++ b/src/CynanBot/cuteness/cutenessUtils.py
@@ -16,10 +16,8 @@ class CutenessUtils(CutenessUtilsInterface):
         pass
 
     def getCuteness(self, result: CutenessResult, delimiter: str) -> str:
-        if not isinstance(result, CutenessResult):
-            raise ValueError(f'result argument is malformed: \"{result}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(result, CutenessResult), f"malformed {result=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         cuteness = result.getCuteness()
 
@@ -29,10 +27,8 @@ class CutenessUtils(CutenessUtilsInterface):
             return f'@{result.getUserName()} has no cuteness in {result.getCutenessDate().getHumanString()}'
 
     def getCutenessChampions(self, result: CutenessChampionsResult, delimiter: str) -> str:
-        if not isinstance(result, CutenessChampionsResult):
-            raise ValueError(f'result argument is malformed: \"{result}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(result, CutenessChampionsResult), f"malformed {result=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         champions = result.getChampions()
 
@@ -48,10 +44,8 @@ class CutenessUtils(CutenessUtilsInterface):
         return f'Cuteness Champions {championsStr} ✨'
 
     def getCutenessHistory(self, result: CutenessHistoryResult, delimiter: str) -> str:
-        if not isinstance(result, CutenessHistoryResult):
-            raise ValueError(f'result argument is malformed: \"{result}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(result, CutenessHistoryResult), f"malformed {result=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         entries = result.getEntries()
 
@@ -79,8 +73,7 @@ class CutenessUtils(CutenessUtilsInterface):
     def getLeaderboard(self, entries: List[CutenessLeaderboardEntry], delimiter: str) -> str:
         if not isinstance(entries, List) or len(entries) == 0:
             raise ValueError(f'entries argument is malformed: \"{entries}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         entryStrings: List[str] = list()
 
@@ -95,12 +88,9 @@ class CutenessUtils(CutenessUtilsInterface):
         entryDelimiter: str,
         leaderboardDelimiter: str
     ) -> str:
-        if not isinstance(result, CutenessLeaderboardHistoryResult):
-            raise ValueError(f'result argument is malformed: \"{result}\"')
-        elif not isinstance(entryDelimiter, str):
-            raise ValueError(f'entryDelimiter argument is malformed: \"{entryDelimiter}\"')
-        elif not isinstance(leaderboardDelimiter, str):
-            raise ValueError(f'leaderboardDelimiter argument is malformed: \"{leaderboardDelimiter}\"')
+        assert isinstance(result, CutenessLeaderboardHistoryResult), f"malformed {result=}"
+        assert isinstance(entryDelimiter, str), f"malformed {entryDelimiter=}"
+        assert isinstance(leaderboardDelimiter, str), f"malformed {leaderboardDelimiter=}"
 
         leaderboards = result.getLeaderboards()
 
@@ -123,8 +113,7 @@ class CutenessUtils(CutenessUtilsInterface):
         return f'Cuteness Leaderboard History — {leaderboardDelimiter.join(leaderboardStrings)} ✨'
 
     def __getLeaderboardPlacementString(self, entry: CutenessLeaderboardEntry) -> str:
-        if not isinstance(entry, CutenessLeaderboardEntry):
-            raise ValueError(f'result argument is malformed: \"{entry}\"')
+        assert isinstance(entry, CutenessLeaderboardEntry), f"malformed {entry=}"
 
         rankStr = ''
 

--- a/src/CynanBot/cuteness/cutenessUtils.py
+++ b/src/CynanBot/cuteness/cutenessUtils.py
@@ -16,8 +16,10 @@ class CutenessUtils(CutenessUtilsInterface):
         pass
 
     def getCuteness(self, result: CutenessResult, delimiter: str) -> str:
-        assert isinstance(result, CutenessResult), f"malformed {result=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(result, CutenessResult):
+            raise ValueError(f'result argument is malformed: \"{result}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         cuteness = result.getCuteness()
 
@@ -27,8 +29,10 @@ class CutenessUtils(CutenessUtilsInterface):
             return f'@{result.getUserName()} has no cuteness in {result.getCutenessDate().getHumanString()}'
 
     def getCutenessChampions(self, result: CutenessChampionsResult, delimiter: str) -> str:
-        assert isinstance(result, CutenessChampionsResult), f"malformed {result=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(result, CutenessChampionsResult):
+            raise ValueError(f'result argument is malformed: \"{result}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         champions = result.getChampions()
 
@@ -44,8 +48,10 @@ class CutenessUtils(CutenessUtilsInterface):
         return f'Cuteness Champions {championsStr} ✨'
 
     def getCutenessHistory(self, result: CutenessHistoryResult, delimiter: str) -> str:
-        assert isinstance(result, CutenessHistoryResult), f"malformed {result=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(result, CutenessHistoryResult):
+            raise ValueError(f'result argument is malformed: \"{result}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         entries = result.getEntries()
 
@@ -73,7 +79,8 @@ class CutenessUtils(CutenessUtilsInterface):
     def getLeaderboard(self, entries: List[CutenessLeaderboardEntry], delimiter: str) -> str:
         if not isinstance(entries, List) or len(entries) == 0:
             raise ValueError(f'entries argument is malformed: \"{entries}\"')
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         entryStrings: List[str] = list()
 
@@ -88,9 +95,12 @@ class CutenessUtils(CutenessUtilsInterface):
         entryDelimiter: str,
         leaderboardDelimiter: str
     ) -> str:
-        assert isinstance(result, CutenessLeaderboardHistoryResult), f"malformed {result=}"
-        assert isinstance(entryDelimiter, str), f"malformed {entryDelimiter=}"
-        assert isinstance(leaderboardDelimiter, str), f"malformed {leaderboardDelimiter=}"
+        if not isinstance(result, CutenessLeaderboardHistoryResult):
+            raise ValueError(f'result argument is malformed: \"{result}\"')
+        elif not isinstance(entryDelimiter, str):
+            raise ValueError(f'entryDelimiter argument is malformed: \"{entryDelimiter}\"')
+        elif not isinstance(leaderboardDelimiter, str):
+            raise ValueError(f'leaderboardDelimiter argument is malformed: \"{leaderboardDelimiter}\"')
 
         leaderboards = result.getLeaderboards()
 
@@ -113,7 +123,8 @@ class CutenessUtils(CutenessUtilsInterface):
         return f'Cuteness Leaderboard History — {leaderboardDelimiter.join(leaderboardStrings)} ✨'
 
     def __getLeaderboardPlacementString(self, entry: CutenessLeaderboardEntry) -> str:
-        assert isinstance(entry, CutenessLeaderboardEntry), f"malformed {entry=}"
+        if not isinstance(entry, CutenessLeaderboardEntry):
+            raise ValueError(f'result argument is malformed: \"{entry}\"')
 
         rankStr = ''
 

--- a/src/CynanBot/cynanBot.py
+++ b/src/CynanBot/cynanBot.py
@@ -317,132 +317,69 @@ class CynanBot(commands.Bot, ChannelJoinListener, ModifyUserEventListener, Recur
             heartbeat = 15
         )
 
-        if not isinstance(eventLoop, AbstractEventLoop):
-            raise TypeError(f'eventLoop argument is malformed: \"{eventLoop}\"')
-        elif additionalTriviaAnswersRepository is not None and not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
-            raise TypeError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
-        elif not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise TypeError(f'administratorProviderInterface argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(authRepository, AuthRepository):
-            raise TypeError(f'authRepository argument is malformed: \"{authRepository}\"')
-        elif not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif bannedTriviaGameControllersRepository is not None and not isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface):
-            raise TypeError(f'bannedTriviaGameControllersRepository argument is malformed: \"{bannedTriviaGameControllersRepository}\"')
-        elif bannedWordsRepository is not None and not isinstance(bannedWordsRepository, BannedWordsRepositoryInterface):
-            raise TypeError(f'bannedWordsRepository argument is malformed: \"{bannedWordsRepository}\"')
-        elif not isinstance(channelJoinHelper, ChannelJoinHelper):
-            raise TypeError(f'channelJoinHelper argument is malformed: \"{channelJoinHelper}\"')
-        elif chatActionsManager is not None and not isinstance(chatActionsManager, ChatActionsManagerInterface):
-            raise TypeError(f'chatActionsManager argument is malformed: \"{chatActionsManager}\"')
-        elif not isinstance(chatLogger, ChatLoggerInterface):
-            raise TypeError(f'chatLogger argument is malformed: \"{chatLogger}\"')
-        elif cheerActionHelper is not None and not isinstance(cheerActionHelper, CheerActionHelperInterface):
-            raise TypeError(f'cheerActionsHelper argument is malformed: \"{cheerActionHelper}\"')
-        elif cheerActionIdGenerator is not None and not isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface):
-            raise TypeError(f'cheerActionIdGenerator argument is malformed: \"{cheerActionIdGenerator}\"')
-        elif cheerActionRemodHelper is not None and not isinstance(cheerActionRemodHelper, CheerActionRemodHelperInterface):
-            raise TypeError(f'cheerActionRemodHelper argument is malformed: \"{cheerActionRemodHelper}\"')
-        elif cheerActionsRepository is not None and not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
-            raise TypeError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
-        elif cutenessRepository is not None and not isinstance(cutenessRepository, CutenessRepositoryInterface):
-            raise TypeError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
-        elif cutenessUtils is not None and not isinstance(cutenessUtils, CutenessUtilsInterface):
-            raise TypeError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
-        elif not isinstance(dependencyHolder, DependencyHolder):
-            raise TypeError(f'dependencyHolder argument is malformed: \"{dependencyHolder}\"')
-        elif funtoonRepository is not None and not isinstance(funtoonRepository, FuntoonRepositoryInterface):
-            raise TypeError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif isLiveOnTwitchRepository is not None and not isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface):
-            raise TypeError(f'isLiveOnTwitchRepository argument is malformed: \"{isLiveOnTwitchRepository}\"')
-        elif jishoHelper is not None and not isinstance(jishoHelper, JishoHelperInterface):
-            raise TypeError(f'jishoHelper argument is malformed: \"{jishoHelper}\"')
-        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
-            raise TypeError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
-        elif locationsRepository is not None and not isinstance(locationsRepository, LocationsRepositoryInterface):
-            raise TypeError(f'locationsRepository argument is malformed: \"{locationsRepository}\"')
-        elif not isinstance(modifyUserDataHelper, ModifyUserDataHelper):
-            raise TypeError(f'modifyUserDataHelper argument is malformed: \"{modifyUserDataHelper}\"')
-        elif mostRecentChatsRepository is not None and not isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface):
-            raise TypeError(f'mostRecentChatsRepository argument is malformed: \"{mostRecentChatsRepository}\"')
-        elif openTriviaDatabaseTriviaQuestionRepository is not None and not isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository):
-            raise TypeError(f'openTriviaDatabaseTriviaQuestionRepository argument is malformed: \"{openTriviaDatabaseTriviaQuestionRepository}\"')
-        elif pokepediaRepository is not None and not isinstance(pokepediaRepository, PokepediaRepository):
-            raise TypeError(f'pokepediaRepository argument is malformed: \"{pokepediaRepository}\"')
-        elif recurringActionsMachine is not None and not isinstance(recurringActionsMachine, RecurringActionsMachineInterface):
-            raise TypeError(f'recurringActionsMachine argument is malformed: \"{recurringActionsMachine}\"')
-        elif recurringActionsRepository is not None and not isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface):
-            raise TypeError(f'recurringActionsRepository argument is malformed: \"{recurringActionsRepository}\"')
-        elif not isinstance(sentMessageLogger, SentMessageLoggerInterface):
-            raise TypeError(f'sentMessageLogger argument is malformed: \"{sentMessageLogger}\"')
-        elif shinyTriviaOccurencesRepository is not None and not isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface):
-            raise TypeError(f'shinyTriviaOccurencesRepository argument is malformed: \"{shinyTriviaOccurencesRepository}\"')
-        elif soundPlayerSettingsRepository is not None and not isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface):
-            raise TypeError(f'soundPlayerSettingsRepository argument is malformed: \"{soundPlayerSettingsRepository}\"')
-        elif starWarsQuotesRepository is not None and not isinstance(starWarsQuotesRepository, StarWarsQuotesRepositoryInterface):
-            raise TypeError(f'starWarsQuotesRepository argument is malformed: \"{starWarsQuotesRepository}\"')
-        elif streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
-            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif toxicTriviaOccurencesRepository is not None and not isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface):
-            raise TypeError(f'toxicTriviaOccurencesRepository argument is malformed: \"{toxicTriviaOccurencesRepository}\"')
-        elif translationHelper is not None and not isinstance(translationHelper, TranslationHelper):
-            raise TypeError(f'translationHelper argument is malformed: \"{translationHelper}\"')
-        elif triviaBanHelper is not None and not isinstance(triviaBanHelper, TriviaBanHelperInterface):
-            raise TypeError(f'triviaBanHelper argument is malformed: \"{triviaBanHelper}\"')
-        elif triviaEmoteGenerator is not None and not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
-            raise TypeError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
-        elif triviaGameBuilder is not None and not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
-            raise TypeError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
-        elif triviaGameControllersRepository is not None and not isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface):
-            raise TypeError(f'triviaGameControllersRepository argument is malformed: \"{triviaGameControllersRepository}\"')
-        elif triviaGameGlobalControllersRepository is not None and not isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface):
-            raise TypeError(f'triviaGameGlobalControllersRepository argument is malformed: \"{triviaGameGlobalControllersRepository}\"')
-        elif triviaGameMachine is not None and not isinstance(triviaGameMachine, TriviaGameMachineInterface):
-            raise TypeError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
-        elif triviaHistoryRepository is not None and not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
-            raise TypeError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
-        elif triviaIdGenerator is not None and not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise TypeError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif triviaRepository is not None and not isinstance(triviaRepository, TriviaRepositoryInterface):
-            raise TypeError(f'triviaRepository argument is malformed: \"{triviaRepository}\"')
-        elif triviaScoreRepository is not None and not isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface):
-            raise TypeError(f'triviaScoreRepository argument is malformed: \"{triviaScoreRepository}\"')
-        elif triviaSettingsRepository is not None and not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise TypeError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
-        elif triviaUtils is not None and not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise TypeError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif ttsSettingsRepository is not None and not isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface):
-            raise TypeError(f'ttsSettingsRepository argument is malformed: \"{ttsSettingsRepository}\"')
-        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
-            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
-        elif not isinstance(twitchConfiguration, TwitchConfiguration):
-            raise TypeError(f'twitchConfiguration argument is malformed: \"{twitchConfiguration}\"')
-        elif twitchFollowerRepository is not None and not isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface):
-            raise TypeError(f'twitchFollowerRepository argument is malformed: \"{twitchFollowerRepository}\"')
-        elif twitchPredictionWebsocketUtils is not None and not isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface):
-            raise TypeError(f'twitchPredictionWebsocketUtils argument is malformed: \"{twitchPredictionWebsocketUtils}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(twitchTokensUtils, TwitchTokensUtilsInterface):
-            raise TypeError(f'twitchTokensUtils argument is malformed: \"{twitchTokensUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif twitchWebsocketClient is not None and not isinstance(twitchWebsocketClient, TwitchWebsocketClientInterface):
-            raise TypeError(f'twitchWebsocketClient argument is malformed: \"{twitchWebsocketClient}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif weatherRepository is not None and not isinstance(weatherRepository, WeatherRepositoryInterface):
-            raise TypeError(f'weatherRepository argument is malformed: \"{weatherRepository}\"')
-        elif websocketConnectionServer is not None and not isinstance(websocketConnectionServer, WebsocketConnectionServerInterface):
-            raise TypeError(f'websocketConnectionServer argument is malformed: \"{websocketConnectionServer}\"')
-        elif wordOfTheDayRepository is not None and not isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface):
-            raise TypeError(f'wordOfTheDayRepository argument is malformed: \"{wordOfTheDayRepository}\"')
+        assert isinstance(eventLoop, AbstractEventLoop), f"malformed {eventLoop=}"
+        assert additionalTriviaAnswersRepository is None or isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(authRepository, AuthRepository), f"malformed {authRepository=}"
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert bannedTriviaGameControllersRepository is None or isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface), f"malformed {bannedTriviaGameControllersRepository=}"
+        assert bannedWordsRepository is None or isinstance(bannedWordsRepository, BannedWordsRepositoryInterface), f"malformed {bannedWordsRepository=}"
+        assert isinstance(channelJoinHelper, ChannelJoinHelper), f"malformed {channelJoinHelper=}"
+        assert chatActionsManager is None or isinstance(chatActionsManager, ChatActionsManagerInterface), f"malformed {chatActionsManager=}"
+        assert isinstance(chatLogger, ChatLoggerInterface), f"malformed {chatLogger=}"
+        assert cheerActionHelper is None or isinstance(cheerActionHelper, CheerActionHelperInterface), f"malformed {cheerActionHelper=}"
+        assert cheerActionIdGenerator is None or isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface), f"malformed {cheerActionIdGenerator=}"
+        assert cheerActionRemodHelper is None or isinstance(cheerActionRemodHelper, CheerActionRemodHelperInterface), f"malformed {cheerActionRemodHelper=}"
+        assert cheerActionsRepository is None or isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
+        assert cutenessRepository is None or isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
+        assert cutenessUtils is None or isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
+        assert isinstance(dependencyHolder, DependencyHolder), f"malformed {dependencyHolder=}"
+        assert funtoonRepository is None or isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isLiveOnTwitchRepository is None or isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface), f"malformed {isLiveOnTwitchRepository=}"
+        assert jishoHelper is None or isinstance(jishoHelper, JishoHelperInterface), f"malformed {jishoHelper=}"
+        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
+        assert locationsRepository is None or isinstance(locationsRepository, LocationsRepositoryInterface), f"malformed {locationsRepository=}"
+        assert isinstance(modifyUserDataHelper, ModifyUserDataHelper), f"malformed {modifyUserDataHelper=}"
+        assert mostRecentChatsRepository is None or isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface), f"malformed {mostRecentChatsRepository=}"
+        assert openTriviaDatabaseTriviaQuestionRepository is None or isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository), f"malformed {openTriviaDatabaseTriviaQuestionRepository=}"
+        assert pokepediaRepository is None or isinstance(pokepediaRepository, PokepediaRepository), f"malformed {pokepediaRepository=}"
+        assert recurringActionsMachine is None or isinstance(recurringActionsMachine, RecurringActionsMachineInterface), f"malformed {recurringActionsMachine=}"
+        assert recurringActionsRepository is None or isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface), f"malformed {recurringActionsRepository=}"
+        assert isinstance(sentMessageLogger, SentMessageLoggerInterface), f"malformed {sentMessageLogger=}"
+        assert shinyTriviaOccurencesRepository is None or isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface), f"malformed {shinyTriviaOccurencesRepository=}"
+        assert soundPlayerSettingsRepository is None or isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface), f"malformed {soundPlayerSettingsRepository=}"
+        assert starWarsQuotesRepository is None or isinstance(starWarsQuotesRepository, StarWarsQuotesRepositoryInterface), f"malformed {starWarsQuotesRepository=}"
+        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert toxicTriviaOccurencesRepository is None or isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface), f"malformed {toxicTriviaOccurencesRepository=}"
+        assert translationHelper is None or isinstance(translationHelper, TranslationHelper), f"malformed {translationHelper=}"
+        assert triviaBanHelper is None or isinstance(triviaBanHelper, TriviaBanHelperInterface), f"malformed {triviaBanHelper=}"
+        assert triviaEmoteGenerator is None or isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
+        assert triviaGameBuilder is None or isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
+        assert triviaGameControllersRepository is None or isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface), f"malformed {triviaGameControllersRepository=}"
+        assert triviaGameGlobalControllersRepository is None or isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface), f"malformed {triviaGameGlobalControllersRepository=}"
+        assert triviaGameMachine is None or isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
+        assert triviaHistoryRepository is None or isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
+        assert triviaIdGenerator is None or isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert triviaRepository is None or isinstance(triviaRepository, TriviaRepositoryInterface), f"malformed {triviaRepository=}"
+        assert triviaScoreRepository is None or isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface), f"malformed {triviaScoreRepository=}"
+        assert triviaSettingsRepository is None or isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        assert triviaUtils is None or isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert ttsSettingsRepository is None or isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface), f"malformed {ttsSettingsRepository=}"
+        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
+        assert isinstance(twitchConfiguration, TwitchConfiguration), f"malformed {twitchConfiguration=}"
+        assert twitchFollowerRepository is None or isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface), f"malformed {twitchFollowerRepository=}"
+        assert twitchPredictionWebsocketUtils is None or isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface), f"malformed {twitchPredictionWebsocketUtils=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(twitchTokensUtils, TwitchTokensUtilsInterface), f"malformed {twitchTokensUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert twitchWebsocketClient is None or isinstance(twitchWebsocketClient, TwitchWebsocketClientInterface), f"malformed {twitchWebsocketClient=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert weatherRepository is None or isinstance(weatherRepository, WeatherRepositoryInterface), f"malformed {weatherRepository=}"
+        assert websocketConnectionServer is None or isinstance(websocketConnectionServer, WebsocketConnectionServerInterface), f"malformed {websocketConnectionServer=}"
+        assert wordOfTheDayRepository is None or isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface), f"malformed {wordOfTheDayRepository=}"
 
         self.__authRepository: AuthRepository = authRepository
         self.__channelJoinHelper: ChannelJoinHelper = channelJoinHelper
@@ -904,22 +841,19 @@ class CynanBot(commands.Bot, ChannelJoinListener, ModifyUserEventListener, Recur
             await self.__handleWordOfTheDayRecurringActionEvent(event)
 
     async def __handleSuperTriviaRecurringActionEvent(self, event: SuperTriviaRecurringEvent):
-        if not isinstance(event, SuperTriviaRecurringEvent):
-            raise ValueError(f'event argument is malformed: \"{event}\"')
+        assert isinstance(event, SuperTriviaRecurringEvent), f"malformed {event=}"
 
         twitchChannel = await self.__getChannel(event.getTwitchChannel())
         await self.__twitchUtils.safeSend(twitchChannel, 'Super trivia starting soon!')
 
     async def __handleWeatherRecurringActionEvent(self, event: WeatherRecurringEvent):
-        if not isinstance(event, WeatherRecurringEvent):
-            raise ValueError(f'event argument is malformed: \"{event}\"')
+        assert isinstance(event, WeatherRecurringEvent), f"malformed {event=}"
 
         twitchChannel = await self.__getChannel(event.getTwitchChannel())
         await self.__twitchUtils.safeSend(twitchChannel, event.getWeatherReport().toStr())
 
     async def __handleWordOfTheDayRecurringActionEvent(self, event: WordOfTheDayRecurringEvent):
-        if not isinstance(event, WordOfTheDayRecurringEvent):
-            raise ValueError(f'event argument is malformed: \"{event}\"')
+        assert isinstance(event, WordOfTheDayRecurringEvent), f"malformed {event=}"
 
         twitchChannel = await self.__getChannel(event.getTwitchChannel())
         await self.__twitchUtils.safeSend(twitchChannel, event.getWordOfTheDayResponse().toStr())

--- a/src/CynanBot/cynanBot.py
+++ b/src/CynanBot/cynanBot.py
@@ -317,69 +317,132 @@ class CynanBot(commands.Bot, ChannelJoinListener, ModifyUserEventListener, Recur
             heartbeat = 15
         )
 
-        assert isinstance(eventLoop, AbstractEventLoop), f"malformed {eventLoop=}"
-        assert additionalTriviaAnswersRepository is None or isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(authRepository, AuthRepository), f"malformed {authRepository=}"
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert bannedTriviaGameControllersRepository is None or isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface), f"malformed {bannedTriviaGameControllersRepository=}"
-        assert bannedWordsRepository is None or isinstance(bannedWordsRepository, BannedWordsRepositoryInterface), f"malformed {bannedWordsRepository=}"
-        assert isinstance(channelJoinHelper, ChannelJoinHelper), f"malformed {channelJoinHelper=}"
-        assert chatActionsManager is None or isinstance(chatActionsManager, ChatActionsManagerInterface), f"malformed {chatActionsManager=}"
-        assert isinstance(chatLogger, ChatLoggerInterface), f"malformed {chatLogger=}"
-        assert cheerActionHelper is None or isinstance(cheerActionHelper, CheerActionHelperInterface), f"malformed {cheerActionHelper=}"
-        assert cheerActionIdGenerator is None or isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface), f"malformed {cheerActionIdGenerator=}"
-        assert cheerActionRemodHelper is None or isinstance(cheerActionRemodHelper, CheerActionRemodHelperInterface), f"malformed {cheerActionRemodHelper=}"
-        assert cheerActionsRepository is None or isinstance(cheerActionsRepository, CheerActionsRepositoryInterface), f"malformed {cheerActionsRepository=}"
-        assert cutenessRepository is None or isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
-        assert cutenessUtils is None or isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
-        assert isinstance(dependencyHolder, DependencyHolder), f"malformed {dependencyHolder=}"
-        assert funtoonRepository is None or isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isLiveOnTwitchRepository is None or isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface), f"malformed {isLiveOnTwitchRepository=}"
-        assert jishoHelper is None or isinstance(jishoHelper, JishoHelperInterface), f"malformed {jishoHelper=}"
-        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
-        assert locationsRepository is None or isinstance(locationsRepository, LocationsRepositoryInterface), f"malformed {locationsRepository=}"
-        assert isinstance(modifyUserDataHelper, ModifyUserDataHelper), f"malformed {modifyUserDataHelper=}"
-        assert mostRecentChatsRepository is None or isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface), f"malformed {mostRecentChatsRepository=}"
-        assert openTriviaDatabaseTriviaQuestionRepository is None or isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository), f"malformed {openTriviaDatabaseTriviaQuestionRepository=}"
-        assert pokepediaRepository is None or isinstance(pokepediaRepository, PokepediaRepository), f"malformed {pokepediaRepository=}"
-        assert recurringActionsMachine is None or isinstance(recurringActionsMachine, RecurringActionsMachineInterface), f"malformed {recurringActionsMachine=}"
-        assert recurringActionsRepository is None or isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface), f"malformed {recurringActionsRepository=}"
-        assert isinstance(sentMessageLogger, SentMessageLoggerInterface), f"malformed {sentMessageLogger=}"
-        assert shinyTriviaOccurencesRepository is None or isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface), f"malformed {shinyTriviaOccurencesRepository=}"
-        assert soundPlayerSettingsRepository is None or isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface), f"malformed {soundPlayerSettingsRepository=}"
-        assert starWarsQuotesRepository is None or isinstance(starWarsQuotesRepository, StarWarsQuotesRepositoryInterface), f"malformed {starWarsQuotesRepository=}"
-        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert toxicTriviaOccurencesRepository is None or isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface), f"malformed {toxicTriviaOccurencesRepository=}"
-        assert translationHelper is None or isinstance(translationHelper, TranslationHelper), f"malformed {translationHelper=}"
-        assert triviaBanHelper is None or isinstance(triviaBanHelper, TriviaBanHelperInterface), f"malformed {triviaBanHelper=}"
-        assert triviaEmoteGenerator is None or isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
-        assert triviaGameBuilder is None or isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
-        assert triviaGameControllersRepository is None or isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface), f"malformed {triviaGameControllersRepository=}"
-        assert triviaGameGlobalControllersRepository is None or isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface), f"malformed {triviaGameGlobalControllersRepository=}"
-        assert triviaGameMachine is None or isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
-        assert triviaHistoryRepository is None or isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
-        assert triviaIdGenerator is None or isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert triviaRepository is None or isinstance(triviaRepository, TriviaRepositoryInterface), f"malformed {triviaRepository=}"
-        assert triviaScoreRepository is None or isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface), f"malformed {triviaScoreRepository=}"
-        assert triviaSettingsRepository is None or isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
-        assert triviaUtils is None or isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert ttsSettingsRepository is None or isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface), f"malformed {ttsSettingsRepository=}"
-        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
-        assert isinstance(twitchConfiguration, TwitchConfiguration), f"malformed {twitchConfiguration=}"
-        assert twitchFollowerRepository is None or isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface), f"malformed {twitchFollowerRepository=}"
-        assert twitchPredictionWebsocketUtils is None or isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface), f"malformed {twitchPredictionWebsocketUtils=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(twitchTokensUtils, TwitchTokensUtilsInterface), f"malformed {twitchTokensUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert twitchWebsocketClient is None or isinstance(twitchWebsocketClient, TwitchWebsocketClientInterface), f"malformed {twitchWebsocketClient=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert weatherRepository is None or isinstance(weatherRepository, WeatherRepositoryInterface), f"malformed {weatherRepository=}"
-        assert websocketConnectionServer is None or isinstance(websocketConnectionServer, WebsocketConnectionServerInterface), f"malformed {websocketConnectionServer=}"
-        assert wordOfTheDayRepository is None or isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface), f"malformed {wordOfTheDayRepository=}"
+        if not isinstance(eventLoop, AbstractEventLoop):
+            raise TypeError(f'eventLoop argument is malformed: \"{eventLoop}\"')
+        elif additionalTriviaAnswersRepository is not None and not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
+            raise TypeError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
+        elif not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise TypeError(f'administratorProviderInterface argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(authRepository, AuthRepository):
+            raise TypeError(f'authRepository argument is malformed: \"{authRepository}\"')
+        elif not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif bannedTriviaGameControllersRepository is not None and not isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface):
+            raise TypeError(f'bannedTriviaGameControllersRepository argument is malformed: \"{bannedTriviaGameControllersRepository}\"')
+        elif bannedWordsRepository is not None and not isinstance(bannedWordsRepository, BannedWordsRepositoryInterface):
+            raise TypeError(f'bannedWordsRepository argument is malformed: \"{bannedWordsRepository}\"')
+        elif not isinstance(channelJoinHelper, ChannelJoinHelper):
+            raise TypeError(f'channelJoinHelper argument is malformed: \"{channelJoinHelper}\"')
+        elif chatActionsManager is not None and not isinstance(chatActionsManager, ChatActionsManagerInterface):
+            raise TypeError(f'chatActionsManager argument is malformed: \"{chatActionsManager}\"')
+        elif not isinstance(chatLogger, ChatLoggerInterface):
+            raise TypeError(f'chatLogger argument is malformed: \"{chatLogger}\"')
+        elif cheerActionHelper is not None and not isinstance(cheerActionHelper, CheerActionHelperInterface):
+            raise TypeError(f'cheerActionsHelper argument is malformed: \"{cheerActionHelper}\"')
+        elif cheerActionIdGenerator is not None and not isinstance(cheerActionIdGenerator, CheerActionIdGeneratorInterface):
+            raise TypeError(f'cheerActionIdGenerator argument is malformed: \"{cheerActionIdGenerator}\"')
+        elif cheerActionRemodHelper is not None and not isinstance(cheerActionRemodHelper, CheerActionRemodHelperInterface):
+            raise TypeError(f'cheerActionRemodHelper argument is malformed: \"{cheerActionRemodHelper}\"')
+        elif cheerActionsRepository is not None and not isinstance(cheerActionsRepository, CheerActionsRepositoryInterface):
+            raise TypeError(f'cheerActionsRepository argument is malformed: \"{cheerActionsRepository}\"')
+        elif cutenessRepository is not None and not isinstance(cutenessRepository, CutenessRepositoryInterface):
+            raise TypeError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
+        elif cutenessUtils is not None and not isinstance(cutenessUtils, CutenessUtilsInterface):
+            raise TypeError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
+        elif not isinstance(dependencyHolder, DependencyHolder):
+            raise TypeError(f'dependencyHolder argument is malformed: \"{dependencyHolder}\"')
+        elif funtoonRepository is not None and not isinstance(funtoonRepository, FuntoonRepositoryInterface):
+            raise TypeError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif isLiveOnTwitchRepository is not None and not isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface):
+            raise TypeError(f'isLiveOnTwitchRepository argument is malformed: \"{isLiveOnTwitchRepository}\"')
+        elif jishoHelper is not None and not isinstance(jishoHelper, JishoHelperInterface):
+            raise TypeError(f'jishoHelper argument is malformed: \"{jishoHelper}\"')
+        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
+            raise TypeError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
+        elif locationsRepository is not None and not isinstance(locationsRepository, LocationsRepositoryInterface):
+            raise TypeError(f'locationsRepository argument is malformed: \"{locationsRepository}\"')
+        elif not isinstance(modifyUserDataHelper, ModifyUserDataHelper):
+            raise TypeError(f'modifyUserDataHelper argument is malformed: \"{modifyUserDataHelper}\"')
+        elif mostRecentChatsRepository is not None and not isinstance(mostRecentChatsRepository, MostRecentChatsRepositoryInterface):
+            raise TypeError(f'mostRecentChatsRepository argument is malformed: \"{mostRecentChatsRepository}\"')
+        elif openTriviaDatabaseTriviaQuestionRepository is not None and not isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository):
+            raise TypeError(f'openTriviaDatabaseTriviaQuestionRepository argument is malformed: \"{openTriviaDatabaseTriviaQuestionRepository}\"')
+        elif pokepediaRepository is not None and not isinstance(pokepediaRepository, PokepediaRepository):
+            raise TypeError(f'pokepediaRepository argument is malformed: \"{pokepediaRepository}\"')
+        elif recurringActionsMachine is not None and not isinstance(recurringActionsMachine, RecurringActionsMachineInterface):
+            raise TypeError(f'recurringActionsMachine argument is malformed: \"{recurringActionsMachine}\"')
+        elif recurringActionsRepository is not None and not isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface):
+            raise TypeError(f'recurringActionsRepository argument is malformed: \"{recurringActionsRepository}\"')
+        elif not isinstance(sentMessageLogger, SentMessageLoggerInterface):
+            raise TypeError(f'sentMessageLogger argument is malformed: \"{sentMessageLogger}\"')
+        elif shinyTriviaOccurencesRepository is not None and not isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface):
+            raise TypeError(f'shinyTriviaOccurencesRepository argument is malformed: \"{shinyTriviaOccurencesRepository}\"')
+        elif soundPlayerSettingsRepository is not None and not isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface):
+            raise TypeError(f'soundPlayerSettingsRepository argument is malformed: \"{soundPlayerSettingsRepository}\"')
+        elif starWarsQuotesRepository is not None and not isinstance(starWarsQuotesRepository, StarWarsQuotesRepositoryInterface):
+            raise TypeError(f'starWarsQuotesRepository argument is malformed: \"{starWarsQuotesRepository}\"')
+        elif streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
+            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif toxicTriviaOccurencesRepository is not None and not isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface):
+            raise TypeError(f'toxicTriviaOccurencesRepository argument is malformed: \"{toxicTriviaOccurencesRepository}\"')
+        elif translationHelper is not None and not isinstance(translationHelper, TranslationHelper):
+            raise TypeError(f'translationHelper argument is malformed: \"{translationHelper}\"')
+        elif triviaBanHelper is not None and not isinstance(triviaBanHelper, TriviaBanHelperInterface):
+            raise TypeError(f'triviaBanHelper argument is malformed: \"{triviaBanHelper}\"')
+        elif triviaEmoteGenerator is not None and not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
+            raise TypeError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
+        elif triviaGameBuilder is not None and not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
+            raise TypeError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
+        elif triviaGameControllersRepository is not None and not isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface):
+            raise TypeError(f'triviaGameControllersRepository argument is malformed: \"{triviaGameControllersRepository}\"')
+        elif triviaGameGlobalControllersRepository is not None and not isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface):
+            raise TypeError(f'triviaGameGlobalControllersRepository argument is malformed: \"{triviaGameGlobalControllersRepository}\"')
+        elif triviaGameMachine is not None and not isinstance(triviaGameMachine, TriviaGameMachineInterface):
+            raise TypeError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
+        elif triviaHistoryRepository is not None and not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
+            raise TypeError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
+        elif triviaIdGenerator is not None and not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise TypeError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif triviaRepository is not None and not isinstance(triviaRepository, TriviaRepositoryInterface):
+            raise TypeError(f'triviaRepository argument is malformed: \"{triviaRepository}\"')
+        elif triviaScoreRepository is not None and not isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface):
+            raise TypeError(f'triviaScoreRepository argument is malformed: \"{triviaScoreRepository}\"')
+        elif triviaSettingsRepository is not None and not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise TypeError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        elif triviaUtils is not None and not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise TypeError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif ttsSettingsRepository is not None and not isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface):
+            raise TypeError(f'ttsSettingsRepository argument is malformed: \"{ttsSettingsRepository}\"')
+        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
+            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
+        elif not isinstance(twitchConfiguration, TwitchConfiguration):
+            raise TypeError(f'twitchConfiguration argument is malformed: \"{twitchConfiguration}\"')
+        elif twitchFollowerRepository is not None and not isinstance(twitchFollowerRepository, TwitchFollowerRepositoryInterface):
+            raise TypeError(f'twitchFollowerRepository argument is malformed: \"{twitchFollowerRepository}\"')
+        elif twitchPredictionWebsocketUtils is not None and not isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface):
+            raise TypeError(f'twitchPredictionWebsocketUtils argument is malformed: \"{twitchPredictionWebsocketUtils}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(twitchTokensUtils, TwitchTokensUtilsInterface):
+            raise TypeError(f'twitchTokensUtils argument is malformed: \"{twitchTokensUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif twitchWebsocketClient is not None and not isinstance(twitchWebsocketClient, TwitchWebsocketClientInterface):
+            raise TypeError(f'twitchWebsocketClient argument is malformed: \"{twitchWebsocketClient}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif weatherRepository is not None and not isinstance(weatherRepository, WeatherRepositoryInterface):
+            raise TypeError(f'weatherRepository argument is malformed: \"{weatherRepository}\"')
+        elif websocketConnectionServer is not None and not isinstance(websocketConnectionServer, WebsocketConnectionServerInterface):
+            raise TypeError(f'websocketConnectionServer argument is malformed: \"{websocketConnectionServer}\"')
+        elif wordOfTheDayRepository is not None and not isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface):
+            raise TypeError(f'wordOfTheDayRepository argument is malformed: \"{wordOfTheDayRepository}\"')
 
         self.__authRepository: AuthRepository = authRepository
         self.__channelJoinHelper: ChannelJoinHelper = channelJoinHelper
@@ -841,19 +904,22 @@ class CynanBot(commands.Bot, ChannelJoinListener, ModifyUserEventListener, Recur
             await self.__handleWordOfTheDayRecurringActionEvent(event)
 
     async def __handleSuperTriviaRecurringActionEvent(self, event: SuperTriviaRecurringEvent):
-        assert isinstance(event, SuperTriviaRecurringEvent), f"malformed {event=}"
+        if not isinstance(event, SuperTriviaRecurringEvent):
+            raise ValueError(f'event argument is malformed: \"{event}\"')
 
         twitchChannel = await self.__getChannel(event.getTwitchChannel())
         await self.__twitchUtils.safeSend(twitchChannel, 'Super trivia starting soon!')
 
     async def __handleWeatherRecurringActionEvent(self, event: WeatherRecurringEvent):
-        assert isinstance(event, WeatherRecurringEvent), f"malformed {event=}"
+        if not isinstance(event, WeatherRecurringEvent):
+            raise ValueError(f'event argument is malformed: \"{event}\"')
 
         twitchChannel = await self.__getChannel(event.getTwitchChannel())
         await self.__twitchUtils.safeSend(twitchChannel, event.getWeatherReport().toStr())
 
     async def __handleWordOfTheDayRecurringActionEvent(self, event: WordOfTheDayRecurringEvent):
-        assert isinstance(event, WordOfTheDayRecurringEvent), f"malformed {event=}"
+        if not isinstance(event, WordOfTheDayRecurringEvent):
+            raise ValueError(f'event argument is malformed: \"{event}\"')
 
         twitchChannel = await self.__getChannel(event.getTwitchChannel())
         await self.__twitchUtils.safeSend(twitchChannel, event.getWordOfTheDayResponse().toStr())

--- a/src/CynanBot/dependencyHolder.py
+++ b/src/CynanBot/dependencyHolder.py
@@ -41,34 +41,20 @@ class DependencyHolder():
         twitchUtils: TwitchUtilsInterface,
         websocketConnectionServer: Optional[WebsocketConnectionServerInterface]
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(chatLogger, ChatLoggerInterface):
-            raise TypeError(f'chatLogger argument is malformed: \"{chatLogger}\"')
-        elif cutenessUtils is not None and not isinstance(cutenessUtils, CutenessUtilsInterface):
-            raise TypeError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(sentMessageLogger, SentMessageLoggerInterface):
-            raise TypeError(f'sentMessageLogger argument is malformed: \"{sentMessageLogger}\"')
-        elif soundPlayerManager is not None and not isinstance(soundPlayerManager, SoundPlayerManagerInterface):
-            raise TypeError(f'soundPlayerHelper argument is malformed: \"{soundPlayerManager}\"')
-        elif streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
-            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif triviaUtils is not None and not isinstance(triviaUtils, TriviaUtilsInterface):
-            raise TypeError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
-        elif ttsManager is not None and not isinstance(ttsManager, TtsManagerInterface):
-            raise TypeError(f'ttsManager argument is malformed: \"{ttsManager}\"')
-        elif twitchPredictionWebsocketUtils is not None and not isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface):
-            raise TypeError(f'twitchPredictionWebsocketUtils argument is malformed: \"{twitchPredictionWebsocketUtils}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
-        elif websocketConnectionServer is not None and not isinstance(websocketConnectionServer, WebsocketConnectionServerInterface):
-            raise TypeError(f'websocketConnectionServer argument is malformed: \"{websocketConnectionServer}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(chatLogger, ChatLoggerInterface), f"malformed {chatLogger=}"
+        assert cutenessUtils is None or isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(sentMessageLogger, SentMessageLoggerInterface), f"malformed {sentMessageLogger=}"
+        assert soundPlayerManager is None or isinstance(soundPlayerManager, SoundPlayerManagerInterface), f"malformed {soundPlayerManager=}"
+        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert triviaUtils is None or isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
+        assert ttsManager is None or isinstance(ttsManager, TtsManagerInterface), f"malformed {ttsManager=}"
+        assert twitchPredictionWebsocketUtils is None or isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface), f"malformed {twitchPredictionWebsocketUtils=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        assert websocketConnectionServer is None or isinstance(websocketConnectionServer, WebsocketConnectionServerInterface), f"malformed {websocketConnectionServer=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper

--- a/src/CynanBot/dependencyHolder.py
+++ b/src/CynanBot/dependencyHolder.py
@@ -41,20 +41,34 @@ class DependencyHolder():
         twitchUtils: TwitchUtilsInterface,
         websocketConnectionServer: Optional[WebsocketConnectionServerInterface]
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(chatLogger, ChatLoggerInterface), f"malformed {chatLogger=}"
-        assert cutenessUtils is None or isinstance(cutenessUtils, CutenessUtilsInterface), f"malformed {cutenessUtils=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(sentMessageLogger, SentMessageLoggerInterface), f"malformed {sentMessageLogger=}"
-        assert soundPlayerManager is None or isinstance(soundPlayerManager, SoundPlayerManagerInterface), f"malformed {soundPlayerManager=}"
-        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert triviaUtils is None or isinstance(triviaUtils, TriviaUtilsInterface), f"malformed {triviaUtils=}"
-        assert ttsManager is None or isinstance(ttsManager, TtsManagerInterface), f"malformed {ttsManager=}"
-        assert twitchPredictionWebsocketUtils is None or isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface), f"malformed {twitchPredictionWebsocketUtils=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
-        assert websocketConnectionServer is None or isinstance(websocketConnectionServer, WebsocketConnectionServerInterface), f"malformed {websocketConnectionServer=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(chatLogger, ChatLoggerInterface):
+            raise TypeError(f'chatLogger argument is malformed: \"{chatLogger}\"')
+        elif cutenessUtils is not None and not isinstance(cutenessUtils, CutenessUtilsInterface):
+            raise TypeError(f'cutenessUtils argument is malformed: \"{cutenessUtils}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(sentMessageLogger, SentMessageLoggerInterface):
+            raise TypeError(f'sentMessageLogger argument is malformed: \"{sentMessageLogger}\"')
+        elif soundPlayerManager is not None and not isinstance(soundPlayerManager, SoundPlayerManagerInterface):
+            raise TypeError(f'soundPlayerHelper argument is malformed: \"{soundPlayerManager}\"')
+        elif streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
+            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif triviaUtils is not None and not isinstance(triviaUtils, TriviaUtilsInterface):
+            raise TypeError(f'triviaUtils argument is malformed: \"{triviaUtils}\"')
+        elif ttsManager is not None and not isinstance(ttsManager, TtsManagerInterface):
+            raise TypeError(f'ttsManager argument is malformed: \"{ttsManager}\"')
+        elif twitchPredictionWebsocketUtils is not None and not isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface):
+            raise TypeError(f'twitchPredictionWebsocketUtils argument is malformed: \"{twitchPredictionWebsocketUtils}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        elif websocketConnectionServer is not None and not isinstance(websocketConnectionServer, WebsocketConnectionServerInterface):
+            raise TypeError(f'websocketConnectionServer argument is malformed: \"{websocketConnectionServer}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper

--- a/src/CynanBot/dependencyHolderBuilder.py
+++ b/src/CynanBot/dependencyHolderBuilder.py
@@ -35,20 +35,13 @@ class DependencyHolderBuilder():
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(chatLogger, ChatLoggerInterface):
-            raise TypeError(f'chatLogger argument is malformed: \"{chatLogger}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(sentMessageLogger, SentMessageLoggerInterface):
-            raise TypeError(f'sentMessageLogger argument is malformed: \"{sentMessageLogger}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(chatLogger, ChatLoggerInterface), f"malformed {chatLogger=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(sentMessageLogger, SentMessageLoggerInterface), f"malformed {sentMessageLogger=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -85,50 +78,43 @@ class DependencyHolderBuilder():
         )
 
     def setCutenessUtils(self, instance: CutenessUtilsInterface) -> Self:
-        if not isinstance(instance, CutenessUtilsInterface):
-            raise TypeError(f'instance argument is malformed: \"{instance}\"')
+        assert isinstance(instance, CutenessUtilsInterface), f"malformed {instance=}"
 
         self.__cutenessUtils = instance
         return self
 
     def setSoundPlayerHelper(self, instance: SoundPlayerManagerInterface) -> Self:
-        if not isinstance(instance, SoundPlayerManagerInterface):
-            raise TypeError(f'instance argument is malformed: \"{instance}\"')
+        assert isinstance(instance, SoundPlayerManagerInterface), f"malformed {instance=}"
 
         self.__soundPlayerManager = instance
         return self
 
     def setStreamAlertsManager(self, instance: StreamAlertsManagerInterface) -> Self:
-        if not isinstance(instance, StreamAlertsManagerInterface):
-            raise TypeError(f'instance argument is malformed: \"{instance}\"')
+        assert isinstance(instance, StreamAlertsManagerInterface), f"malformed {instance=}"
 
         self.__streamAlertsManager = instance
         return self
 
     def setTriviaUtils(self, instance: TriviaUtilsInterface) -> Self:
-        if not isinstance(instance, TriviaUtilsInterface):
-            raise TypeError(f'instance argument is malformed: \"{instance}\"')
+        assert isinstance(instance, TriviaUtilsInterface), f"malformed {instance=}"
 
         self.__triviaUtils = instance
         return self
 
     def setTtsManager(self, instance: TtsManagerInterface) -> Self:
-        if not isinstance(instance, TtsManagerInterface):
-            raise TypeError(f'instance argument is malformed: \"{instance}\"')
+        assert isinstance(instance, TtsManagerInterface), f"malformed {instance=}"
 
         self.__ttsManager = instance
         return self
 
     def setTwitchPredictionWebsocketUtils(self, instance: TwitchPredictionWebsocketUtilsInterface) -> Self:
-        if not isinstance(instance, TwitchPredictionWebsocketUtilsInterface):
-            raise TypeError(f'instance argument is malformed: \"{instance}\"')
+        assert isinstance(instance, TwitchPredictionWebsocketUtilsInterface), f"malformed {instance=}"
 
         self.__twitchPredictionWebsocketUtils = instance
         return self
 
     def setWebsocketConnectionServer(self, instance: WebsocketConnectionServerInterface) -> Self:
-        if not isinstance(instance, WebsocketConnectionServerInterface):
-            raise TypeError(f'instance argument is malformed: \"{instance}\"')
+        assert isinstance(instance, WebsocketConnectionServerInterface), f"malformed {instance=}"
 
         self.__websocketConnectionServer = instance
         return self

--- a/src/CynanBot/dependencyHolderBuilder.py
+++ b/src/CynanBot/dependencyHolderBuilder.py
@@ -35,13 +35,20 @@ class DependencyHolderBuilder():
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(chatLogger, ChatLoggerInterface), f"malformed {chatLogger=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(sentMessageLogger, SentMessageLoggerInterface), f"malformed {sentMessageLogger=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(chatLogger, ChatLoggerInterface):
+            raise TypeError(f'chatLogger argument is malformed: \"{chatLogger}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(sentMessageLogger, SentMessageLoggerInterface):
+            raise TypeError(f'sentMessageLogger argument is malformed: \"{sentMessageLogger}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -78,43 +85,50 @@ class DependencyHolderBuilder():
         )
 
     def setCutenessUtils(self, instance: CutenessUtilsInterface) -> Self:
-        assert isinstance(instance, CutenessUtilsInterface), f"malformed {instance=}"
+        if not isinstance(instance, CutenessUtilsInterface):
+            raise TypeError(f'instance argument is malformed: \"{instance}\"')
 
         self.__cutenessUtils = instance
         return self
 
     def setSoundPlayerHelper(self, instance: SoundPlayerManagerInterface) -> Self:
-        assert isinstance(instance, SoundPlayerManagerInterface), f"malformed {instance=}"
+        if not isinstance(instance, SoundPlayerManagerInterface):
+            raise TypeError(f'instance argument is malformed: \"{instance}\"')
 
         self.__soundPlayerManager = instance
         return self
 
     def setStreamAlertsManager(self, instance: StreamAlertsManagerInterface) -> Self:
-        assert isinstance(instance, StreamAlertsManagerInterface), f"malformed {instance=}"
+        if not isinstance(instance, StreamAlertsManagerInterface):
+            raise TypeError(f'instance argument is malformed: \"{instance}\"')
 
         self.__streamAlertsManager = instance
         return self
 
     def setTriviaUtils(self, instance: TriviaUtilsInterface) -> Self:
-        assert isinstance(instance, TriviaUtilsInterface), f"malformed {instance=}"
+        if not isinstance(instance, TriviaUtilsInterface):
+            raise TypeError(f'instance argument is malformed: \"{instance}\"')
 
         self.__triviaUtils = instance
         return self
 
     def setTtsManager(self, instance: TtsManagerInterface) -> Self:
-        assert isinstance(instance, TtsManagerInterface), f"malformed {instance=}"
+        if not isinstance(instance, TtsManagerInterface):
+            raise TypeError(f'instance argument is malformed: \"{instance}\"')
 
         self.__ttsManager = instance
         return self
 
     def setTwitchPredictionWebsocketUtils(self, instance: TwitchPredictionWebsocketUtilsInterface) -> Self:
-        assert isinstance(instance, TwitchPredictionWebsocketUtilsInterface), f"malformed {instance=}"
+        if not isinstance(instance, TwitchPredictionWebsocketUtilsInterface):
+            raise TypeError(f'instance argument is malformed: \"{instance}\"')
 
         self.__twitchPredictionWebsocketUtils = instance
         return self
 
     def setWebsocketConnectionServer(self, instance: WebsocketConnectionServerInterface) -> Self:
-        assert isinstance(instance, WebsocketConnectionServerInterface), f"malformed {instance=}"
+        if not isinstance(instance, WebsocketConnectionServerInterface):
+            raise TypeError(f'instance argument is malformed: \"{instance}\"')
 
         self.__websocketConnectionServer = instance
         return self

--- a/src/CynanBot/emojiHelper/emojiHelper.py
+++ b/src/CynanBot/emojiHelper/emojiHelper.py
@@ -14,8 +14,7 @@ class EmojiHelper(EmojiHelperInterface):
         self,
         emojiRepository: EmojiRepositoryInterface
     ):
-        if not isinstance(emojiRepository, EmojiRepositoryInterface):
-            raise ValueError(f'emojiRepository argument is malformed: \"{emojiRepository}\"')
+        assert isinstance(emojiRepository, EmojiRepositoryInterface), f"malformed {emojiRepository=}"
 
         self.__emojiRepository: EmojiRepositoryInterface = emojiRepository
 

--- a/src/CynanBot/emojiHelper/emojiHelper.py
+++ b/src/CynanBot/emojiHelper/emojiHelper.py
@@ -14,7 +14,8 @@ class EmojiHelper(EmojiHelperInterface):
         self,
         emojiRepository: EmojiRepositoryInterface
     ):
-        assert isinstance(emojiRepository, EmojiRepositoryInterface), f"malformed {emojiRepository=}"
+        if not isinstance(emojiRepository, EmojiRepositoryInterface):
+            raise ValueError(f'emojiRepository argument is malformed: \"{emojiRepository}\"')
 
         self.__emojiRepository: EmojiRepositoryInterface = emojiRepository
 

--- a/src/CynanBot/emojiHelper/emojiRepository.py
+++ b/src/CynanBot/emojiHelper/emojiRepository.py
@@ -16,10 +16,8 @@ class EmojiRepository(EmojiRepositoryInterface):
         emojiJsonReader: JsonReaderInterface,
         timber: TimberInterface
     ):
-        if not isinstance(emojiJsonReader, JsonReaderInterface):
-            raise ValueError(f'emojiJsonReader argument is malformed: \"{emojiJsonReader}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(emojiJsonReader, JsonReaderInterface), f"malformed {emojiJsonReader=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__emojiJsonReader: JsonReaderInterface = emojiJsonReader
         self.__timber: TimberInterface = timber
@@ -30,9 +28,8 @@ class EmojiRepository(EmojiRepositoryInterface):
     async def fetchEmojiInfo(self, emoji: Optional[str]) -> Optional[EmojiInfo]:
         if emoji is None:
             return None
-        elif not isinstance(emoji, str):
-            raise ValueError(f'emoji argument is malformed: \"{emoji}\"')
-        elif not utils.isValidStr(emoji):
+        assert isinstance(emoji, str), f"malformed {emoji=}"
+        if not utils.isValidStr(emoji):
             return None
 
         await self.__readJson()

--- a/src/CynanBot/emojiHelper/emojiRepository.py
+++ b/src/CynanBot/emojiHelper/emojiRepository.py
@@ -16,8 +16,10 @@ class EmojiRepository(EmojiRepositoryInterface):
         emojiJsonReader: JsonReaderInterface,
         timber: TimberInterface
     ):
-        assert isinstance(emojiJsonReader, JsonReaderInterface), f"malformed {emojiJsonReader=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(emojiJsonReader, JsonReaderInterface):
+            raise ValueError(f'emojiJsonReader argument is malformed: \"{emojiJsonReader}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__emojiJsonReader: JsonReaderInterface = emojiJsonReader
         self.__timber: TimberInterface = timber
@@ -28,8 +30,9 @@ class EmojiRepository(EmojiRepositoryInterface):
     async def fetchEmojiInfo(self, emoji: Optional[str]) -> Optional[EmojiInfo]:
         if emoji is None:
             return None
-        assert isinstance(emoji, str), f"malformed {emoji=}"
-        if not utils.isValidStr(emoji):
+        elif not isinstance(emoji, str):
+            raise ValueError(f'emoji argument is malformed: \"{emoji}\"')
+        elif not utils.isValidStr(emoji):
             return None
 
         await self.__readJson()

--- a/src/CynanBot/events.py
+++ b/src/CynanBot/events.py
@@ -32,10 +32,8 @@ class RaidLogEvent(AbsEvent):
         chatLogger: ChatLoggerInterface,
         timber: TimberInterface
     ):
-        if not isinstance(chatLogger, ChatLoggerInterface):
-            raise ValueError(f'chatLogger argument is malformed: \"{chatLogger}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(chatLogger, ChatLoggerInterface), f"malformed {chatLogger=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__chatLogger: ChatLoggerInterface = chatLogger
         self.__timber: TimberInterface = timber
@@ -73,12 +71,9 @@ class RaidThankEvent(AbsEvent):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -131,14 +126,10 @@ class SubGiftThankingEvent(AbsEvent):
         twitchHandleProvider: TwitchHandleProviderInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
-            raise ValueError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/events.py
+++ b/src/CynanBot/events.py
@@ -32,8 +32,10 @@ class RaidLogEvent(AbsEvent):
         chatLogger: ChatLoggerInterface,
         timber: TimberInterface
     ):
-        assert isinstance(chatLogger, ChatLoggerInterface), f"malformed {chatLogger=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(chatLogger, ChatLoggerInterface):
+            raise ValueError(f'chatLogger argument is malformed: \"{chatLogger}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__chatLogger: ChatLoggerInterface = chatLogger
         self.__timber: TimberInterface = timber
@@ -71,9 +73,12 @@ class RaidThankEvent(AbsEvent):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber
@@ -126,10 +131,14 @@ class SubGiftThankingEvent(AbsEvent):
         twitchHandleProvider: TwitchHandleProviderInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
+            raise ValueError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
 
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/funtoon/funtoonRepository.py
+++ b/src/CynanBot/funtoon/funtoonRepository.py
@@ -22,13 +22,10 @@ class FuntoonRepository(FuntoonRepositoryInterface):
         timber: TimberInterface,
         funtoonApiUrl: str = 'https://funtoon.party/api'
     ):
-        if not isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface):
-            raise ValueError(f'funtoonTokensRepository argument is malformed: \"{funtoonTokensRepository}\"')
-        elif not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidUrl(funtoonApiUrl):
+        assert isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface), f"malformed {funtoonTokensRepository=}"
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidUrl(funtoonApiUrl):
             raise ValueError(f'funtoonApiUrl argument is malformed: \"{funtoonApiUrl}\"')
 
         self.__funtoonTokensRepository: FuntoonTokensRepositoryInterface = funtoonTokensRepository
@@ -65,9 +62,9 @@ class FuntoonRepository(FuntoonRepositoryInterface):
     ) -> bool:
         if not utils.isValidStr(event):
             raise ValueError(f'event argument is malformed: \"{event}\"')
-        elif not utils.isValidStr(funtoonToken):
+        if not utils.isValidStr(funtoonToken):
             raise ValueError(f'funtoonToken argument is malformed: \"{funtoonToken}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         url = f'{self.__funtoonApiUrl}/events/custom'
@@ -114,9 +111,9 @@ class FuntoonRepository(FuntoonRepositoryInterface):
     ) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userThatRedeemed):
+        if not utils.isValidStr(userThatRedeemed):
             raise ValueError(f'userThatRedeemed argument is malformed: \"{userThatRedeemed}\"')
-        elif not utils.isValidStr(userToBattle):
+        if not utils.isValidStr(userToBattle):
             raise ValueError(f'userToBattle argument is malformed: \"{userToBattle}\"')
 
         try:
@@ -143,10 +140,9 @@ class FuntoonRepository(FuntoonRepositoryInterface):
     ) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userThatRedeemed):
+        if not utils.isValidStr(userThatRedeemed):
             raise ValueError(f'userThatRedeemed argument is malformed: \"{userThatRedeemed}\"')
-        elif funtoonPkmnCatchType is not None and not isinstance(funtoonPkmnCatchType, FuntoonPkmnCatchType):
-            raise ValueError(f'funtoonPkmnCatchType argument is malformed: \"{funtoonPkmnCatchType}\"')
+        assert funtoonPkmnCatchType is None or isinstance(funtoonPkmnCatchType, FuntoonPkmnCatchType), f"malformed {funtoonPkmnCatchType=}"
 
         try:
             funtoonToken = await self.__funtoonTokensRepository.requireToken(twitchChannel)
@@ -177,7 +173,7 @@ class FuntoonRepository(FuntoonRepositoryInterface):
     ) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userThatRedeemed):
+        if not utils.isValidStr(userThatRedeemed):
             raise ValueError(f'userThatRedeemed argument is malformed: \"{userThatRedeemed}\"')
 
         try:
@@ -200,7 +196,7 @@ class FuntoonRepository(FuntoonRepositoryInterface):
     ) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userThatRedeemed):
+        if not utils.isValidStr(userThatRedeemed):
             raise ValueError(f'userThatRedeemed argument is malformed: \"{userThatRedeemed}\"')
 
         try:

--- a/src/CynanBot/funtoon/funtoonRepository.py
+++ b/src/CynanBot/funtoon/funtoonRepository.py
@@ -22,10 +22,13 @@ class FuntoonRepository(FuntoonRepositoryInterface):
         timber: TimberInterface,
         funtoonApiUrl: str = 'https://funtoon.party/api'
     ):
-        assert isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface), f"malformed {funtoonTokensRepository=}"
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidUrl(funtoonApiUrl):
+        if not isinstance(funtoonTokensRepository, FuntoonTokensRepositoryInterface):
+            raise ValueError(f'funtoonTokensRepository argument is malformed: \"{funtoonTokensRepository}\"')
+        elif not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidUrl(funtoonApiUrl):
             raise ValueError(f'funtoonApiUrl argument is malformed: \"{funtoonApiUrl}\"')
 
         self.__funtoonTokensRepository: FuntoonTokensRepositoryInterface = funtoonTokensRepository
@@ -62,9 +65,9 @@ class FuntoonRepository(FuntoonRepositoryInterface):
     ) -> bool:
         if not utils.isValidStr(event):
             raise ValueError(f'event argument is malformed: \"{event}\"')
-        if not utils.isValidStr(funtoonToken):
+        elif not utils.isValidStr(funtoonToken):
             raise ValueError(f'funtoonToken argument is malformed: \"{funtoonToken}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         url = f'{self.__funtoonApiUrl}/events/custom'
@@ -111,9 +114,9 @@ class FuntoonRepository(FuntoonRepositoryInterface):
     ) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userThatRedeemed):
+        elif not utils.isValidStr(userThatRedeemed):
             raise ValueError(f'userThatRedeemed argument is malformed: \"{userThatRedeemed}\"')
-        if not utils.isValidStr(userToBattle):
+        elif not utils.isValidStr(userToBattle):
             raise ValueError(f'userToBattle argument is malformed: \"{userToBattle}\"')
 
         try:
@@ -140,9 +143,10 @@ class FuntoonRepository(FuntoonRepositoryInterface):
     ) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userThatRedeemed):
+        elif not utils.isValidStr(userThatRedeemed):
             raise ValueError(f'userThatRedeemed argument is malformed: \"{userThatRedeemed}\"')
-        assert funtoonPkmnCatchType is None or isinstance(funtoonPkmnCatchType, FuntoonPkmnCatchType), f"malformed {funtoonPkmnCatchType=}"
+        elif funtoonPkmnCatchType is not None and not isinstance(funtoonPkmnCatchType, FuntoonPkmnCatchType):
+            raise ValueError(f'funtoonPkmnCatchType argument is malformed: \"{funtoonPkmnCatchType}\"')
 
         try:
             funtoonToken = await self.__funtoonTokensRepository.requireToken(twitchChannel)
@@ -173,7 +177,7 @@ class FuntoonRepository(FuntoonRepositoryInterface):
     ) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userThatRedeemed):
+        elif not utils.isValidStr(userThatRedeemed):
             raise ValueError(f'userThatRedeemed argument is malformed: \"{userThatRedeemed}\"')
 
         try:
@@ -196,7 +200,7 @@ class FuntoonRepository(FuntoonRepositoryInterface):
     ) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userThatRedeemed):
+        elif not utils.isValidStr(userThatRedeemed):
             raise ValueError(f'userThatRedeemed argument is malformed: \"{userThatRedeemed}\"')
 
         try:

--- a/src/CynanBot/funtoon/funtoonTokensRepository.py
+++ b/src/CynanBot/funtoon/funtoonTokensRepository.py
@@ -19,12 +19,9 @@ class FuntoonTokensRepository(FuntoonTokensRepositoryInterface):
         timber: TimberInterface,
         seedFileReader: Optional[JsonReaderInterface] = None
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif seedFileReader is not None and not isinstance(seedFileReader, JsonReaderInterface):
-            raise ValueError(f'seedFileReader argument is malformed: \"{seedFileReader}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert seedFileReader is None or isinstance(seedFileReader, JsonReaderInterface), f"malformed {seedFileReader=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -140,9 +137,8 @@ class FuntoonTokensRepository(FuntoonTokensRepositoryInterface):
         return token
 
     async def setToken(self, token: Optional[str], twitchChannel: str):
-        if token is not None and not isinstance(token, str):
-            raise ValueError(f'token argument is malformed: \"{token}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert token is None or isinstance(token, str), f"malformed {token=}"
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()

--- a/src/CynanBot/funtoon/funtoonTokensRepository.py
+++ b/src/CynanBot/funtoon/funtoonTokensRepository.py
@@ -19,9 +19,12 @@ class FuntoonTokensRepository(FuntoonTokensRepositoryInterface):
         timber: TimberInterface,
         seedFileReader: Optional[JsonReaderInterface] = None
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert seedFileReader is None or isinstance(seedFileReader, JsonReaderInterface), f"malformed {seedFileReader=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif seedFileReader is not None and not isinstance(seedFileReader, JsonReaderInterface):
+            raise ValueError(f'seedFileReader argument is malformed: \"{seedFileReader}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -137,8 +140,9 @@ class FuntoonTokensRepository(FuntoonTokensRepositoryInterface):
         return token
 
     async def setToken(self, token: Optional[str], twitchChannel: str):
-        assert token is None or isinstance(token, str), f"malformed {token=}"
-        if not utils.isValidStr(twitchChannel):
+        if token is not None and not isinstance(token, str):
+            raise ValueError(f'token argument is malformed: \"{token}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()

--- a/src/CynanBot/generalSettingsRepository.py
+++ b/src/CynanBot/generalSettingsRepository.py
@@ -11,8 +11,7 @@ from CynanBot.trivia.builder.triviaGameBuilderSettingsInterface import \
 class GeneralSettingsRepository(Clearable, TriviaGameBuilderSettingsInterface):
 
     def __init__(self, settingsJsonReader: JsonReaderInterface):
-        if not isinstance(settingsJsonReader, JsonReaderInterface):
-            raise TypeError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
+        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
 
@@ -97,7 +96,7 @@ class GeneralSettingsRepository(Clearable, TriviaGameBuilderSettingsInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from General Settings file: \"{self.__settingsJsonReader}\"')
-        elif len(jsonContents) == 0:
+        if len(jsonContents) == 0:
             raise ValueError(f'JSON contents of General Settings file \"{self.__settingsJsonReader}\" is empty')
 
         return jsonContents
@@ -110,7 +109,7 @@ class GeneralSettingsRepository(Clearable, TriviaGameBuilderSettingsInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from General Settings file: \"{self.__settingsJsonReader}\"')
-        elif len(jsonContents) == 0:
+        if len(jsonContents) == 0:
             raise ValueError(f'JSON contents of General Settings file \"{self.__settingsJsonReader}\" is empty')
 
         return jsonContents

--- a/src/CynanBot/generalSettingsRepository.py
+++ b/src/CynanBot/generalSettingsRepository.py
@@ -11,7 +11,8 @@ from CynanBot.trivia.builder.triviaGameBuilderSettingsInterface import \
 class GeneralSettingsRepository(Clearable, TriviaGameBuilderSettingsInterface):
 
     def __init__(self, settingsJsonReader: JsonReaderInterface):
-        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
+        if not isinstance(settingsJsonReader, JsonReaderInterface):
+            raise TypeError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
 
@@ -96,7 +97,7 @@ class GeneralSettingsRepository(Clearable, TriviaGameBuilderSettingsInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from General Settings file: \"{self.__settingsJsonReader}\"')
-        if len(jsonContents) == 0:
+        elif len(jsonContents) == 0:
             raise ValueError(f'JSON contents of General Settings file \"{self.__settingsJsonReader}\" is empty')
 
         return jsonContents
@@ -109,7 +110,7 @@ class GeneralSettingsRepository(Clearable, TriviaGameBuilderSettingsInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from General Settings file: \"{self.__settingsJsonReader}\"')
-        if len(jsonContents) == 0:
+        elif len(jsonContents) == 0:
             raise ValueError(f'JSON contents of General Settings file \"{self.__settingsJsonReader}\" is empty')
 
         return jsonContents

--- a/src/CynanBot/language/jishoHelper.py
+++ b/src/CynanBot/language/jishoHelper.py
@@ -20,17 +20,15 @@ class JishoHelper(JishoHelperInterface):
         definitionsMaxSize: int = 3,
         variantsMaxSize: int = 3
     ):
-        if not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidInt(definitionsMaxSize):
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidInt(definitionsMaxSize):
             raise ValueError(f'definitionsMaxSize argument is malformed: \"{definitionsMaxSize}\"')
-        elif definitionsMaxSize < 1 or definitionsMaxSize > 5:
+        if definitionsMaxSize < 1 or definitionsMaxSize > 5:
             raise ValueError(f'definitionsMaxSize argument is out of bounds: \"{definitionsMaxSize}\"')
-        elif not utils.isValidInt(variantsMaxSize):
+        if not utils.isValidInt(variantsMaxSize):
             raise ValueError(f'variantsMaxSize argument is malformed: \"{variantsMaxSize}\"')
-        elif variantsMaxSize < 1 or variantsMaxSize > 5:
+        if variantsMaxSize < 1 or variantsMaxSize > 5:
             raise ValueError(f'variantsMaxSize argument is out of bounds: \"{variantsMaxSize}\"')
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
@@ -62,16 +60,16 @@ class JishoHelper(JishoHelperInterface):
 
         if not utils.hasItems(jsonResponse):
             raise RuntimeError(f'Jisho\'s response for \"{query}\" has malformed or empty JSON: {jsonResponse}')
-        elif 'meta' not in jsonResponse or utils.getIntFromDict(jsonResponse['meta'], 'status') != 200:
+        if 'meta' not in jsonResponse or utils.getIntFromDict(jsonResponse['meta'], 'status') != 200:
             raise RuntimeError(f'Jisho\'s response for \"{query}\" has an invalid \"status\": {jsonResponse}')
-        elif not utils.hasItems(jsonResponse['data']):
+        if not utils.hasItems(jsonResponse['data']):
             raise RuntimeError(f'Jisho\'s response for \"{query}\" has malformed or empty \"data\": {jsonResponse}')
 
         variants: List[JishoVariant] = list()
         for variantJson in jsonResponse['data']:
             if not utils.hasItems(variantJson['japanese']):
                 raise RuntimeError(f'Jisho\'s response for \"{query}\" has malformed or empty \"japanese\": {jsonResponse}')
-            elif not utils.hasItems(variantJson['senses']):
+            if not utils.hasItems(variantJson['senses']):
                 raise RuntimeError(f'Jisho\'s response for \"{query}\" has malformed or empty \"senses\": {jsonResponse}')
 
             word = utils.cleanStr(variantJson['japanese'][0].get('word', ''))

--- a/src/CynanBot/language/jishoHelper.py
+++ b/src/CynanBot/language/jishoHelper.py
@@ -20,15 +20,17 @@ class JishoHelper(JishoHelperInterface):
         definitionsMaxSize: int = 3,
         variantsMaxSize: int = 3
     ):
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidInt(definitionsMaxSize):
+        if not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidInt(definitionsMaxSize):
             raise ValueError(f'definitionsMaxSize argument is malformed: \"{definitionsMaxSize}\"')
-        if definitionsMaxSize < 1 or definitionsMaxSize > 5:
+        elif definitionsMaxSize < 1 or definitionsMaxSize > 5:
             raise ValueError(f'definitionsMaxSize argument is out of bounds: \"{definitionsMaxSize}\"')
-        if not utils.isValidInt(variantsMaxSize):
+        elif not utils.isValidInt(variantsMaxSize):
             raise ValueError(f'variantsMaxSize argument is malformed: \"{variantsMaxSize}\"')
-        if variantsMaxSize < 1 or variantsMaxSize > 5:
+        elif variantsMaxSize < 1 or variantsMaxSize > 5:
             raise ValueError(f'variantsMaxSize argument is out of bounds: \"{variantsMaxSize}\"')
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
@@ -60,16 +62,16 @@ class JishoHelper(JishoHelperInterface):
 
         if not utils.hasItems(jsonResponse):
             raise RuntimeError(f'Jisho\'s response for \"{query}\" has malformed or empty JSON: {jsonResponse}')
-        if 'meta' not in jsonResponse or utils.getIntFromDict(jsonResponse['meta'], 'status') != 200:
+        elif 'meta' not in jsonResponse or utils.getIntFromDict(jsonResponse['meta'], 'status') != 200:
             raise RuntimeError(f'Jisho\'s response for \"{query}\" has an invalid \"status\": {jsonResponse}')
-        if not utils.hasItems(jsonResponse['data']):
+        elif not utils.hasItems(jsonResponse['data']):
             raise RuntimeError(f'Jisho\'s response for \"{query}\" has malformed or empty \"data\": {jsonResponse}')
 
         variants: List[JishoVariant] = list()
         for variantJson in jsonResponse['data']:
             if not utils.hasItems(variantJson['japanese']):
                 raise RuntimeError(f'Jisho\'s response for \"{query}\" has malformed or empty \"japanese\": {jsonResponse}')
-            if not utils.hasItems(variantJson['senses']):
+            elif not utils.hasItems(variantJson['senses']):
                 raise RuntimeError(f'Jisho\'s response for \"{query}\" has malformed or empty \"senses\": {jsonResponse}')
 
             word = utils.cleanStr(variantJson['japanese'][0].get('word', ''))

--- a/src/CynanBot/language/jishoResult.py
+++ b/src/CynanBot/language/jishoResult.py
@@ -13,7 +13,7 @@ class JishoResult():
     ):
         if not utils.hasItems(variants):
             raise ValueError(f'variants argument is malformed: \"{variants}\"')
-        elif not utils.isValidStr(initialQuery):
+        if not utils.isValidStr(initialQuery):
             raise ValueError(f'initialQuery argument is malformed: \"{initialQuery}\"')
 
         self.__variants: List[JishoVariant] = variants
@@ -26,8 +26,7 @@ class JishoResult():
         return self.__variants
 
     def toStrList(self, definitionDelimiter: str = ', ') -> List[str]:
-        if not isinstance(definitionDelimiter, str):
-            raise ValueError(f'definitionDelimiter argument is malformed: \"{definitionDelimiter}\"')
+        assert isinstance(definitionDelimiter, str), f"malformed {definitionDelimiter=}"
 
         strings: List[str] = list()
         for variant in self.__variants:

--- a/src/CynanBot/language/jishoResult.py
+++ b/src/CynanBot/language/jishoResult.py
@@ -13,7 +13,7 @@ class JishoResult():
     ):
         if not utils.hasItems(variants):
             raise ValueError(f'variants argument is malformed: \"{variants}\"')
-        if not utils.isValidStr(initialQuery):
+        elif not utils.isValidStr(initialQuery):
             raise ValueError(f'initialQuery argument is malformed: \"{initialQuery}\"')
 
         self.__variants: List[JishoVariant] = variants
@@ -26,7 +26,8 @@ class JishoResult():
         return self.__variants
 
     def toStrList(self, definitionDelimiter: str = ', ') -> List[str]:
-        assert isinstance(definitionDelimiter, str), f"malformed {definitionDelimiter=}"
+        if not isinstance(definitionDelimiter, str):
+            raise ValueError(f'definitionDelimiter argument is malformed: \"{definitionDelimiter}\"')
 
         strings: List[str] = list()
         for variant in self.__variants:

--- a/src/CynanBot/language/jishoVariant.py
+++ b/src/CynanBot/language/jishoVariant.py
@@ -42,8 +42,7 @@ class JishoVariant():
         return utils.isValidStr(self.__word)
 
     def toStr(self, definitionDelimiter: str = ', ') -> str:
-        if not isinstance(definitionDelimiter, str):
-            raise ValueError(f'definitionDelimiter argument is malformed: \"{definitionDelimiter}\"')
+        assert isinstance(definitionDelimiter, str), f"malformed {definitionDelimiter=}"
 
         word = ''
         if self.hasWord():

--- a/src/CynanBot/language/jishoVariant.py
+++ b/src/CynanBot/language/jishoVariant.py
@@ -42,7 +42,8 @@ class JishoVariant():
         return utils.isValidStr(self.__word)
 
     def toStr(self, definitionDelimiter: str = ', ') -> str:
-        assert isinstance(definitionDelimiter, str), f"malformed {definitionDelimiter=}"
+        if not isinstance(definitionDelimiter, str):
+            raise ValueError(f'definitionDelimiter argument is malformed: \"{definitionDelimiter}\"')
 
         word = ''
         if self.hasWord():

--- a/src/CynanBot/language/languageEntry.py
+++ b/src/CynanBot/language/languageEntry.py
@@ -15,14 +15,11 @@ class LanguageEntry():
     ):
         if not utils.areValidStrs(commandNames):
             raise ValueError(f'commandNames argument is malformed: \"{commandNames}\"')
-        elif not utils.isValidStr(name):
+        if not utils.isValidStr(name):
             raise ValueError(f'name argument is malformed: \"{name}\"')
-        elif flag is not None and not isinstance(flag, str):
-            raise ValueError(f'flag argument is malformed: \"{flag}\"')
-        elif iso6391Code is not None and not isinstance(iso6391Code, str):
-            raise ValueError(f'iso6391Code argument is malformed: \"{iso6391Code}\"')
-        elif wotdApiCode is not None and not isinstance(wotdApiCode, str):
-            raise ValueError(f'wotdApiCode argument is malformed: \"{wotdApiCode}\"')
+        assert flag is None or isinstance(flag, str), f"malformed {flag=}"
+        assert iso6391Code is None or isinstance(iso6391Code, str), f"malformed {iso6391Code=}"
+        assert wotdApiCode is None or isinstance(wotdApiCode, str), f"malformed {wotdApiCode=}"
 
         self.__commandNames: List[str] = commandNames
         self.__name: str = name

--- a/src/CynanBot/language/languageEntry.py
+++ b/src/CynanBot/language/languageEntry.py
@@ -15,11 +15,14 @@ class LanguageEntry():
     ):
         if not utils.areValidStrs(commandNames):
             raise ValueError(f'commandNames argument is malformed: \"{commandNames}\"')
-        if not utils.isValidStr(name):
+        elif not utils.isValidStr(name):
             raise ValueError(f'name argument is malformed: \"{name}\"')
-        assert flag is None or isinstance(flag, str), f"malformed {flag=}"
-        assert iso6391Code is None or isinstance(iso6391Code, str), f"malformed {iso6391Code=}"
-        assert wotdApiCode is None or isinstance(wotdApiCode, str), f"malformed {wotdApiCode=}"
+        elif flag is not None and not isinstance(flag, str):
+            raise ValueError(f'flag argument is malformed: \"{flag}\"')
+        elif iso6391Code is not None and not isinstance(iso6391Code, str):
+            raise ValueError(f'iso6391Code argument is malformed: \"{iso6391Code}\"')
+        elif wotdApiCode is not None and not isinstance(wotdApiCode, str):
+            raise ValueError(f'wotdApiCode argument is malformed: \"{wotdApiCode}\"')
 
         self.__commandNames: List[str] = commandNames
         self.__name: str = name

--- a/src/CynanBot/language/languagesRepository.py
+++ b/src/CynanBot/language/languagesRepository.py
@@ -182,8 +182,7 @@ class LanguagesRepository(LanguagesRepositoryInterface):
         self,
         delimiter: str = ', '
     ) -> str:
-        if not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         wotdApiCodes: List[str] = list()
         validEntries = await self.__getLanguageEntries(hasWotdApiCode = True)
@@ -201,7 +200,7 @@ class LanguagesRepository(LanguagesRepositoryInterface):
     ) -> LanguageEntry:
         if hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
             raise ValueError(f'hasIso6391Code argument is malformed: \"{hasIso6391Code}\"')
-        elif hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
+        if hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
             raise ValueError(f'hasWotdApiCode argument is malformed: \"{hasWotdApiCode}\"')
 
         validEntries = await self.__getLanguageEntries(
@@ -218,7 +217,7 @@ class LanguagesRepository(LanguagesRepositoryInterface):
     ) -> List[LanguageEntry]:
         if hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
             raise ValueError(f'hasIso6391Code argument is malformed: \"{hasIso6391Code}\"')
-        elif hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
+        if hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
             raise ValueError(f'hasWotdApiCode argument is malformed: \"{hasWotdApiCode}\"')
 
         validEntries: List[LanguageEntry] = list()
@@ -249,9 +248,9 @@ class LanguagesRepository(LanguagesRepositoryInterface):
     ) -> Optional[LanguageEntry]:
         if not utils.isValidStr(command):
             raise ValueError(f'command argument is malformed: \"{command}\"')
-        elif hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
+        if hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
             raise ValueError(f'hasIso6391Code argument is malformed: \"{hasIso6391Code}\"')
-        elif hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
+        if hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
             raise ValueError(f'hasWotdApiCode argumet is malformed: \"{hasWotdApiCode}\"')
 
         validEntries = await self.__getLanguageEntries(
@@ -289,9 +288,9 @@ class LanguagesRepository(LanguagesRepositoryInterface):
     ) -> LanguageEntry:
         if not utils.isValidStr(command):
             raise ValueError(f'command argument is malformed: \"{command}\"')
-        elif hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
+        if hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
             raise ValueError(f'hasIso6391Code argument is malformed: \"{hasIso6391Code}\"')
-        elif hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
+        if hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
             raise ValueError(f'hasWotdApiCode argumet is malformed: \"{hasWotdApiCode}\"')
 
         languageEntry = await self.getLanguageForCommand(

--- a/src/CynanBot/language/languagesRepository.py
+++ b/src/CynanBot/language/languagesRepository.py
@@ -182,7 +182,8 @@ class LanguagesRepository(LanguagesRepositoryInterface):
         self,
         delimiter: str = ', '
     ) -> str:
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         wotdApiCodes: List[str] = list()
         validEntries = await self.__getLanguageEntries(hasWotdApiCode = True)
@@ -200,7 +201,7 @@ class LanguagesRepository(LanguagesRepositoryInterface):
     ) -> LanguageEntry:
         if hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
             raise ValueError(f'hasIso6391Code argument is malformed: \"{hasIso6391Code}\"')
-        if hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
+        elif hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
             raise ValueError(f'hasWotdApiCode argument is malformed: \"{hasWotdApiCode}\"')
 
         validEntries = await self.__getLanguageEntries(
@@ -217,7 +218,7 @@ class LanguagesRepository(LanguagesRepositoryInterface):
     ) -> List[LanguageEntry]:
         if hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
             raise ValueError(f'hasIso6391Code argument is malformed: \"{hasIso6391Code}\"')
-        if hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
+        elif hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
             raise ValueError(f'hasWotdApiCode argument is malformed: \"{hasWotdApiCode}\"')
 
         validEntries: List[LanguageEntry] = list()
@@ -248,9 +249,9 @@ class LanguagesRepository(LanguagesRepositoryInterface):
     ) -> Optional[LanguageEntry]:
         if not utils.isValidStr(command):
             raise ValueError(f'command argument is malformed: \"{command}\"')
-        if hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
+        elif hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
             raise ValueError(f'hasIso6391Code argument is malformed: \"{hasIso6391Code}\"')
-        if hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
+        elif hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
             raise ValueError(f'hasWotdApiCode argumet is malformed: \"{hasWotdApiCode}\"')
 
         validEntries = await self.__getLanguageEntries(
@@ -288,9 +289,9 @@ class LanguagesRepository(LanguagesRepositoryInterface):
     ) -> LanguageEntry:
         if not utils.isValidStr(command):
             raise ValueError(f'command argument is malformed: \"{command}\"')
-        if hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
+        elif hasIso6391Code is not None and not utils.isValidBool(hasIso6391Code):
             raise ValueError(f'hasIso6391Code argument is malformed: \"{hasIso6391Code}\"')
-        if hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
+        elif hasWotdApiCode is not None and not utils.isValidBool(hasWotdApiCode):
             raise ValueError(f'hasWotdApiCode argumet is malformed: \"{hasWotdApiCode}\"')
 
         languageEntry = await self.getLanguageForCommand(

--- a/src/CynanBot/language/translation/deepLTranslationApi.py
+++ b/src/CynanBot/language/translation/deepLTranslationApi.py
@@ -24,14 +24,10 @@ class DeepLTranslationApi(TranslationApi):
         deepLAuthKey: Optional[str],
         timber: TimberInterface
     ):
-        if not isinstance(languagesRepository, LanguagesRepositoryInterface):
-            raise TypeError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
-        elif not isinstance(networkClientProvider, NetworkClientProvider):
-            raise TypeError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif deepLAuthKey is not None and not isinstance(deepLAuthKey, str):
-            raise TypeError(f'deepLAuthKey argument is malformed: \"{deepLAuthKey}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert deepLAuthKey is None or isinstance(deepLAuthKey, str), f"malformed {deepLAuthKey=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
@@ -47,9 +43,8 @@ class DeepLTranslationApi(TranslationApi):
     async def translate(self, text: str, targetLanguage: LanguageEntry) -> TranslationResponse:
         if not utils.isValidStr(text):
             raise TypeError(f'text argument is malformed: \"{text}\"')
-        elif not isinstance(targetLanguage, LanguageEntry):
-            raise TypeError(f'targetLanguage argument is malformed: \"{targetLanguage}\"')
-        elif not targetLanguage.hasIso6391Code():
+        assert isinstance(targetLanguage, LanguageEntry), f"malformed {targetLanguage=}"
+        if not targetLanguage.hasIso6391Code():
             raise ValueError(f'targetLanguage has no ISO 639-1 code: \"{targetLanguage}\"')
 
         deepLAuthKey = self.__deepLAuthKey

--- a/src/CynanBot/language/translation/deepLTranslationApi.py
+++ b/src/CynanBot/language/translation/deepLTranslationApi.py
@@ -24,10 +24,14 @@ class DeepLTranslationApi(TranslationApi):
         deepLAuthKey: Optional[str],
         timber: TimberInterface
     ):
-        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert deepLAuthKey is None or isinstance(deepLAuthKey, str), f"malformed {deepLAuthKey=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(languagesRepository, LanguagesRepositoryInterface):
+            raise TypeError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
+        elif not isinstance(networkClientProvider, NetworkClientProvider):
+            raise TypeError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif deepLAuthKey is not None and not isinstance(deepLAuthKey, str):
+            raise TypeError(f'deepLAuthKey argument is malformed: \"{deepLAuthKey}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
 
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
@@ -43,8 +47,9 @@ class DeepLTranslationApi(TranslationApi):
     async def translate(self, text: str, targetLanguage: LanguageEntry) -> TranslationResponse:
         if not utils.isValidStr(text):
             raise TypeError(f'text argument is malformed: \"{text}\"')
-        assert isinstance(targetLanguage, LanguageEntry), f"malformed {targetLanguage=}"
-        if not targetLanguage.hasIso6391Code():
+        elif not isinstance(targetLanguage, LanguageEntry):
+            raise TypeError(f'targetLanguage argument is malformed: \"{targetLanguage}\"')
+        elif not targetLanguage.hasIso6391Code():
             raise ValueError(f'targetLanguage has no ISO 639-1 code: \"{targetLanguage}\"')
 
         deepLAuthKey = self.__deepLAuthKey

--- a/src/CynanBot/language/translation/exceptions.py
+++ b/src/CynanBot/language/translation/exceptions.py
@@ -8,10 +8,8 @@ class TranslationEngineUnavailableException(Exception):
         message: str,
         translationApiSource: TranslationApiSource
     ):
-        if not isinstance(message, str):
-            raise TypeError(f'message argument is malformed: \"{message}\"')
-        elif not isinstance(translationApiSource, TranslationApiSource):
-            raise TypeError(f'translationApiSource argument is malformed: \"{translationApiSource}\"')
+        assert isinstance(message, str), f"malformed {message=}"
+        assert isinstance(translationApiSource, TranslationApiSource), f"malformed {translationApiSource=}"
 
         super().__init__(message, translationApiSource)
 
@@ -23,9 +21,7 @@ class TranslationException(Exception):
         message: str,
         translationApiSource: TranslationApiSource
     ):
-        if not isinstance(message, str):
-            raise TypeError(f'message argument is malformed: \"{message}\"')
-        elif not isinstance(translationApiSource, TranslationApiSource):
-            raise TypeError(f'translationApiSource argument is malformed: \"{translationApiSource}\"')
+        assert isinstance(message, str), f"malformed {message=}"
+        assert isinstance(translationApiSource, TranslationApiSource), f"malformed {translationApiSource=}"
 
         super().__init__(message, translationApiSource)

--- a/src/CynanBot/language/translation/exceptions.py
+++ b/src/CynanBot/language/translation/exceptions.py
@@ -8,8 +8,10 @@ class TranslationEngineUnavailableException(Exception):
         message: str,
         translationApiSource: TranslationApiSource
     ):
-        assert isinstance(message, str), f"malformed {message=}"
-        assert isinstance(translationApiSource, TranslationApiSource), f"malformed {translationApiSource=}"
+        if not isinstance(message, str):
+            raise TypeError(f'message argument is malformed: \"{message}\"')
+        elif not isinstance(translationApiSource, TranslationApiSource):
+            raise TypeError(f'translationApiSource argument is malformed: \"{translationApiSource}\"')
 
         super().__init__(message, translationApiSource)
 
@@ -21,7 +23,9 @@ class TranslationException(Exception):
         message: str,
         translationApiSource: TranslationApiSource
     ):
-        assert isinstance(message, str), f"malformed {message=}"
-        assert isinstance(translationApiSource, TranslationApiSource), f"malformed {translationApiSource=}"
+        if not isinstance(message, str):
+            raise TypeError(f'message argument is malformed: \"{message}\"')
+        elif not isinstance(translationApiSource, TranslationApiSource):
+            raise TypeError(f'translationApiSource argument is malformed: \"{translationApiSource}\"')
 
         super().__init__(message, translationApiSource)

--- a/src/CynanBot/language/translation/googleTranslationApi.py
+++ b/src/CynanBot/language/translation/googleTranslationApi.py
@@ -48,7 +48,7 @@ class GoogleTranslationApi(TranslationApi):
 
             if not await self.__hasGoogleApiCredentials():
                 raise RuntimeError(f'Unable to initialize a new Google translate.Client instance because the Google API credentials are missing')
-            elif not await aiofiles.ospath.exists(self.__googleServiceAccountFile):
+            if not await aiofiles.ospath.exists(self.__googleServiceAccountFile):
                 raise FileNotFoundError(f'googleServiceAccount file not found: \"{self.__googleServiceAccountFile}\"')
 
             self.__googleTranslateClient = translate.Client.from_service_account_json(self.__googleServiceAccountFile)
@@ -85,9 +85,8 @@ class GoogleTranslationApi(TranslationApi):
     async def translate(self, text: str, targetLanguage: LanguageEntry) -> TranslationResponse:
         if not utils.isValidStr(text):
             raise TypeError(f'text argument is malformed: \"{text}\"')
-        elif not isinstance(targetLanguage, LanguageEntry):
-            raise TypeError(f'targetLanguage argument is malformed: \"{targetLanguage}\"')
-        elif not targetLanguage.hasIso6391Code():
+        assert isinstance(targetLanguage, LanguageEntry), f"malformed {targetLanguage=}"
+        if not targetLanguage.hasIso6391Code():
             raise ValueError(f'targetLanguage has no ISO 639-1 code: \"{targetLanguage}\"')
 
         googleTranslateClient = await self.__getGoogleTranslateClient()

--- a/src/CynanBot/language/translation/googleTranslationApi.py
+++ b/src/CynanBot/language/translation/googleTranslationApi.py
@@ -48,7 +48,7 @@ class GoogleTranslationApi(TranslationApi):
 
             if not await self.__hasGoogleApiCredentials():
                 raise RuntimeError(f'Unable to initialize a new Google translate.Client instance because the Google API credentials are missing')
-            if not await aiofiles.ospath.exists(self.__googleServiceAccountFile):
+            elif not await aiofiles.ospath.exists(self.__googleServiceAccountFile):
                 raise FileNotFoundError(f'googleServiceAccount file not found: \"{self.__googleServiceAccountFile}\"')
 
             self.__googleTranslateClient = translate.Client.from_service_account_json(self.__googleServiceAccountFile)
@@ -85,8 +85,9 @@ class GoogleTranslationApi(TranslationApi):
     async def translate(self, text: str, targetLanguage: LanguageEntry) -> TranslationResponse:
         if not utils.isValidStr(text):
             raise TypeError(f'text argument is malformed: \"{text}\"')
-        assert isinstance(targetLanguage, LanguageEntry), f"malformed {targetLanguage=}"
-        if not targetLanguage.hasIso6391Code():
+        elif not isinstance(targetLanguage, LanguageEntry):
+            raise TypeError(f'targetLanguage argument is malformed: \"{targetLanguage}\"')
+        elif not targetLanguage.hasIso6391Code():
             raise ValueError(f'targetLanguage has no ISO 639-1 code: \"{targetLanguage}\"')
 
         googleTranslateClient = await self.__getGoogleTranslateClient()

--- a/src/CynanBot/language/translationHelper.py
+++ b/src/CynanBot/language/translationHelper.py
@@ -35,17 +35,13 @@ class TranslationHelper(TranslationHelperInterface):
         timber: TimberInterface,
         maxAttempts: int = 3
     ):
-        if not isinstance(deepLTranslationApi, DeepLTranslationApi):
-            raise TypeError(f'deepLTranslationApi argument is malformed: \"{deepLTranslationApi}\"')
-        elif not isinstance(googleTranslationApi, GoogleTranslationApi):
-            raise TypeError(f'googleTranslationApi argument is malformed: \"{googleTranslationApi}\"')
-        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
-            raise TypeError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidInt(maxAttempts):
+        assert isinstance(deepLTranslationApi, DeepLTranslationApi), f"malformed {deepLTranslationApi=}"
+        assert isinstance(googleTranslationApi, GoogleTranslationApi), f"malformed {googleTranslationApi=}"
+        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidInt(maxAttempts):
             raise TypeError(f'maxAttempts argument is malformed: \"{maxAttempts}\"')
-        elif maxAttempts < 1 or maxAttempts > 10:
+        if maxAttempts < 1 or maxAttempts > 10:
             raise ValueError(f'maxAttempts argument is out of bounds: {maxAttempts}')
 
         self.__deepLTranslationApi: TranslationApi = deepLTranslationApi
@@ -61,9 +57,8 @@ class TranslationHelper(TranslationHelperInterface):
     ) -> TranslationResponse:
         if not utils.isValidStr(text):
             raise TypeError(f'text argument is malformed: \"{text}\"')
-        elif targetLanguage is not None and not isinstance(targetLanguage, LanguageEntry):
-            raise TypeError(f'targetLanguageEntry argument is malformed: \"{targetLanguage}\"')
-        elif targetLanguage is not None and not targetLanguage.hasIso6391Code():
+        assert targetLanguage is None or isinstance(targetLanguage, LanguageEntry), f"malformed {targetLanguage=}"
+        if targetLanguage is not None and not targetLanguage.hasIso6391Code():
             raise ValueError(f'targetLanguage has no ISO 639-1 code: \"{targetLanguage}\"')
 
         text = utils.cleanStr(text)

--- a/src/CynanBot/language/translationHelper.py
+++ b/src/CynanBot/language/translationHelper.py
@@ -35,13 +35,17 @@ class TranslationHelper(TranslationHelperInterface):
         timber: TimberInterface,
         maxAttempts: int = 3
     ):
-        assert isinstance(deepLTranslationApi, DeepLTranslationApi), f"malformed {deepLTranslationApi=}"
-        assert isinstance(googleTranslationApi, GoogleTranslationApi), f"malformed {googleTranslationApi=}"
-        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidInt(maxAttempts):
+        if not isinstance(deepLTranslationApi, DeepLTranslationApi):
+            raise TypeError(f'deepLTranslationApi argument is malformed: \"{deepLTranslationApi}\"')
+        elif not isinstance(googleTranslationApi, GoogleTranslationApi):
+            raise TypeError(f'googleTranslationApi argument is malformed: \"{googleTranslationApi}\"')
+        elif not isinstance(languagesRepository, LanguagesRepositoryInterface):
+            raise TypeError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidInt(maxAttempts):
             raise TypeError(f'maxAttempts argument is malformed: \"{maxAttempts}\"')
-        if maxAttempts < 1 or maxAttempts > 10:
+        elif maxAttempts < 1 or maxAttempts > 10:
             raise ValueError(f'maxAttempts argument is out of bounds: {maxAttempts}')
 
         self.__deepLTranslationApi: TranslationApi = deepLTranslationApi
@@ -57,8 +61,9 @@ class TranslationHelper(TranslationHelperInterface):
     ) -> TranslationResponse:
         if not utils.isValidStr(text):
             raise TypeError(f'text argument is malformed: \"{text}\"')
-        assert targetLanguage is None or isinstance(targetLanguage, LanguageEntry), f"malformed {targetLanguage=}"
-        if targetLanguage is not None and not targetLanguage.hasIso6391Code():
+        elif targetLanguage is not None and not isinstance(targetLanguage, LanguageEntry):
+            raise TypeError(f'targetLanguageEntry argument is malformed: \"{targetLanguage}\"')
+        elif targetLanguage is not None and not targetLanguage.hasIso6391Code():
             raise ValueError(f'targetLanguage has no ISO 639-1 code: \"{targetLanguage}\"')
 
         text = utils.cleanStr(text)

--- a/src/CynanBot/language/translationResponse.py
+++ b/src/CynanBot/language/translationResponse.py
@@ -17,14 +17,13 @@ class TranslationResponse():
     ):
         if originalLanguage is not None and not originalLanguage.hasIso6391Code():
             raise ValueError(f'originalLanguage argument must be either None or have an ISO 639-1 code: \"{originalLanguage}\"')
-        elif translatedLanguage is not None and not translatedLanguage.hasIso6391Code():
+        if translatedLanguage is not None and not translatedLanguage.hasIso6391Code():
             raise ValueError(f'translatedLanguage argument must be either None or have an ISO 639-1 code: \"{translatedLanguage}\"')
-        elif not utils.isValidStr(originalText):
+        if not utils.isValidStr(originalText):
             raise ValueError(f'originalText argument is malformed: \"{originalText}\"')
-        elif not utils.isValidStr(translatedText):
+        if not utils.isValidStr(translatedText):
             raise ValueError(f'translatedText argument is malformed: \"{translatedText}\"')
-        elif not isinstance(translationApiSource, TranslationApiSource):
-            raise ValueError(f'translationApiSource argument is malformed: \"{translationApiSource}\"')
+        assert isinstance(translationApiSource, TranslationApiSource), f"malformed {translationApiSource=}"
 
         self.__originalLanguage: Optional[LanguageEntry] = originalLanguage
         self.__translatedLanguage: Optional[LanguageEntry] = translatedLanguage

--- a/src/CynanBot/language/translationResponse.py
+++ b/src/CynanBot/language/translationResponse.py
@@ -17,13 +17,14 @@ class TranslationResponse():
     ):
         if originalLanguage is not None and not originalLanguage.hasIso6391Code():
             raise ValueError(f'originalLanguage argument must be either None or have an ISO 639-1 code: \"{originalLanguage}\"')
-        if translatedLanguage is not None and not translatedLanguage.hasIso6391Code():
+        elif translatedLanguage is not None and not translatedLanguage.hasIso6391Code():
             raise ValueError(f'translatedLanguage argument must be either None or have an ISO 639-1 code: \"{translatedLanguage}\"')
-        if not utils.isValidStr(originalText):
+        elif not utils.isValidStr(originalText):
             raise ValueError(f'originalText argument is malformed: \"{originalText}\"')
-        if not utils.isValidStr(translatedText):
+        elif not utils.isValidStr(translatedText):
             raise ValueError(f'translatedText argument is malformed: \"{translatedText}\"')
-        assert isinstance(translationApiSource, TranslationApiSource), f"malformed {translationApiSource=}"
+        elif not isinstance(translationApiSource, TranslationApiSource):
+            raise ValueError(f'translationApiSource argument is malformed: \"{translationApiSource}\"')
 
         self.__originalLanguage: Optional[LanguageEntry] = originalLanguage
         self.__translatedLanguage: Optional[LanguageEntry] = translatedLanguage

--- a/src/CynanBot/language/wordOfTheDayRepository.py
+++ b/src/CynanBot/language/wordOfTheDayRepository.py
@@ -23,12 +23,9 @@ class WordOfTheDayRepository(WordOfTheDayRepositoryInterface):
         timber: TimberInterface,
         cacheTimeDelta: timedelta = timedelta(hours = 1)
     ):
-        if not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(cacheTimeDelta, timedelta):
-            raise ValueError(f'cacheTimeDelta argument is malformed: \"{cacheTimeDelta}\"')
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(cacheTimeDelta, timedelta), f"malformed {cacheTimeDelta=}"
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__timber: TimberInterface = timber
@@ -39,9 +36,8 @@ class WordOfTheDayRepository(WordOfTheDayRepositoryInterface):
         self.__timber.log('WordOfTheDayRepository', 'Caches cleared')
 
     async def fetchWotd(self, languageEntry: LanguageEntry) -> WordOfTheDayResponse:
-        if not isinstance(languageEntry, LanguageEntry):
-            raise ValueError(f'languageEntry argument is malformed: \"{languageEntry}\"')
-        elif not languageEntry.hasWotdApiCode():
+        assert isinstance(languageEntry, LanguageEntry), f"malformed {languageEntry=}"
+        if not languageEntry.hasWotdApiCode():
             raise ValueError(f'the given languageEntry is not supported for Word Of The Day: \"{languageEntry.getName()}\"')
 
         cacheValue = self.__cache[languageEntry.getName()]
@@ -54,9 +50,8 @@ class WordOfTheDayRepository(WordOfTheDayRepositoryInterface):
         return wotd
 
     async def __fetchWotd(self, languageEntry: LanguageEntry) -> WordOfTheDayResponse:
-        if not isinstance(languageEntry, LanguageEntry):
-            raise ValueError(f'languageEntry argument is malformed: \"{languageEntry}\"')
-        elif not languageEntry.hasWotdApiCode():
+        assert isinstance(languageEntry, LanguageEntry), f"malformed {languageEntry=}"
+        if not languageEntry.hasWotdApiCode():
             raise ValueError(f'the given languageEntry is not supported for Word Of The Day: \"{languageEntry.getName()}\"')
 
         self.__timber.log('WordOfTheDayRepository', f'Fetching Word Of The Day for \"{languageEntry.getName()}\" ({languageEntry.getWotdApiCode()})...')

--- a/src/CynanBot/language/wordOfTheDayRepository.py
+++ b/src/CynanBot/language/wordOfTheDayRepository.py
@@ -23,9 +23,12 @@ class WordOfTheDayRepository(WordOfTheDayRepositoryInterface):
         timber: TimberInterface,
         cacheTimeDelta: timedelta = timedelta(hours = 1)
     ):
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(cacheTimeDelta, timedelta), f"malformed {cacheTimeDelta=}"
+        if not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(cacheTimeDelta, timedelta):
+            raise ValueError(f'cacheTimeDelta argument is malformed: \"{cacheTimeDelta}\"')
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__timber: TimberInterface = timber
@@ -36,8 +39,9 @@ class WordOfTheDayRepository(WordOfTheDayRepositoryInterface):
         self.__timber.log('WordOfTheDayRepository', 'Caches cleared')
 
     async def fetchWotd(self, languageEntry: LanguageEntry) -> WordOfTheDayResponse:
-        assert isinstance(languageEntry, LanguageEntry), f"malformed {languageEntry=}"
-        if not languageEntry.hasWotdApiCode():
+        if not isinstance(languageEntry, LanguageEntry):
+            raise ValueError(f'languageEntry argument is malformed: \"{languageEntry}\"')
+        elif not languageEntry.hasWotdApiCode():
             raise ValueError(f'the given languageEntry is not supported for Word Of The Day: \"{languageEntry.getName()}\"')
 
         cacheValue = self.__cache[languageEntry.getName()]
@@ -50,8 +54,9 @@ class WordOfTheDayRepository(WordOfTheDayRepositoryInterface):
         return wotd
 
     async def __fetchWotd(self, languageEntry: LanguageEntry) -> WordOfTheDayResponse:
-        assert isinstance(languageEntry, LanguageEntry), f"malformed {languageEntry=}"
-        if not languageEntry.hasWotdApiCode():
+        if not isinstance(languageEntry, LanguageEntry):
+            raise ValueError(f'languageEntry argument is malformed: \"{languageEntry}\"')
+        elif not languageEntry.hasWotdApiCode():
             raise ValueError(f'the given languageEntry is not supported for Word Of The Day: \"{languageEntry.getName()}\"')
 
         self.__timber.log('WordOfTheDayRepository', f'Fetching Word Of The Day for \"{languageEntry.getName()}\" ({languageEntry.getWotdApiCode()})...')

--- a/src/CynanBot/language/wordOfTheDayResponse.py
+++ b/src/CynanBot/language/wordOfTheDayResponse.py
@@ -16,17 +16,13 @@ class WordOfTheDayResponse():
         transliteration: Optional[str],
         word: str
     ):
-        if not isinstance(languageEntry, LanguageEntry):
-            raise ValueError(f'languageEntry argument is malformed: \"{languageEntry}\"')
-        elif not utils.isValidStr(definition):
+        assert isinstance(languageEntry, LanguageEntry), f"malformed {languageEntry=}"
+        if not utils.isValidStr(definition):
             raise ValueError(f'definition argument is malformed: \"{definition}\"')
-        elif englishExample is not None and not isinstance(englishExample, str):
-            raise ValueError(f'englishExample argument is malformed: \"{englishExample}\"')
-        elif foreignExample is not None and not isinstance(foreignExample, str):
-            raise ValueError(f'foreignExample argument is malformed: \"{foreignExample}\"')
-        elif transliteration is not None and not isinstance(transliteration, str):
-            raise ValueError(f'transliteration argument is malformed: \"{transliteration}\"')
-        elif not utils.isValidStr(word):
+        assert englishExample is None or isinstance(englishExample, str), f"malformed {englishExample=}"
+        assert foreignExample is None or isinstance(foreignExample, str), f"malformed {foreignExample=}"
+        assert transliteration is None or isinstance(transliteration, str), f"malformed {transliteration=}"
+        if not utils.isValidStr(word):
             raise ValueError(f'word argument is malformed: \"{word}\"')
 
         self.__languageEntry: LanguageEntry = languageEntry

--- a/src/CynanBot/language/wordOfTheDayResponse.py
+++ b/src/CynanBot/language/wordOfTheDayResponse.py
@@ -16,13 +16,17 @@ class WordOfTheDayResponse():
         transliteration: Optional[str],
         word: str
     ):
-        assert isinstance(languageEntry, LanguageEntry), f"malformed {languageEntry=}"
-        if not utils.isValidStr(definition):
+        if not isinstance(languageEntry, LanguageEntry):
+            raise ValueError(f'languageEntry argument is malformed: \"{languageEntry}\"')
+        elif not utils.isValidStr(definition):
             raise ValueError(f'definition argument is malformed: \"{definition}\"')
-        assert englishExample is None or isinstance(englishExample, str), f"malformed {englishExample=}"
-        assert foreignExample is None or isinstance(foreignExample, str), f"malformed {foreignExample=}"
-        assert transliteration is None or isinstance(transliteration, str), f"malformed {transliteration=}"
-        if not utils.isValidStr(word):
+        elif englishExample is not None and not isinstance(englishExample, str):
+            raise ValueError(f'englishExample argument is malformed: \"{englishExample}\"')
+        elif foreignExample is not None and not isinstance(foreignExample, str):
+            raise ValueError(f'foreignExample argument is malformed: \"{foreignExample}\"')
+        elif transliteration is not None and not isinstance(transliteration, str):
+            raise ValueError(f'transliteration argument is malformed: \"{transliteration}\"')
+        elif not utils.isValidStr(word):
             raise ValueError(f'word argument is malformed: \"{word}\"')
 
         self.__languageEntry: LanguageEntry = languageEntry

--- a/src/CynanBot/location/location.py
+++ b/src/CynanBot/location/location.py
@@ -16,14 +16,13 @@ class Location():
     ):
         if not utils.isValidNum(latitude):
             raise ValueError(f'latitude argument is malformed: \"{latitude}\"')
-        elif not utils.isValidNum(longitude):
+        if not utils.isValidNum(longitude):
             raise ValueError(f'longitude argument is malformed: \"{longitude}\"')
-        elif not utils.isValidStr(locationId):
+        if not utils.isValidStr(locationId):
             raise ValueError(f'locationId argument is malformed: \"{locationId}\"')
-        elif not utils.isValidStr(name):
+        if not utils.isValidStr(name):
             raise ValueError(f'name argument is malformed: \"{name}\"')
-        elif not isinstance(timeZone, tzinfo):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
 
         self.__latitude: float = latitude
         self.__longitude: float = longitude

--- a/src/CynanBot/location/location.py
+++ b/src/CynanBot/location/location.py
@@ -16,13 +16,14 @@ class Location():
     ):
         if not utils.isValidNum(latitude):
             raise ValueError(f'latitude argument is malformed: \"{latitude}\"')
-        if not utils.isValidNum(longitude):
+        elif not utils.isValidNum(longitude):
             raise ValueError(f'longitude argument is malformed: \"{longitude}\"')
-        if not utils.isValidStr(locationId):
+        elif not utils.isValidStr(locationId):
             raise ValueError(f'locationId argument is malformed: \"{locationId}\"')
-        if not utils.isValidStr(name):
+        elif not utils.isValidStr(name):
             raise ValueError(f'name argument is malformed: \"{name}\"')
-        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
+        elif not isinstance(timeZone, tzinfo):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__latitude: float = latitude
         self.__longitude: float = longitude

--- a/src/CynanBot/location/locationsRepository.py
+++ b/src/CynanBot/location/locationsRepository.py
@@ -18,12 +18,9 @@ class LocationsRepository(LocationsRepositoryInterface):
         timber: TimberInterface,
         timeZoneRepository: TimeZoneRepositoryInterface
     ):
-        if not isinstance(locationsJsonReader, JsonReaderInterface):
-            raise ValueError(f'locationsJsonReader argument is malformed: \"{locationsJsonReader}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(timeZoneRepository, TimeZoneRepositoryInterface):
-            raise ValueError(f'timeZoneRepository argument is malformed: \"{timeZoneRepository}\"')
+        assert isinstance(locationsJsonReader, JsonReaderInterface), f"malformed {locationsJsonReader=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(timeZoneRepository, TimeZoneRepositoryInterface), f"malformed {timeZoneRepository=}"
 
         self.__locationsJsonReader: JsonReaderInterface = locationsJsonReader
         self.__timber: TimberInterface = timber
@@ -70,7 +67,7 @@ class LocationsRepository(LocationsRepositoryInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from locations file: {self.__locationsJsonReader}')
-        elif len(jsonContents) == 0:
+        if len(jsonContents) == 0:
             raise ValueError(f'JSON contents of locations file {self.__locationsJsonReader} is empty')
 
         return jsonContents

--- a/src/CynanBot/location/locationsRepository.py
+++ b/src/CynanBot/location/locationsRepository.py
@@ -18,9 +18,12 @@ class LocationsRepository(LocationsRepositoryInterface):
         timber: TimberInterface,
         timeZoneRepository: TimeZoneRepositoryInterface
     ):
-        assert isinstance(locationsJsonReader, JsonReaderInterface), f"malformed {locationsJsonReader=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(timeZoneRepository, TimeZoneRepositoryInterface), f"malformed {timeZoneRepository=}"
+        if not isinstance(locationsJsonReader, JsonReaderInterface):
+            raise ValueError(f'locationsJsonReader argument is malformed: \"{locationsJsonReader}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(timeZoneRepository, TimeZoneRepositoryInterface):
+            raise ValueError(f'timeZoneRepository argument is malformed: \"{timeZoneRepository}\"')
 
         self.__locationsJsonReader: JsonReaderInterface = locationsJsonReader
         self.__timber: TimberInterface = timber
@@ -67,7 +70,7 @@ class LocationsRepository(LocationsRepositoryInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from locations file: {self.__locationsJsonReader}')
-        if len(jsonContents) == 0:
+        elif len(jsonContents) == 0:
             raise ValueError(f'JSON contents of locations file {self.__locationsJsonReader} is empty')
 
         return jsonContents

--- a/src/CynanBot/misc/simpleDateTime.py
+++ b/src/CynanBot/misc/simpleDateTime.py
@@ -11,10 +11,8 @@ class SimpleDateTime():
         now: Optional[datetime] = None,
         timeZone: tzinfo = timezone.utc
     ):
-        if now is not None and not isinstance(now, datetime):
-            raise TypeError(f'now argument is malformed: \"{now}\"')
-        elif not isinstance(timeZone, tzinfo):
-            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert now is None or isinstance(now, datetime), f"malformed {now=}"
+        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
 
         if now is None:
             self.__now: datetime = datetime.now(timeZone)

--- a/src/CynanBot/misc/simpleDateTime.py
+++ b/src/CynanBot/misc/simpleDateTime.py
@@ -11,8 +11,10 @@ class SimpleDateTime():
         now: Optional[datetime] = None,
         timeZone: tzinfo = timezone.utc
     ):
-        assert now is None or isinstance(now, datetime), f"malformed {now=}"
-        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
+        if now is not None and not isinstance(now, datetime):
+            raise TypeError(f'now argument is malformed: \"{now}\"')
+        elif not isinstance(timeZone, tzinfo):
+            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         if now is None:
             self.__now: datetime = datetime.now(timeZone)

--- a/src/CynanBot/misc/timedDict.py
+++ b/src/CynanBot/misc/timedDict.py
@@ -11,10 +11,8 @@ class TimedDict():
         cacheTimeToLive: timedelta,
         timeZone: tzinfo = timezone.utc
     ):
-        if not isinstance(cacheTimeToLive, timedelta):
-            raise TypeError(f'cacheTimeToLive argument is malformed: \"{cacheTimeToLive}\"')
-        elif not isinstance(timeZone, tzinfo):
-            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(cacheTimeToLive, timedelta), f"malformed {cacheTimeToLive=}"
+        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
 
         self.__cacheTimeToLive: timedelta = cacheTimeToLive
         self.__timeZone: tzinfo = timeZone

--- a/src/CynanBot/misc/timedDict.py
+++ b/src/CynanBot/misc/timedDict.py
@@ -11,8 +11,10 @@ class TimedDict():
         cacheTimeToLive: timedelta,
         timeZone: tzinfo = timezone.utc
     ):
-        assert isinstance(cacheTimeToLive, timedelta), f"malformed {cacheTimeToLive=}"
-        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
+        if not isinstance(cacheTimeToLive, timedelta):
+            raise TypeError(f'cacheTimeToLive argument is malformed: \"{cacheTimeToLive}\"')
+        elif not isinstance(timeZone, tzinfo):
+            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__cacheTimeToLive: timedelta = cacheTimeToLive
         self.__timeZone: tzinfo = timeZone

--- a/src/CynanBot/misc/utils.py
+++ b/src/CynanBot/misc/utils.py
@@ -71,9 +71,9 @@ def cleanStr(
 ) -> str:
     if replacement is None:
         raise ValueError(f'replacement argument is malformed: \"{replacement}\"')
-    elif not isValidBool(htmlUnescape):
+    if not isValidBool(htmlUnescape):
         raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
-    elif not isValidBool(removeCarrots):
+    if not isValidBool(removeCarrots):
         raise ValueError(f'removeCarrots argument is malformed: \"{removeCarrots}\"')
 
     if s is None:
@@ -130,7 +130,7 @@ def formatTime(time) -> str:
 def formatTimeShort(time, includeSeconds: bool = False) -> str:
     if time is None:
         raise ValueError(f'time argument is malformed: \"{time}\"')
-    elif not isValidBool(includeSeconds):
+    if not isValidBool(includeSeconds):
         raise ValueError(f'includeSeconds argument is malformed: \"{includeSeconds}\"')
 
     if includeSeconds:
@@ -141,7 +141,7 @@ def formatTimeShort(time, includeSeconds: bool = False) -> str:
 def getBoolFromDict(d: Optional[Dict[str, Any]], key: str, fallback: Optional[bool] = None) -> bool:
     if not isValidStr(key):
         raise ValueError(f'key argument is malformed: \"{key}\"')
-    elif fallback is not None and not isValidBool(fallback):
+    if fallback is not None and not isValidBool(fallback):
         raise ValueError(f'fallback argument is malformed: \"{fallback}\"')
 
     value: Optional[bool] = None
@@ -218,7 +218,7 @@ def getDateTimeFromStr(text: Optional[str]) -> Optional[datetime]:
 def getFloatFromDict(d: Optional[Dict[str, Any]], key: str, fallback: Optional[float] = None) -> float:
     if not isValidStr(key):
         raise ValueError(f'key argument is malformed: \"{key}\"')
-    elif fallback is not None and not isValidNum(fallback):
+    if fallback is not None and not isValidNum(fallback):
         raise ValueError(f'fallback argument is malformed: \"{fallback}\"')
 
     value: Optional[float] = None
@@ -246,7 +246,7 @@ def getFloatFromDict(d: Optional[Dict[str, Any]], key: str, fallback: Optional[f
 def getIntFromDict(d: Optional[Dict[str, Any]], key: str, fallback: Optional[int] = None) -> int:
     if not isValidStr(key):
         raise ValueError(f'key argument is malformed: \"{key}\"')
-    elif fallback is not None and not isValidNum(fallback):
+    if fallback is not None and not isValidNum(fallback):
         raise ValueError(f'fallback argument is malformed: \"{fallback}\"')
 
     value: Optional[int] = None
@@ -307,13 +307,12 @@ def getStrFromDict(
 ) -> str:
     if not isValidStr(key):
         raise ValueError(f'key argument is malformed: \"{key}\"')
-    elif fallback is not None and not isinstance(fallback, str):
-        raise ValueError(f'fallback argument is malformed: \"{fallback}\"')
-    elif not isValidBool(clean):
+    assert fallback is None or isinstance(fallback, str), f"malformed {fallback=}"
+    if not isValidBool(clean):
         raise ValueError(f'clean argument is malformed: \"{clean}\"')
-    elif not isValidBool(htmlUnescape):
+    if not isValidBool(htmlUnescape):
         raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
-    elif not isValidBool(removeCarrots):
+    if not isValidBool(removeCarrots):
         raise ValueError(f'removeCarrots argument is malformed: \"{removeCarrots}\"')
 
     value: Optional[str] = None
@@ -415,11 +414,11 @@ def splitLongStringIntoMessages(
 ) -> List[str]:
     if not isValidInt(maxMessages):
         raise ValueError(f'maxMessages argument is malformed: \"{maxMessages}\"')
-    elif maxMessages < 1 or maxMessages >= getIntMaxSafeSize():
+    if maxMessages < 1 or maxMessages >= getIntMaxSafeSize():
         raise ValueError(f'maxMessages argument is out of bounds: {maxMessages}')
-    elif not isValidInt(perMessageMaxSize):
+    if not isValidInt(perMessageMaxSize):
         raise ValueError(f'perMessageMaxSize argument is malformed: \"{perMessageMaxSize}\"')
-    elif perMessageMaxSize < 50 or perMessageMaxSize >= getIntMaxSafeSize():
+    if perMessageMaxSize < 50 or perMessageMaxSize >= getIntMaxSafeSize():
         raise ValueError(f'perMessageMaxSize argument is out of bounds: {perMessageMaxSize}')
 
     messages: List[str] = list()

--- a/src/CynanBot/misc/utils.py
+++ b/src/CynanBot/misc/utils.py
@@ -71,9 +71,9 @@ def cleanStr(
 ) -> str:
     if replacement is None:
         raise ValueError(f'replacement argument is malformed: \"{replacement}\"')
-    if not isValidBool(htmlUnescape):
+    elif not isValidBool(htmlUnescape):
         raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
-    if not isValidBool(removeCarrots):
+    elif not isValidBool(removeCarrots):
         raise ValueError(f'removeCarrots argument is malformed: \"{removeCarrots}\"')
 
     if s is None:
@@ -130,7 +130,7 @@ def formatTime(time) -> str:
 def formatTimeShort(time, includeSeconds: bool = False) -> str:
     if time is None:
         raise ValueError(f'time argument is malformed: \"{time}\"')
-    if not isValidBool(includeSeconds):
+    elif not isValidBool(includeSeconds):
         raise ValueError(f'includeSeconds argument is malformed: \"{includeSeconds}\"')
 
     if includeSeconds:
@@ -141,7 +141,7 @@ def formatTimeShort(time, includeSeconds: bool = False) -> str:
 def getBoolFromDict(d: Optional[Dict[str, Any]], key: str, fallback: Optional[bool] = None) -> bool:
     if not isValidStr(key):
         raise ValueError(f'key argument is malformed: \"{key}\"')
-    if fallback is not None and not isValidBool(fallback):
+    elif fallback is not None and not isValidBool(fallback):
         raise ValueError(f'fallback argument is malformed: \"{fallback}\"')
 
     value: Optional[bool] = None
@@ -218,7 +218,7 @@ def getDateTimeFromStr(text: Optional[str]) -> Optional[datetime]:
 def getFloatFromDict(d: Optional[Dict[str, Any]], key: str, fallback: Optional[float] = None) -> float:
     if not isValidStr(key):
         raise ValueError(f'key argument is malformed: \"{key}\"')
-    if fallback is not None and not isValidNum(fallback):
+    elif fallback is not None and not isValidNum(fallback):
         raise ValueError(f'fallback argument is malformed: \"{fallback}\"')
 
     value: Optional[float] = None
@@ -246,7 +246,7 @@ def getFloatFromDict(d: Optional[Dict[str, Any]], key: str, fallback: Optional[f
 def getIntFromDict(d: Optional[Dict[str, Any]], key: str, fallback: Optional[int] = None) -> int:
     if not isValidStr(key):
         raise ValueError(f'key argument is malformed: \"{key}\"')
-    if fallback is not None and not isValidNum(fallback):
+    elif fallback is not None and not isValidNum(fallback):
         raise ValueError(f'fallback argument is malformed: \"{fallback}\"')
 
     value: Optional[int] = None
@@ -307,12 +307,13 @@ def getStrFromDict(
 ) -> str:
     if not isValidStr(key):
         raise ValueError(f'key argument is malformed: \"{key}\"')
-    assert fallback is None or isinstance(fallback, str), f"malformed {fallback=}"
-    if not isValidBool(clean):
+    elif fallback is not None and not isinstance(fallback, str):
+        raise ValueError(f'fallback argument is malformed: \"{fallback}\"')
+    elif not isValidBool(clean):
         raise ValueError(f'clean argument is malformed: \"{clean}\"')
-    if not isValidBool(htmlUnescape):
+    elif not isValidBool(htmlUnescape):
         raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
-    if not isValidBool(removeCarrots):
+    elif not isValidBool(removeCarrots):
         raise ValueError(f'removeCarrots argument is malformed: \"{removeCarrots}\"')
 
     value: Optional[str] = None
@@ -414,11 +415,11 @@ def splitLongStringIntoMessages(
 ) -> List[str]:
     if not isValidInt(maxMessages):
         raise ValueError(f'maxMessages argument is malformed: \"{maxMessages}\"')
-    if maxMessages < 1 or maxMessages >= getIntMaxSafeSize():
+    elif maxMessages < 1 or maxMessages >= getIntMaxSafeSize():
         raise ValueError(f'maxMessages argument is out of bounds: {maxMessages}')
-    if not isValidInt(perMessageMaxSize):
+    elif not isValidInt(perMessageMaxSize):
         raise ValueError(f'perMessageMaxSize argument is malformed: \"{perMessageMaxSize}\"')
-    if perMessageMaxSize < 50 or perMessageMaxSize >= getIntMaxSafeSize():
+    elif perMessageMaxSize < 50 or perMessageMaxSize >= getIntMaxSafeSize():
         raise ValueError(f'perMessageMaxSize argument is out of bounds: {perMessageMaxSize}')
 
     messages: List[str] = list()

--- a/src/CynanBot/mostRecentChat/mostRecentChat.py
+++ b/src/CynanBot/mostRecentChat/mostRecentChat.py
@@ -12,11 +12,10 @@ class MostRecentChat():
         twitchChannelId: str,
         userId: str
     ):
-        if not isinstance(mostRecentChat, SimpleDateTime):
-            raise TypeError(f'mostRecentChat argument is malformed: \"{mostRecentChat}\"')
-        elif not utils.isValidStr(twitchChannelId):
+        assert isinstance(mostRecentChat, SimpleDateTime), f"malformed {mostRecentChat=}"
+        if not utils.isValidStr(twitchChannelId):
             raise TypeError(f'twitchChannelId argument is malformed: \"{twitchChannelId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         self.__mostRecentChat: SimpleDateTime = mostRecentChat

--- a/src/CynanBot/mostRecentChat/mostRecentChat.py
+++ b/src/CynanBot/mostRecentChat/mostRecentChat.py
@@ -12,10 +12,11 @@ class MostRecentChat():
         twitchChannelId: str,
         userId: str
     ):
-        assert isinstance(mostRecentChat, SimpleDateTime), f"malformed {mostRecentChat=}"
-        if not utils.isValidStr(twitchChannelId):
+        if not isinstance(mostRecentChat, SimpleDateTime):
+            raise TypeError(f'mostRecentChat argument is malformed: \"{mostRecentChat}\"')
+        elif not utils.isValidStr(twitchChannelId):
             raise TypeError(f'twitchChannelId argument is malformed: \"{twitchChannelId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         self.__mostRecentChat: SimpleDateTime = mostRecentChat

--- a/src/CynanBot/mostRecentChat/mostRecentChatsRepository.py
+++ b/src/CynanBot/mostRecentChat/mostRecentChatsRepository.py
@@ -24,11 +24,9 @@ class MostRecentChatsRepository(MostRecentChatsRepositoryInterface):
         timber: TimberInterface,
         cacheSize: int = 100
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise TypeError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidInt(cacheSize):
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidInt(cacheSize):
             raise TypeError(f'cacheSize argument is malformed: \"{cacheSize}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
@@ -44,7 +42,7 @@ class MostRecentChatsRepository(MostRecentChatsRepositoryInterface):
     async def get(self, chatterUserId: str, twitchChannelId: str) -> Optional[MostRecentChat]:
         if not utils.isValidStr(chatterUserId):
             raise TypeError(f'chatterUserId argument is malformed: \"{chatterUserId}\"')
-        elif not utils.isValidStr(twitchChannelId):
+        if not utils.isValidStr(twitchChannelId):
             raise TypeError(f'twitchChannelId argument is malformed: \"{twitchChannelId}\"')
 
         cache = self.__caches[twitchChannelId]
@@ -118,7 +116,7 @@ class MostRecentChatsRepository(MostRecentChatsRepositoryInterface):
     async def set(self, chatterUserId: str, twitchChannelId: str):
         if not utils.isValidStr(chatterUserId):
             raise TypeError(f'chatterUserId argument is malformed: \"{chatterUserId}\"')
-        elif not utils.isValidStr(twitchChannelId):
+        if not utils.isValidStr(twitchChannelId):
             raise TypeError(f'twitchChannelId argument is malformed: \"{twitchChannelId}\"')
 
         simpleDateTime = SimpleDateTime()

--- a/src/CynanBot/mostRecentChat/mostRecentChatsRepository.py
+++ b/src/CynanBot/mostRecentChat/mostRecentChatsRepository.py
@@ -24,9 +24,11 @@ class MostRecentChatsRepository(MostRecentChatsRepositoryInterface):
         timber: TimberInterface,
         cacheSize: int = 100
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidInt(cacheSize):
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise TypeError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidInt(cacheSize):
             raise TypeError(f'cacheSize argument is malformed: \"{cacheSize}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
@@ -42,7 +44,7 @@ class MostRecentChatsRepository(MostRecentChatsRepositoryInterface):
     async def get(self, chatterUserId: str, twitchChannelId: str) -> Optional[MostRecentChat]:
         if not utils.isValidStr(chatterUserId):
             raise TypeError(f'chatterUserId argument is malformed: \"{chatterUserId}\"')
-        if not utils.isValidStr(twitchChannelId):
+        elif not utils.isValidStr(twitchChannelId):
             raise TypeError(f'twitchChannelId argument is malformed: \"{twitchChannelId}\"')
 
         cache = self.__caches[twitchChannelId]
@@ -116,7 +118,7 @@ class MostRecentChatsRepository(MostRecentChatsRepositoryInterface):
     async def set(self, chatterUserId: str, twitchChannelId: str):
         if not utils.isValidStr(chatterUserId):
             raise TypeError(f'chatterUserId argument is malformed: \"{chatterUserId}\"')
-        if not utils.isValidStr(twitchChannelId):
+        elif not utils.isValidStr(twitchChannelId):
             raise TypeError(f'twitchChannelId argument is malformed: \"{twitchChannelId}\"')
 
         simpleDateTime = SimpleDateTime()

--- a/src/CynanBot/network/aioHttpClientProvider.py
+++ b/src/CynanBot/network/aioHttpClientProvider.py
@@ -19,13 +19,11 @@ class AioHttpClientProvider(NetworkClientProvider):
         timber: TimberInterface,
         timeoutSeconds: int = 8
     ):
-        if not isinstance(eventLoop, AbstractEventLoop):
-            raise ValueError(f'eventLoop argument is malformed: \"{eventLoop}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidInt(timeoutSeconds):
+        assert isinstance(eventLoop, AbstractEventLoop), f"malformed {eventLoop=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidInt(timeoutSeconds):
             raise ValueError(f'timeoutSeconds argument is malformed: \"{timeoutSeconds}\"')
-        elif timeoutSeconds < 3 or timeoutSeconds > 16:
+        if timeoutSeconds < 3 or timeoutSeconds > 16:
             raise ValueError(f'timeoutSeconds argument is out of bounds: {timeoutSeconds}')
 
         self.__eventLoop: AbstractEventLoop = eventLoop

--- a/src/CynanBot/network/aioHttpClientProvider.py
+++ b/src/CynanBot/network/aioHttpClientProvider.py
@@ -19,11 +19,13 @@ class AioHttpClientProvider(NetworkClientProvider):
         timber: TimberInterface,
         timeoutSeconds: int = 8
     ):
-        assert isinstance(eventLoop, AbstractEventLoop), f"malformed {eventLoop=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidInt(timeoutSeconds):
+        if not isinstance(eventLoop, AbstractEventLoop):
+            raise ValueError(f'eventLoop argument is malformed: \"{eventLoop}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidInt(timeoutSeconds):
             raise ValueError(f'timeoutSeconds argument is malformed: \"{timeoutSeconds}\"')
-        if timeoutSeconds < 3 or timeoutSeconds > 16:
+        elif timeoutSeconds < 3 or timeoutSeconds > 16:
             raise ValueError(f'timeoutSeconds argument is out of bounds: {timeoutSeconds}')
 
         self.__eventLoop: AbstractEventLoop = eventLoop

--- a/src/CynanBot/network/aioHttpHandle.py
+++ b/src/CynanBot/network/aioHttpHandle.py
@@ -19,8 +19,7 @@ class AioHttpHandle(NetworkHandle):
     ):
         if not isinstance(clientSession, aiohttp.ClientSession):
             raise ValueError(f'clientSession argument is malformed: \"{clientSession}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__clientSession: aiohttp.ClientSession = clientSession
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/network/aioHttpHandle.py
+++ b/src/CynanBot/network/aioHttpHandle.py
@@ -19,7 +19,8 @@ class AioHttpHandle(NetworkHandle):
     ):
         if not isinstance(clientSession, aiohttp.ClientSession):
             raise ValueError(f'clientSession argument is malformed: \"{clientSession}\"')
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__clientSession: aiohttp.ClientSession = clientSession
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/network/aioHttpResponse.py
+++ b/src/CynanBot/network/aioHttpResponse.py
@@ -20,10 +20,9 @@ class AioHttpResponse(NetworkResponse):
     ):
         if not isinstance(response, aiohttp.ClientResponse):
             raise ValueError(f'response argument is malformed: \"{response}\"')
-        elif not utils.isValidStr(url):
+        if not utils.isValidStr(url):
             raise ValueError(f'url argument is malformed: \"{url}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__response: aiohttp.ClientResponse = response
         self.__url: str = url

--- a/src/CynanBot/network/aioHttpResponse.py
+++ b/src/CynanBot/network/aioHttpResponse.py
@@ -20,9 +20,10 @@ class AioHttpResponse(NetworkResponse):
     ):
         if not isinstance(response, aiohttp.ClientResponse):
             raise ValueError(f'response argument is malformed: \"{response}\"')
-        if not utils.isValidStr(url):
+        elif not utils.isValidStr(url):
             raise ValueError(f'url argument is malformed: \"{url}\"')
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__response: aiohttp.ClientResponse = response
         self.__url: str = url

--- a/src/CynanBot/network/requestsClientProvider.py
+++ b/src/CynanBot/network/requestsClientProvider.py
@@ -13,11 +13,10 @@ class RequestsClientProvider(NetworkClientProvider):
         timber: TimberInterface,
         timeoutSeconds: int = 8
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidInt(timeoutSeconds):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidInt(timeoutSeconds):
             raise ValueError(f'timeoutSeconds argument is malformed: \"{timeoutSeconds}\"')
-        elif timeoutSeconds < 3 or timeoutSeconds > 16:
+        if timeoutSeconds < 3 or timeoutSeconds > 16:
             raise ValueError(f'timeoutSeconds argument is out of bounds: {timeoutSeconds}')
 
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/network/requestsClientProvider.py
+++ b/src/CynanBot/network/requestsClientProvider.py
@@ -13,10 +13,11 @@ class RequestsClientProvider(NetworkClientProvider):
         timber: TimberInterface,
         timeoutSeconds: int = 8
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidInt(timeoutSeconds):
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidInt(timeoutSeconds):
             raise ValueError(f'timeoutSeconds argument is malformed: \"{timeoutSeconds}\"')
-        if timeoutSeconds < 3 or timeoutSeconds > 16:
+        elif timeoutSeconds < 3 or timeoutSeconds > 16:
             raise ValueError(f'timeoutSeconds argument is out of bounds: {timeoutSeconds}')
 
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/network/requestsHandle.py
+++ b/src/CynanBot/network/requestsHandle.py
@@ -19,11 +19,10 @@ class RequestsHandle(NetworkHandle):
         timber: TimberInterface,
         timeoutSeconds: int = 8
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidInt(timeoutSeconds):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidInt(timeoutSeconds):
             raise ValueError(f'timeoutSeconds argument is malformed: \"{timeoutSeconds}\"')
-        elif timeoutSeconds < 3 or timeoutSeconds > 16:
+        if timeoutSeconds < 3 or timeoutSeconds > 16:
             raise ValueError(f'timeoutSeconds argument is out of bounds: {timeoutSeconds}')
 
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/network/requestsHandle.py
+++ b/src/CynanBot/network/requestsHandle.py
@@ -19,10 +19,11 @@ class RequestsHandle(NetworkHandle):
         timber: TimberInterface,
         timeoutSeconds: int = 8
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidInt(timeoutSeconds):
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidInt(timeoutSeconds):
             raise ValueError(f'timeoutSeconds argument is malformed: \"{timeoutSeconds}\"')
-        if timeoutSeconds < 3 or timeoutSeconds > 16:
+        elif timeoutSeconds < 3 or timeoutSeconds > 16:
             raise ValueError(f'timeoutSeconds argument is out of bounds: {timeoutSeconds}')
 
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/network/requestsResponse.py
+++ b/src/CynanBot/network/requestsResponse.py
@@ -18,12 +18,10 @@ class RequestsResponse(NetworkResponse):
         url: str,
         timber: TimberInterface
     ):
-        if not isinstance(response, Response):
-            raise ValueError(f'response argument is malformed: \"{response}\"')
-        elif not utils.isValidStr(url):
+        assert isinstance(response, Response), f"malformed {response=}"
+        if not utils.isValidStr(url):
             raise ValueError(f'url argument is malformed: \"{url}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__response: Response = response
         self.__url: str = url

--- a/src/CynanBot/network/requestsResponse.py
+++ b/src/CynanBot/network/requestsResponse.py
@@ -18,10 +18,12 @@ class RequestsResponse(NetworkResponse):
         url: str,
         timber: TimberInterface
     ):
-        assert isinstance(response, Response), f"malformed {response=}"
-        if not utils.isValidStr(url):
+        if not isinstance(response, Response):
+            raise ValueError(f'response argument is malformed: \"{response}\"')
+        elif not utils.isValidStr(url):
             raise ValueError(f'url argument is malformed: \"{url}\"')
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__response: Response = response
         self.__url: str = url

--- a/src/CynanBot/pkmn/pokepediaDamageClass.py
+++ b/src/CynanBot/pkmn/pokepediaDamageClass.py
@@ -16,8 +16,7 @@ class PokepediaDamageClass(EnumWithToFromStr):
     # gen 1-3 have damage classes based off element type
     @classmethod
     def getTypeBasedDamageClass(cls, elementType: PokepediaElementType):
-        if not isinstance(elementType, PokepediaElementType):
-            raise ValueError(f'elementType argument is malformed: \"{elementType}\"')
+        assert isinstance(elementType, PokepediaElementType), f"malformed {elementType=}"
 
         physicalElementTypes: Set[PokepediaElementType] = {
             PokepediaElementType.BUG, PokepediaElementType.FIGHTING, PokepediaElementType.FLYING,

--- a/src/CynanBot/pkmn/pokepediaDamageClass.py
+++ b/src/CynanBot/pkmn/pokepediaDamageClass.py
@@ -16,7 +16,8 @@ class PokepediaDamageClass(EnumWithToFromStr):
     # gen 1-3 have damage classes based off element type
     @classmethod
     def getTypeBasedDamageClass(cls, elementType: PokepediaElementType):
-        assert isinstance(elementType, PokepediaElementType), f"malformed {elementType=}"
+        if not isinstance(elementType, PokepediaElementType):
+            raise ValueError(f'elementType argument is malformed: \"{elementType}\"')
 
         physicalElementTypes: Set[PokepediaElementType] = {
             PokepediaElementType.BUG, PokepediaElementType.FIGHTING, PokepediaElementType.FLYING,

--- a/src/CynanBot/pkmn/pokepediaMachine.py
+++ b/src/CynanBot/pkmn/pokepediaMachine.py
@@ -16,15 +16,13 @@ class PokepediaMachine():
     ):
         if not utils.isValidInt(machineId):
             raise ValueError(f'machineId argument is malformed: \"{machineId}\"')
-        elif not utils.isValidInt(machineNumber):
+        if not utils.isValidInt(machineNumber):
             raise ValueError(f'machineNumber argument is malformed: \"{machineNumber}\"')
-        elif not isinstance(generation, PokepediaGeneration):
-            raise ValueError(f'generation argument is malformed: \"{generation}\"')
-        elif not isinstance(machineType, PokepediaMachineType):
-            raise ValueError(f'machineType argment is malformed: \"{machineType}\"')
-        elif not utils.isValidStr(machineName):
+        assert isinstance(generation, PokepediaGeneration), f"malformed {generation=}"
+        assert isinstance(machineType, PokepediaMachineType), f"malformed {machineType=}"
+        if not utils.isValidStr(machineName):
             raise ValueError(f'machineName argument is malformed: \"{machineName}\"')
-        elif not utils.isValidStr(moveName):
+        if not utils.isValidStr(moveName):
             raise ValueError(f'moveName argument is malformed: \"{moveName}\"')
 
         self.__machineId: int = machineId

--- a/src/CynanBot/pkmn/pokepediaMachine.py
+++ b/src/CynanBot/pkmn/pokepediaMachine.py
@@ -16,13 +16,15 @@ class PokepediaMachine():
     ):
         if not utils.isValidInt(machineId):
             raise ValueError(f'machineId argument is malformed: \"{machineId}\"')
-        if not utils.isValidInt(machineNumber):
+        elif not utils.isValidInt(machineNumber):
             raise ValueError(f'machineNumber argument is malformed: \"{machineNumber}\"')
-        assert isinstance(generation, PokepediaGeneration), f"malformed {generation=}"
-        assert isinstance(machineType, PokepediaMachineType), f"malformed {machineType=}"
-        if not utils.isValidStr(machineName):
+        elif not isinstance(generation, PokepediaGeneration):
+            raise ValueError(f'generation argument is malformed: \"{generation}\"')
+        elif not isinstance(machineType, PokepediaMachineType):
+            raise ValueError(f'machineType argment is malformed: \"{machineType}\"')
+        elif not utils.isValidStr(machineName):
             raise ValueError(f'machineName argument is malformed: \"{machineName}\"')
-        if not utils.isValidStr(moveName):
+        elif not utils.isValidStr(moveName):
             raise ValueError(f'moveName argument is malformed: \"{moveName}\"')
 
         self.__machineId: int = machineId

--- a/src/CynanBot/pkmn/pokepediaMove.py
+++ b/src/CynanBot/pkmn/pokepediaMove.py
@@ -25,27 +25,24 @@ class PokepediaMove():
         name: str,
         rawName: str
     ):
-        if contestType is not None and not isinstance(contestType, PokepediaContestType):
-            raise ValueError(f'contestType argument is malformed: \"{contestType}\"')
-        elif not isinstance(damageClass, PokepediaDamageClass):
-            raise ValueError(f'damageClass argument is malformed: \"{damageClass}\"')
-        elif not utils.hasItems(generationMoves):
+        assert contestType is None or isinstance(contestType, PokepediaContestType), f"malformed {contestType=}"
+        assert isinstance(damageClass, PokepediaDamageClass), f"malformed {damageClass=}"
+        if not utils.hasItems(generationMoves):
             raise ValueError(f'generationMoves argument is malformed: \"{generationMoves}\"')
-        elif not utils.isValidInt(critRate):
+        if not utils.isValidInt(critRate):
             raise ValueError(f'critRate argument is malformed: \"{critRate}\"')
-        elif not utils.isValidInt(drain):
+        if not utils.isValidInt(drain):
             raise ValueError(f'drain argument is malformed: \"{drain}\"')
-        elif not utils.isValidInt(flinchChance):
+        if not utils.isValidInt(flinchChance):
             raise ValueError(f'flinchChance argument is malformed: \"{flinchChance}\"')
-        elif not utils.isValidInt(moveId):
+        if not utils.isValidInt(moveId):
             raise ValueError(f'moveId argument is malformed: \"{moveId}\"')
-        elif not isinstance(initialGeneration, PokepediaGeneration):
-            raise ValueError(f'initialGeneration argument is malformed: \"{initialGeneration}\"')
-        elif not utils.isValidStr(description):
+        assert isinstance(initialGeneration, PokepediaGeneration), f"malformed {initialGeneration=}"
+        if not utils.isValidStr(description):
             raise ValueError(f'description argument is malformed: \"{description}\"')
-        elif not utils.isValidStr(name):
+        if not utils.isValidStr(name):
             raise ValueError(f'name argument is malformed: \"{name}\"')
-        elif not utils.isValidStr(rawName):
+        if not utils.isValidStr(rawName):
             raise ValueError(f'rawName argument is malformed: \"{rawName}\"')
 
         self.__contestType: Optional[PokepediaContestType] = contestType

--- a/src/CynanBot/pkmn/pokepediaMove.py
+++ b/src/CynanBot/pkmn/pokepediaMove.py
@@ -25,24 +25,27 @@ class PokepediaMove():
         name: str,
         rawName: str
     ):
-        assert contestType is None or isinstance(contestType, PokepediaContestType), f"malformed {contestType=}"
-        assert isinstance(damageClass, PokepediaDamageClass), f"malformed {damageClass=}"
-        if not utils.hasItems(generationMoves):
+        if contestType is not None and not isinstance(contestType, PokepediaContestType):
+            raise ValueError(f'contestType argument is malformed: \"{contestType}\"')
+        elif not isinstance(damageClass, PokepediaDamageClass):
+            raise ValueError(f'damageClass argument is malformed: \"{damageClass}\"')
+        elif not utils.hasItems(generationMoves):
             raise ValueError(f'generationMoves argument is malformed: \"{generationMoves}\"')
-        if not utils.isValidInt(critRate):
+        elif not utils.isValidInt(critRate):
             raise ValueError(f'critRate argument is malformed: \"{critRate}\"')
-        if not utils.isValidInt(drain):
+        elif not utils.isValidInt(drain):
             raise ValueError(f'drain argument is malformed: \"{drain}\"')
-        if not utils.isValidInt(flinchChance):
+        elif not utils.isValidInt(flinchChance):
             raise ValueError(f'flinchChance argument is malformed: \"{flinchChance}\"')
-        if not utils.isValidInt(moveId):
+        elif not utils.isValidInt(moveId):
             raise ValueError(f'moveId argument is malformed: \"{moveId}\"')
-        assert isinstance(initialGeneration, PokepediaGeneration), f"malformed {initialGeneration=}"
-        if not utils.isValidStr(description):
+        elif not isinstance(initialGeneration, PokepediaGeneration):
+            raise ValueError(f'initialGeneration argument is malformed: \"{initialGeneration}\"')
+        elif not utils.isValidStr(description):
             raise ValueError(f'description argument is malformed: \"{description}\"')
-        if not utils.isValidStr(name):
+        elif not utils.isValidStr(name):
             raise ValueError(f'name argument is malformed: \"{name}\"')
-        if not utils.isValidStr(rawName):
+        elif not utils.isValidStr(rawName):
             raise ValueError(f'rawName argument is malformed: \"{rawName}\"')
 
         self.__contestType: Optional[PokepediaContestType] = contestType

--- a/src/CynanBot/pkmn/pokepediaMoveGeneration.py
+++ b/src/CynanBot/pkmn/pokepediaMoveGeneration.py
@@ -20,12 +20,9 @@ class PokepediaMoveGeneration():
     ):
         if not utils.isValidNum(pp):
             raise ValueError(f'pp argument is malformed: \"{pp}\"')
-        elif not isinstance(damageClass, PokepediaDamageClass):
-            raise ValueError(f'damageClass argument is malformed: \"{damageClass}\"')
-        elif not isinstance(elementType, PokepediaElementType):
-            raise ValueError(f'elementType argument is malformed: \"{elementType}\"')
-        elif not isinstance(generation, PokepediaGeneration):
-            raise ValueError(f'generation argument is malformed: \"{generation}\"')
+        assert isinstance(damageClass, PokepediaDamageClass), f"malformed {damageClass=}"
+        assert isinstance(elementType, PokepediaElementType), f"malformed {elementType=}"
+        assert isinstance(generation, PokepediaGeneration), f"malformed {generation=}"
 
         self.__accuracy: Optional[int] = accuracy
         self.__power: Optional[int] = power

--- a/src/CynanBot/pkmn/pokepediaMoveGeneration.py
+++ b/src/CynanBot/pkmn/pokepediaMoveGeneration.py
@@ -20,9 +20,12 @@ class PokepediaMoveGeneration():
     ):
         if not utils.isValidNum(pp):
             raise ValueError(f'pp argument is malformed: \"{pp}\"')
-        assert isinstance(damageClass, PokepediaDamageClass), f"malformed {damageClass=}"
-        assert isinstance(elementType, PokepediaElementType), f"malformed {elementType=}"
-        assert isinstance(generation, PokepediaGeneration), f"malformed {generation=}"
+        elif not isinstance(damageClass, PokepediaDamageClass):
+            raise ValueError(f'damageClass argument is malformed: \"{damageClass}\"')
+        elif not isinstance(elementType, PokepediaElementType):
+            raise ValueError(f'elementType argument is malformed: \"{elementType}\"')
+        elif not isinstance(generation, PokepediaGeneration):
+            raise ValueError(f'generation argument is malformed: \"{generation}\"')
 
         self.__accuracy: Optional[int] = accuracy
         self.__power: Optional[int] = power

--- a/src/CynanBot/pkmn/pokepediaPokemon.py
+++ b/src/CynanBot/pkmn/pokepediaPokemon.py
@@ -21,15 +21,14 @@ class PokepediaPokemon():
     ):
         if not utils.hasItems(generationElementTypes):
             raise ValueError(f'generationElementTypes argument is malformed: \"{generationElementTypes}\"')
-        elif not isinstance(initialGeneration, PokepediaGeneration):
-            raise ValueError(f'initialGeneration argument is malformed: \"{initialGeneration}\"')
-        elif not utils.isValidNum(height):
+        assert isinstance(initialGeneration, PokepediaGeneration), f"malformed {initialGeneration=}"
+        if not utils.isValidNum(height):
             raise ValueError(f'height argument is malformed: \"{height}\"')
-        elif not utils.isValidNum(pokedexId):
+        if not utils.isValidNum(pokedexId):
             raise ValueError(f'pokedexId argument is malformed: \"{pokedexId}\"')
-        elif not utils.isValidNum(weight):
+        if not utils.isValidNum(weight):
             raise ValueError(f'weight argument is malformed: \"{weight}\"')
-        elif not utils.isValidStr(name):
+        if not utils.isValidStr(name):
             raise ValueError(f'name argument is malformed: \"{name}\"')
 
         self.__generationElementTypes: Dict[PokepediaGeneration, List[PokepediaElementType]] = generationElementTypes
@@ -47,10 +46,8 @@ class PokepediaPokemon():
     ) -> Optional[str]:
         if not utils.hasItems(weaknessesAndResistances):
             raise ValueError(f'weaknessesAndResistances argument is malformed: \"{weaknessesAndResistances}\"')
-        elif not isinstance(damageMultiplier, PokepediaDamageMultiplier):
-            raise ValueError(f'damageMultiplier argument is malformed: \"{damageMultiplier}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(damageMultiplier, PokepediaDamageMultiplier), f"malformed {damageMultiplier=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         if damageMultiplier not in weaknessesAndResistances or not utils.hasItems(weaknessesAndResistances[damageMultiplier]):
             return None
@@ -66,8 +63,7 @@ class PokepediaPokemon():
         self,
         generation: PokepediaGeneration
     ) -> List[PokepediaElementType]:
-        if not isinstance(generation, PokepediaGeneration):
-            raise ValueError(f'generation argument is malformed: \"{generation}\"')
+        assert isinstance(generation, PokepediaGeneration), f"malformed {generation=}"
 
         allGenerations = list(PokepediaGeneration)
         index = allGenerations.index(generation)
@@ -108,8 +104,7 @@ class PokepediaPokemon():
         return locale.format_string("%d", self.__weight, grouping = True)
 
     def toStrList(self, delimiter: str = ', ') -> List[str]:
-        if not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         strings: List[str] = list()
         strings.append(f'{self.__name} (#{self.getPokedexIdStr()}) — introduced in {self.__initialGeneration.toShortStr()}, weight is {self.getWeightStr()} and height is {self.getHeightStr()}.')

--- a/src/CynanBot/pkmn/pokepediaPokemon.py
+++ b/src/CynanBot/pkmn/pokepediaPokemon.py
@@ -21,14 +21,15 @@ class PokepediaPokemon():
     ):
         if not utils.hasItems(generationElementTypes):
             raise ValueError(f'generationElementTypes argument is malformed: \"{generationElementTypes}\"')
-        assert isinstance(initialGeneration, PokepediaGeneration), f"malformed {initialGeneration=}"
-        if not utils.isValidNum(height):
+        elif not isinstance(initialGeneration, PokepediaGeneration):
+            raise ValueError(f'initialGeneration argument is malformed: \"{initialGeneration}\"')
+        elif not utils.isValidNum(height):
             raise ValueError(f'height argument is malformed: \"{height}\"')
-        if not utils.isValidNum(pokedexId):
+        elif not utils.isValidNum(pokedexId):
             raise ValueError(f'pokedexId argument is malformed: \"{pokedexId}\"')
-        if not utils.isValidNum(weight):
+        elif not utils.isValidNum(weight):
             raise ValueError(f'weight argument is malformed: \"{weight}\"')
-        if not utils.isValidStr(name):
+        elif not utils.isValidStr(name):
             raise ValueError(f'name argument is malformed: \"{name}\"')
 
         self.__generationElementTypes: Dict[PokepediaGeneration, List[PokepediaElementType]] = generationElementTypes
@@ -46,8 +47,10 @@ class PokepediaPokemon():
     ) -> Optional[str]:
         if not utils.hasItems(weaknessesAndResistances):
             raise ValueError(f'weaknessesAndResistances argument is malformed: \"{weaknessesAndResistances}\"')
-        assert isinstance(damageMultiplier, PokepediaDamageMultiplier), f"malformed {damageMultiplier=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif not isinstance(damageMultiplier, PokepediaDamageMultiplier):
+            raise ValueError(f'damageMultiplier argument is malformed: \"{damageMultiplier}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         if damageMultiplier not in weaknessesAndResistances or not utils.hasItems(weaknessesAndResistances[damageMultiplier]):
             return None
@@ -63,7 +66,8 @@ class PokepediaPokemon():
         self,
         generation: PokepediaGeneration
     ) -> List[PokepediaElementType]:
-        assert isinstance(generation, PokepediaGeneration), f"malformed {generation=}"
+        if not isinstance(generation, PokepediaGeneration):
+            raise ValueError(f'generation argument is malformed: \"{generation}\"')
 
         allGenerations = list(PokepediaGeneration)
         index = allGenerations.index(generation)
@@ -104,7 +108,8 @@ class PokepediaPokemon():
         return locale.format_string("%d", self.__weight, grouping = True)
 
     def toStrList(self, delimiter: str = ', ') -> List[str]:
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         strings: List[str] = list()
         strings.append(f'{self.__name} (#{self.getPokedexIdStr()}) — introduced in {self.__initialGeneration.toShortStr()}, weight is {self.getWeightStr()} and height is {self.getHeightStr()}.')

--- a/src/CynanBot/pkmn/pokepediaRepository.py
+++ b/src/CynanBot/pkmn/pokepediaRepository.py
@@ -29,12 +29,9 @@ class PokepediaRepository():
         pokepediaUtils: PokepediaUtilsInterface,
         timber: TimberInterface
     ):
-        if not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not isinstance(pokepediaUtils, PokepediaUtilsInterface):
-            raise ValueError(f'pokepediaUtils argument is malformed: \"{pokepediaUtils}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert isinstance(pokepediaUtils, PokepediaUtilsInterface), f"malformed {pokepediaUtils=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__pokepediaUtils: PokepediaUtilsInterface = pokepediaUtils
@@ -223,8 +220,7 @@ class PokepediaRepository():
         return PokepediaNature.fromInt(natureId)
 
     async def fetchRandomMove(self, maxGeneration: PokepediaGeneration) -> PokepediaMove:
-        if not isinstance(maxGeneration, PokepediaGeneration):
-            raise ValueError(f'maxGeneration argument is malformed: \"{maxGeneration}\"')
+        assert isinstance(maxGeneration, PokepediaGeneration), f"malformed {maxGeneration=}"
 
         randomMoveId = random.randint(1, maxGeneration.getMaxMoveId())
         return await self.fetchMove(randomMoveId)
@@ -235,8 +231,7 @@ class PokepediaRepository():
         return await self.fetchNature(randomNature.getNatureId())
 
     async def fetchRandomPokemon(self, maxGeneration: PokepediaGeneration) -> PokepediaPokemon:
-        if not isinstance(maxGeneration, PokepediaGeneration):
-            raise ValueError(f'maxGeneration argument is malformed: \"{maxGeneration}\"')
+        assert isinstance(maxGeneration, PokepediaGeneration), f"malformed {maxGeneration=}"
 
         randomPokemonId = random.randint(1, maxGeneration.getMaxPokedexId())
         clientSession = await self.__networkClientProvider.get()
@@ -278,8 +273,7 @@ class PokepediaRepository():
     ) -> Dict[PokepediaGeneration, List[PokepediaElementType]]:
         if jsonResponse is None:
             raise ValueError(f'jsonResponse argument is malformed: \"{jsonResponse}\"')
-        elif not isinstance(initialGeneration, PokepediaGeneration):
-            raise ValueError(f'initialGeneration argument is malformed: \"{initialGeneration}\"')
+        assert isinstance(initialGeneration, PokepediaGeneration), f"malformed {initialGeneration=}"
 
         currentTypesJson: Optional[List[Dict[str, Any]]] = jsonResponse.get('types')
         if not utils.hasItems(currentTypesJson):

--- a/src/CynanBot/pkmn/pokepediaRepository.py
+++ b/src/CynanBot/pkmn/pokepediaRepository.py
@@ -29,9 +29,12 @@ class PokepediaRepository():
         pokepediaUtils: PokepediaUtilsInterface,
         timber: TimberInterface
     ):
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert isinstance(pokepediaUtils, PokepediaUtilsInterface), f"malformed {pokepediaUtils=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not isinstance(pokepediaUtils, PokepediaUtilsInterface):
+            raise ValueError(f'pokepediaUtils argument is malformed: \"{pokepediaUtils}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__pokepediaUtils: PokepediaUtilsInterface = pokepediaUtils
@@ -220,7 +223,8 @@ class PokepediaRepository():
         return PokepediaNature.fromInt(natureId)
 
     async def fetchRandomMove(self, maxGeneration: PokepediaGeneration) -> PokepediaMove:
-        assert isinstance(maxGeneration, PokepediaGeneration), f"malformed {maxGeneration=}"
+        if not isinstance(maxGeneration, PokepediaGeneration):
+            raise ValueError(f'maxGeneration argument is malformed: \"{maxGeneration}\"')
 
         randomMoveId = random.randint(1, maxGeneration.getMaxMoveId())
         return await self.fetchMove(randomMoveId)
@@ -231,7 +235,8 @@ class PokepediaRepository():
         return await self.fetchNature(randomNature.getNatureId())
 
     async def fetchRandomPokemon(self, maxGeneration: PokepediaGeneration) -> PokepediaPokemon:
-        assert isinstance(maxGeneration, PokepediaGeneration), f"malformed {maxGeneration=}"
+        if not isinstance(maxGeneration, PokepediaGeneration):
+            raise ValueError(f'maxGeneration argument is malformed: \"{maxGeneration}\"')
 
         randomPokemonId = random.randint(1, maxGeneration.getMaxPokedexId())
         clientSession = await self.__networkClientProvider.get()
@@ -273,7 +278,8 @@ class PokepediaRepository():
     ) -> Dict[PokepediaGeneration, List[PokepediaElementType]]:
         if jsonResponse is None:
             raise ValueError(f'jsonResponse argument is malformed: \"{jsonResponse}\"')
-        assert isinstance(initialGeneration, PokepediaGeneration), f"malformed {initialGeneration=}"
+        elif not isinstance(initialGeneration, PokepediaGeneration):
+            raise ValueError(f'initialGeneration argument is malformed: \"{initialGeneration}\"')
 
         currentTypesJson: Optional[List[Dict[str, Any]]] = jsonResponse.get('types')
         if not utils.hasItems(currentTypesJson):

--- a/src/CynanBot/pkmn/pokepediaTypeChart.py
+++ b/src/CynanBot/pkmn/pokepediaTypeChart.py
@@ -22,7 +22,7 @@ class PokepediaTypeChart(Enum):
     ) -> Dict[PokepediaDamageMultiplier, List[PokepediaElementType]]:
         if noEffect is None:
             raise ValueError(f'noEffect argument is malformed: \"{noEffect}\"')
-        elif resistances is None:
+        if resistances is None:
             raise ValueError(f'resistances argument is malformed: \"{resistances}\"')
         if weaknesses is None:
             raise ValueError(f'noEffect argument is malformed: \"{weaknesses}\"')
@@ -100,8 +100,7 @@ class PokepediaTypeChart(Enum):
 
     @classmethod
     def fromPokepediaGeneration(cls, pokepediaGeneration: PokepediaGeneration):
-        if not isinstance(pokepediaGeneration, PokepediaGeneration):
-            raise ValueError(f'pokepediaGeneration argument is malformed: \"{pokepediaGeneration}\"')
+        assert isinstance(pokepediaGeneration, PokepediaGeneration), f"malformed {pokepediaGeneration=}"
 
         if pokepediaGeneration is PokepediaGeneration.GENERATION_1:
             return PokepediaTypeChart.GENERATION_1
@@ -132,7 +131,7 @@ class PokepediaTypeChart(Enum):
                 weaknesses.append(PokepediaElementType.ROCK)
             elif elementType is PokepediaElementType.DARK:
                 raise ValueError(f'illegal PokepediaElementType for this type chart ({self}): \"{elementType}\"')
-            elif elementType is PokepediaElementType.DRAGON:
+            if elementType is PokepediaElementType.DRAGON:
                 resistances.append(PokepediaElementType.ELECTRIC)
                 resistances.append(PokepediaElementType.FIRE)
                 resistances.append(PokepediaElementType.GRASS)
@@ -145,7 +144,7 @@ class PokepediaTypeChart(Enum):
                 weaknesses.append(PokepediaElementType.GROUND)
             elif elementType is PokepediaElementType.FAIRY:
                 raise ValueError(f'illegal PokepediaElementType for this type chart ({self}): \"{elementType}\"')
-            elif elementType is PokepediaElementType.FIGHTING:
+            if elementType is PokepediaElementType.FIGHTING:
                 resistances.append(PokepediaElementType.BUG)
                 resistances.append(PokepediaElementType.ROCK)
                 weaknesses.append(PokepediaElementType.FLYING)
@@ -219,9 +218,9 @@ class PokepediaTypeChart(Enum):
                 weaknesses.append(PokepediaElementType.WATER)
             elif elementType is PokepediaElementType.STEEL:
                 raise ValueError(f'illegal PokepediaElementType for this type chart ({self}): \"{elementType}\"')
-            elif elementType is PokepediaElementType.UNKNOWN:
+            if elementType is PokepediaElementType.UNKNOWN:
                 raise ValueError(f'illegal PokepediaElementType for this type chart ({self}): \"{elementType}\"')
-            elif elementType is PokepediaElementType.WATER:
+            if elementType is PokepediaElementType.WATER:
                 resistances.append(PokepediaElementType.FIRE)
                 resistances.append(PokepediaElementType.ICE)
                 resistances.append(PokepediaElementType.WATER)
@@ -274,7 +273,7 @@ class PokepediaTypeChart(Enum):
                 weaknesses.append(PokepediaElementType.GROUND)
             elif elementType is PokepediaElementType.FAIRY:
                 raise ValueError(f'illegal PokepediaElementType for this type chart ({self}): \"{elementType}\"')
-            elif elementType is PokepediaElementType.FIGHTING:
+            if elementType is PokepediaElementType.FIGHTING:
                 resistances.append(PokepediaElementType.BUG)
                 resistances.append(PokepediaElementType.DARK)
                 resistances.append(PokepediaElementType.ROCK)

--- a/src/CynanBot/pkmn/pokepediaTypeChart.py
+++ b/src/CynanBot/pkmn/pokepediaTypeChart.py
@@ -22,7 +22,7 @@ class PokepediaTypeChart(Enum):
     ) -> Dict[PokepediaDamageMultiplier, List[PokepediaElementType]]:
         if noEffect is None:
             raise ValueError(f'noEffect argument is malformed: \"{noEffect}\"')
-        if resistances is None:
+        elif resistances is None:
             raise ValueError(f'resistances argument is malformed: \"{resistances}\"')
         if weaknesses is None:
             raise ValueError(f'noEffect argument is malformed: \"{weaknesses}\"')
@@ -100,7 +100,8 @@ class PokepediaTypeChart(Enum):
 
     @classmethod
     def fromPokepediaGeneration(cls, pokepediaGeneration: PokepediaGeneration):
-        assert isinstance(pokepediaGeneration, PokepediaGeneration), f"malformed {pokepediaGeneration=}"
+        if not isinstance(pokepediaGeneration, PokepediaGeneration):
+            raise ValueError(f'pokepediaGeneration argument is malformed: \"{pokepediaGeneration}\"')
 
         if pokepediaGeneration is PokepediaGeneration.GENERATION_1:
             return PokepediaTypeChart.GENERATION_1
@@ -131,7 +132,7 @@ class PokepediaTypeChart(Enum):
                 weaknesses.append(PokepediaElementType.ROCK)
             elif elementType is PokepediaElementType.DARK:
                 raise ValueError(f'illegal PokepediaElementType for this type chart ({self}): \"{elementType}\"')
-            if elementType is PokepediaElementType.DRAGON:
+            elif elementType is PokepediaElementType.DRAGON:
                 resistances.append(PokepediaElementType.ELECTRIC)
                 resistances.append(PokepediaElementType.FIRE)
                 resistances.append(PokepediaElementType.GRASS)
@@ -144,7 +145,7 @@ class PokepediaTypeChart(Enum):
                 weaknesses.append(PokepediaElementType.GROUND)
             elif elementType is PokepediaElementType.FAIRY:
                 raise ValueError(f'illegal PokepediaElementType for this type chart ({self}): \"{elementType}\"')
-            if elementType is PokepediaElementType.FIGHTING:
+            elif elementType is PokepediaElementType.FIGHTING:
                 resistances.append(PokepediaElementType.BUG)
                 resistances.append(PokepediaElementType.ROCK)
                 weaknesses.append(PokepediaElementType.FLYING)
@@ -218,9 +219,9 @@ class PokepediaTypeChart(Enum):
                 weaknesses.append(PokepediaElementType.WATER)
             elif elementType is PokepediaElementType.STEEL:
                 raise ValueError(f'illegal PokepediaElementType for this type chart ({self}): \"{elementType}\"')
-            if elementType is PokepediaElementType.UNKNOWN:
+            elif elementType is PokepediaElementType.UNKNOWN:
                 raise ValueError(f'illegal PokepediaElementType for this type chart ({self}): \"{elementType}\"')
-            if elementType is PokepediaElementType.WATER:
+            elif elementType is PokepediaElementType.WATER:
                 resistances.append(PokepediaElementType.FIRE)
                 resistances.append(PokepediaElementType.ICE)
                 resistances.append(PokepediaElementType.WATER)
@@ -273,7 +274,7 @@ class PokepediaTypeChart(Enum):
                 weaknesses.append(PokepediaElementType.GROUND)
             elif elementType is PokepediaElementType.FAIRY:
                 raise ValueError(f'illegal PokepediaElementType for this type chart ({self}): \"{elementType}\"')
-            if elementType is PokepediaElementType.FIGHTING:
+            elif elementType is PokepediaElementType.FIGHTING:
                 resistances.append(PokepediaElementType.BUG)
                 resistances.append(PokepediaElementType.DARK)
                 resistances.append(PokepediaElementType.ROCK)

--- a/src/CynanBot/pkmn/pokepediaUtils.py
+++ b/src/CynanBot/pkmn/pokepediaUtils.py
@@ -10,8 +10,7 @@ from CynanBot.timber.timberInterface import TimberInterface
 class PokepediaUtils(PokepediaUtilsInterface):
 
     def __init__(self, timber: TimberInterface):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__timber: TimberInterface = timber
 

--- a/src/CynanBot/pkmn/pokepediaUtils.py
+++ b/src/CynanBot/pkmn/pokepediaUtils.py
@@ -10,7 +10,8 @@ from CynanBot.timber.timberInterface import TimberInterface
 class PokepediaUtils(PokepediaUtilsInterface):
 
     def __init__(self, timber: TimberInterface):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__timber: TimberInterface = timber
 

--- a/src/CynanBot/pointRedemptions.py
+++ b/src/CynanBot/pointRedemptions.py
@@ -33,12 +33,9 @@ class CutenessRedemption(AbsChannelPointRedemption):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
-            raise TypeError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__timber: TimberInterface = timber
@@ -91,14 +88,10 @@ class PkmnBattleRedemption(AbsChannelPointRedemption):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        if not isinstance(funtoonRepository, FuntoonRepositoryInterface):
-            raise TypeError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        assert isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
 
         self.__funtoonRepository: FuntoonRepositoryInterface = funtoonRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -149,14 +142,10 @@ class PkmnCatchRedemption(AbsChannelPointRedemption):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        if not isinstance(funtoonRepository, FuntoonRepositoryInterface):
-            raise ValueError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        assert isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
 
         self.__funtoonRepository: FuntoonRepositoryInterface = funtoonRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -213,8 +202,7 @@ class PkmnCatchRedemption(AbsChannelPointRedemption):
         self,
         pkmnCatchBoosterPack: PkmnCatchBoosterPack
     ) -> FuntoonPkmnCatchType:
-        if not isinstance(pkmnCatchBoosterPack, PkmnCatchBoosterPack):
-            raise ValueError(f'pkmnCatchBoosterPack argument is malformed: \"{pkmnCatchBoosterPack}\"')
+        assert isinstance(pkmnCatchBoosterPack, PkmnCatchBoosterPack), f"malformed {pkmnCatchBoosterPack=}"
 
         if pkmnCatchBoosterPack.getCatchType() is PkmnCatchType.NORMAL:
             return FuntoonPkmnCatchType.NORMAL
@@ -235,14 +223,10 @@ class PkmnEvolveRedemption(AbsChannelPointRedemption):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        if not isinstance(funtoonRepository, FuntoonRepositoryInterface):
-            raise ValueError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        assert isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
 
         self.__funtoonRepository: FuntoonRepositoryInterface = funtoonRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -285,14 +269,10 @@ class PkmnShinyRedemption(AbsChannelPointRedemption):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        if not isinstance(funtoonRepository, FuntoonRepositoryInterface):
-            raise ValueError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
-        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
-            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchUtils, TwitchUtilsInterface):
-            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
+        assert isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
+        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
 
         self.__funtoonRepository: FuntoonRepositoryInterface = funtoonRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -334,12 +314,9 @@ class SuperTriviaGameRedemption(AbsChannelPointRedemption):
         triviaGameBuilder: TriviaGameBuilderInterface,
         triviaGameMachine: TriviaGameMachineInterface,
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
-            raise ValueError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
-        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
-            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
+        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
 
         self.__timber: TimberInterface = timber
         self.__triviaGameBuilder: TriviaGameBuilderInterface = triviaGameBuilder
@@ -371,12 +348,9 @@ class TriviaGameRedemption(AbsChannelPointRedemption):
         triviaGameBuilder: TriviaGameBuilderInterface,
         triviaGameMachine: TriviaGameMachineInterface,
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
-            raise ValueError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
-        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
-            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
+        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
 
         self.__timber: TimberInterface = timber
         self.__triviaGameBuilder: TriviaGameBuilderInterface = triviaGameBuilder

--- a/src/CynanBot/pointRedemptions.py
+++ b/src/CynanBot/pointRedemptions.py
@@ -33,9 +33,12 @@ class CutenessRedemption(AbsChannelPointRedemption):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
+            raise TypeError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__timber: TimberInterface = timber
@@ -88,10 +91,14 @@ class PkmnBattleRedemption(AbsChannelPointRedemption):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        assert isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not isinstance(funtoonRepository, FuntoonRepositoryInterface):
+            raise TypeError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise TypeError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise TypeError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
 
         self.__funtoonRepository: FuntoonRepositoryInterface = funtoonRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -142,10 +149,14 @@ class PkmnCatchRedemption(AbsChannelPointRedemption):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        assert isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not isinstance(funtoonRepository, FuntoonRepositoryInterface):
+            raise ValueError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
 
         self.__funtoonRepository: FuntoonRepositoryInterface = funtoonRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -202,7 +213,8 @@ class PkmnCatchRedemption(AbsChannelPointRedemption):
         self,
         pkmnCatchBoosterPack: PkmnCatchBoosterPack
     ) -> FuntoonPkmnCatchType:
-        assert isinstance(pkmnCatchBoosterPack, PkmnCatchBoosterPack), f"malformed {pkmnCatchBoosterPack=}"
+        if not isinstance(pkmnCatchBoosterPack, PkmnCatchBoosterPack):
+            raise ValueError(f'pkmnCatchBoosterPack argument is malformed: \"{pkmnCatchBoosterPack}\"')
 
         if pkmnCatchBoosterPack.getCatchType() is PkmnCatchType.NORMAL:
             return FuntoonPkmnCatchType.NORMAL
@@ -223,10 +235,14 @@ class PkmnEvolveRedemption(AbsChannelPointRedemption):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        assert isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not isinstance(funtoonRepository, FuntoonRepositoryInterface):
+            raise ValueError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
 
         self.__funtoonRepository: FuntoonRepositoryInterface = funtoonRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -269,10 +285,14 @@ class PkmnShinyRedemption(AbsChannelPointRedemption):
         timber: TimberInterface,
         twitchUtils: TwitchUtilsInterface
     ):
-        assert isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
-        assert isinstance(generalSettingsRepository, GeneralSettingsRepository), f"malformed {generalSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchUtils, TwitchUtilsInterface), f"malformed {twitchUtils=}"
+        if not isinstance(funtoonRepository, FuntoonRepositoryInterface):
+            raise ValueError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
+        elif not isinstance(generalSettingsRepository, GeneralSettingsRepository):
+            raise ValueError(f'generalSettingsRepository argument is malformed: \"{generalSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchUtils, TwitchUtilsInterface):
+            raise ValueError(f'twitchUtils argument is malformed: \"{twitchUtils}\"')
 
         self.__funtoonRepository: FuntoonRepositoryInterface = funtoonRepository
         self.__generalSettingsRepository: GeneralSettingsRepository = generalSettingsRepository
@@ -314,9 +334,12 @@ class SuperTriviaGameRedemption(AbsChannelPointRedemption):
         triviaGameBuilder: TriviaGameBuilderInterface,
         triviaGameMachine: TriviaGameMachineInterface,
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
-        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
+            raise ValueError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
+        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
+            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
 
         self.__timber: TimberInterface = timber
         self.__triviaGameBuilder: TriviaGameBuilderInterface = triviaGameBuilder
@@ -348,9 +371,12 @@ class TriviaGameRedemption(AbsChannelPointRedemption):
         triviaGameBuilder: TriviaGameBuilderInterface,
         triviaGameMachine: TriviaGameMachineInterface,
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
-        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
+            raise ValueError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
+        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
+            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
 
         self.__timber: TimberInterface = timber
         self.__triviaGameBuilder: TriviaGameBuilderInterface = triviaGameBuilder

--- a/src/CynanBot/recurringActions/mostRecentRecurringAction.py
+++ b/src/CynanBot/recurringActions/mostRecentRecurringAction.py
@@ -11,11 +11,9 @@ class MostRecentRecurringAction():
         dateTime: SimpleDateTime,
         twitchChannel: str
     ):
-        if not isinstance(actionType, RecurringActionType):
-            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
-        elif not isinstance(dateTime, SimpleDateTime):
-            raise ValueError(f'dateTime argument is malformed: \"{dateTime}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert isinstance(actionType, RecurringActionType), f"malformed {actionType=}"
+        assert isinstance(dateTime, SimpleDateTime), f"malformed {dateTime=}"
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__actionType: RecurringActionType = actionType

--- a/src/CynanBot/recurringActions/mostRecentRecurringAction.py
+++ b/src/CynanBot/recurringActions/mostRecentRecurringAction.py
@@ -11,9 +11,11 @@ class MostRecentRecurringAction():
         dateTime: SimpleDateTime,
         twitchChannel: str
     ):
-        assert isinstance(actionType, RecurringActionType), f"malformed {actionType=}"
-        assert isinstance(dateTime, SimpleDateTime), f"malformed {dateTime=}"
-        if not utils.isValidStr(twitchChannel):
+        if not isinstance(actionType, RecurringActionType):
+            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
+        elif not isinstance(dateTime, SimpleDateTime):
+            raise ValueError(f'dateTime argument is malformed: \"{dateTime}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__actionType: RecurringActionType = actionType

--- a/src/CynanBot/recurringActions/mostRecentRecurringActionRepository.py
+++ b/src/CynanBot/recurringActions/mostRecentRecurringActionRepository.py
@@ -23,12 +23,9 @@ class MostRecentRecurringActionRepository(MostRecentRecurringActionRepositoryInt
         timber: TimberInterface,
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -104,8 +101,7 @@ class MostRecentRecurringActionRepository(MostRecentRecurringActionRepositoryInt
         await connection.close()
 
     async def setMostRecentRecurringAction(self, action: RecurringAction):
-        if not isinstance(action, RecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(action, RecurringAction), f"malformed {action=}"
 
         nowDateTime = datetime.now(self.__timeZone)
         nowDateTimeStr = nowDateTime.isoformat()

--- a/src/CynanBot/recurringActions/mostRecentRecurringActionRepository.py
+++ b/src/CynanBot/recurringActions/mostRecentRecurringActionRepository.py
@@ -23,9 +23,12 @@ class MostRecentRecurringActionRepository(MostRecentRecurringActionRepositoryInt
         timber: TimberInterface,
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -101,7 +104,8 @@ class MostRecentRecurringActionRepository(MostRecentRecurringActionRepositoryInt
         await connection.close()
 
     async def setMostRecentRecurringAction(self, action: RecurringAction):
-        assert isinstance(action, RecurringAction), f"malformed {action=}"
+        if not isinstance(action, RecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         nowDateTime = datetime.now(self.__timeZone)
         nowDateTimeStr = nowDateTime.isoformat()

--- a/src/CynanBot/recurringActions/recurringActionsJsonParser.py
+++ b/src/CynanBot/recurringActions/recurringActionsJsonParser.py
@@ -25,10 +25,8 @@ class RecurringActionsJsonParser(RecurringActionsJsonParserInterface):
         languagesRepository: LanguagesRepositoryInterface,
         timber: TimberInterface
     ):
-        if not isinstance(languagesRepository, LanguagesRepositoryInterface):
-            raise ValueError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository
         self.__timber: TimberInterface = timber
@@ -110,15 +108,13 @@ class RecurringActionsJsonParser(RecurringActionsJsonParserInterface):
         )
 
     async def __superTriviaToJson(self, action: SuperTriviaRecurringAction) -> str:
-        if not isinstance(action, SuperTriviaRecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(action, SuperTriviaRecurringAction), f"malformed {action=}"
 
         jsonContents: Dict[str, Any] = dict()
         return json.dumps(jsonContents)
 
     async def toJson(self, action: RecurringAction) -> str:
-        if not isinstance(action, RecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(action, RecurringAction), f"malformed {action=}"
 
         actionType = action.getActionType()
 
@@ -132,8 +128,7 @@ class RecurringActionsJsonParser(RecurringActionsJsonParserInterface):
             raise RuntimeError(f'Encountered unknown actionType (\"{actionType}\") for action (\"{action}\")')
 
     async def __weatherToJson(self, action: WeatherRecurringAction) -> str:
-        if not isinstance(action, WeatherRecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(action, WeatherRecurringAction), f"malformed {action=}"
 
         jsonContents: Dict[str, Any] = {
             'alertsOnly': action.isAlertsOnly()
@@ -142,8 +137,7 @@ class RecurringActionsJsonParser(RecurringActionsJsonParserInterface):
         return json.dumps(jsonContents)
 
     async def __wordOfTheDayToJson(self, action: WordOfTheDayRecurringAction) -> str:
-        if not isinstance(action, WordOfTheDayRecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(action, WordOfTheDayRecurringAction), f"malformed {action=}"
 
         languageEntry = action.getLanguageEntry()
         wotdApiCode: Optional[str] = None

--- a/src/CynanBot/recurringActions/recurringActionsJsonParser.py
+++ b/src/CynanBot/recurringActions/recurringActionsJsonParser.py
@@ -25,8 +25,10 @@ class RecurringActionsJsonParser(RecurringActionsJsonParserInterface):
         languagesRepository: LanguagesRepositoryInterface,
         timber: TimberInterface
     ):
-        assert isinstance(languagesRepository, LanguagesRepositoryInterface), f"malformed {languagesRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(languagesRepository, LanguagesRepositoryInterface):
+            raise ValueError(f'languagesRepository argument is malformed: \"{languagesRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__languagesRepository: LanguagesRepositoryInterface = languagesRepository
         self.__timber: TimberInterface = timber
@@ -108,13 +110,15 @@ class RecurringActionsJsonParser(RecurringActionsJsonParserInterface):
         )
 
     async def __superTriviaToJson(self, action: SuperTriviaRecurringAction) -> str:
-        assert isinstance(action, SuperTriviaRecurringAction), f"malformed {action=}"
+        if not isinstance(action, SuperTriviaRecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         jsonContents: Dict[str, Any] = dict()
         return json.dumps(jsonContents)
 
     async def toJson(self, action: RecurringAction) -> str:
-        assert isinstance(action, RecurringAction), f"malformed {action=}"
+        if not isinstance(action, RecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         actionType = action.getActionType()
 
@@ -128,7 +132,8 @@ class RecurringActionsJsonParser(RecurringActionsJsonParserInterface):
             raise RuntimeError(f'Encountered unknown actionType (\"{actionType}\") for action (\"{action}\")')
 
     async def __weatherToJson(self, action: WeatherRecurringAction) -> str:
-        assert isinstance(action, WeatherRecurringAction), f"malformed {action=}"
+        if not isinstance(action, WeatherRecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         jsonContents: Dict[str, Any] = {
             'alertsOnly': action.isAlertsOnly()
@@ -137,7 +142,8 @@ class RecurringActionsJsonParser(RecurringActionsJsonParserInterface):
         return json.dumps(jsonContents)
 
     async def __wordOfTheDayToJson(self, action: WordOfTheDayRecurringAction) -> str:
-        assert isinstance(action, WordOfTheDayRecurringAction), f"malformed {action=}"
+        if not isinstance(action, WordOfTheDayRecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         languageEntry = action.getLanguageEntry()
         wotdApiCode: Optional[str] = None

--- a/src/CynanBot/recurringActions/recurringActionsMachine.py
+++ b/src/CynanBot/recurringActions/recurringActionsMachine.py
@@ -72,48 +72,35 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         cooldown: timedelta = timedelta(minutes = 3),
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface):
-            raise ValueError(f'isLiveOnTwitchRepository argument is malformed: \"{isLiveOnTwitchRepository}\"')
-        elif not isinstance(locationsRepository, LocationsRepositoryInterface):
-            raise ValueError(f'locationsRepository argument is malformed: \"{locationsRepository}\"')
-        elif not isinstance(mostRecentRecurringActionRepository, MostRecentRecurringActionRepositoryInterface):
-            raise ValueError(f'mostRecentRecurringActionRepository argument is malformed: \"{mostRecentRecurringActionRepository}\"')
-        elif not isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface):
-            raise ValueError(f'recurringActionsRepository argument is malformed: \"{recurringActionsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
-            raise ValueError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
-        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
-            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif weatherRepository is not None and not isinstance(weatherRepository, WeatherRepositoryInterface):
-            raise ValueError(f'weatherRepository argument is malformed: \"{weatherRepository}\"')
-        elif not isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface):
-            raise ValueError(f'wordOfTheDayRepository argument is malformed: \"{wordOfTheDayRepository}\"')
-        elif not utils.isValidNum(queueSleepTimeSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface), f"malformed {isLiveOnTwitchRepository=}"
+        assert isinstance(locationsRepository, LocationsRepositoryInterface), f"malformed {locationsRepository=}"
+        assert isinstance(mostRecentRecurringActionRepository, MostRecentRecurringActionRepositoryInterface), f"malformed {mostRecentRecurringActionRepository=}"
+        assert isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface), f"malformed {recurringActionsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
+        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        assert weatherRepository is None or isinstance(weatherRepository, WeatherRepositoryInterface), f"malformed {weatherRepository=}"
+        assert isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface), f"malformed {wordOfTheDayRepository=}"
+        if not utils.isValidNum(queueSleepTimeSeconds):
             raise ValueError(f'queueSleepTimeSeconds argument is malformed: \"{queueSleepTimeSeconds}\"')
-        elif queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 15:
+        if queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 15:
             raise ValueError(f'queueSleepTimeSeconds argument is out of bounds: {queueSleepTimeSeconds}')
-        elif not utils.isValidNum(refreshSleepTimeSeconds):
+        if not utils.isValidNum(refreshSleepTimeSeconds):
             raise ValueError(f'refreshSleepTimeSeconds argument is malformed: \"{refreshSleepTimeSeconds}\"')
-        elif refreshSleepTimeSeconds < 30 or refreshSleepTimeSeconds > 600:
+        if refreshSleepTimeSeconds < 30 or refreshSleepTimeSeconds > 600:
             raise ValueError(f'refreshSleepTimeSeconds argument is out of bounds: {refreshSleepTimeSeconds}')
-        elif not utils.isValidInt(queueTimeoutSeconds):
+        if not utils.isValidInt(queueTimeoutSeconds):
             raise ValueError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
+        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
-        elif not utils.isValidInt(superTriviaCountdownSeconds):
+        if not utils.isValidInt(superTriviaCountdownSeconds):
             raise ValueError(f'superTriviaCountdownSeconds argument is malformed: \"{superTriviaCountdownSeconds}\"')
-        elif superTriviaCountdownSeconds < 3 or superTriviaCountdownSeconds > 10:
+        if superTriviaCountdownSeconds < 3 or superTriviaCountdownSeconds > 10:
             raise ValueError(f'superTriviaCountdownSeconds argument is out of bounds: {superTriviaCountdownSeconds}')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
         self.__isLiveOnTwitchRepository: IsLiveOnTwitchRepositoryInterface = isLiveOnTwitchRepository
@@ -151,8 +138,7 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         return users
 
     async def __findDueRecurringAction(self, user: UserInterface) -> Optional[RecurringAction]:
-        if not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         actionTypes: List[RecurringActionType] = list(RecurringActionType)
         action: Optional[RecurringAction] = None
@@ -192,10 +178,8 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         return action
 
     async def __processRecurringAction(self, user: UserInterface, action: RecurringAction):
-        if not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(action, RecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(action, RecurringAction), f"malformed {action=}"
 
         if not action.isEnabled():
             raise RuntimeError(f'Attempting to process a disabled action: \"{action}\"')
@@ -225,10 +209,8 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         user: UserInterface,
         action: SuperTriviaRecurringAction
     ) -> bool:
-        if not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(action, SuperTriviaRecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(action, SuperTriviaRecurringAction), f"malformed {action=}"
 
         newTriviaGame = await self.__triviaGameBuilder.createNewSuperTriviaGame(
             twitchChannel = user.getHandle(),
@@ -253,10 +235,8 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         user: UserInterface,
         action: WeatherRecurringAction
     ) -> bool:
-        if not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(action, WeatherRecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(action, WeatherRecurringAction), f"malformed {action=}"
 
         if self.__weatherRepository is None:
             return False
@@ -291,10 +271,8 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         user: UserInterface,
         action: WordOfTheDayRecurringAction
     ) -> bool:
-        if not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(action, WordOfTheDayRecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(action, WordOfTheDayRecurringAction), f"malformed {action=}"
 
         languageEntry = action.getLanguageEntry()
 
@@ -357,8 +335,7 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
             await asyncio.sleep(self.__refreshSleepTimeSeconds)
 
     def setEventListener(self, listener: Optional[RecurringActionEventListener]):
-        if listener is not None and not isinstance(listener, RecurringActionEventListener):
-            raise ValueError(f'listener argument is malformed: \"{listener}\"')
+        assert listener is None or isinstance(listener, RecurringActionEventListener), f"malformed {listener=}"
 
         self.__eventListener = listener
 
@@ -394,8 +371,7 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         self.__backgroundTaskHelper.createTask(self.__startEventLoop())
 
     async def __submitEvent(self, event: RecurringEvent):
-        if not isinstance(event, RecurringEvent):
-            raise ValueError(f'event argument is malformed: \"{event}\"')
+        assert isinstance(event, RecurringEvent), f"malformed {event=}"
 
         try:
             self.__eventQueue.put(event, block = True, timeout = self.__queueTimeoutSeconds)

--- a/src/CynanBot/recurringActions/recurringActionsMachine.py
+++ b/src/CynanBot/recurringActions/recurringActionsMachine.py
@@ -72,35 +72,48 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         cooldown: timedelta = timedelta(minutes = 3),
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface), f"malformed {isLiveOnTwitchRepository=}"
-        assert isinstance(locationsRepository, LocationsRepositoryInterface), f"malformed {locationsRepository=}"
-        assert isinstance(mostRecentRecurringActionRepository, MostRecentRecurringActionRepositoryInterface), f"malformed {mostRecentRecurringActionRepository=}"
-        assert isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface), f"malformed {recurringActionsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
-        assert isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        assert weatherRepository is None or isinstance(weatherRepository, WeatherRepositoryInterface), f"malformed {weatherRepository=}"
-        assert isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface), f"malformed {wordOfTheDayRepository=}"
-        if not utils.isValidNum(queueSleepTimeSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(isLiveOnTwitchRepository, IsLiveOnTwitchRepositoryInterface):
+            raise ValueError(f'isLiveOnTwitchRepository argument is malformed: \"{isLiveOnTwitchRepository}\"')
+        elif not isinstance(locationsRepository, LocationsRepositoryInterface):
+            raise ValueError(f'locationsRepository argument is malformed: \"{locationsRepository}\"')
+        elif not isinstance(mostRecentRecurringActionRepository, MostRecentRecurringActionRepositoryInterface):
+            raise ValueError(f'mostRecentRecurringActionRepository argument is malformed: \"{mostRecentRecurringActionRepository}\"')
+        elif not isinstance(recurringActionsRepository, RecurringActionsRepositoryInterface):
+            raise ValueError(f'recurringActionsRepository argument is malformed: \"{recurringActionsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
+            raise ValueError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
+        elif not isinstance(triviaGameMachine, TriviaGameMachineInterface):
+            raise ValueError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif weatherRepository is not None and not isinstance(weatherRepository, WeatherRepositoryInterface):
+            raise ValueError(f'weatherRepository argument is malformed: \"{weatherRepository}\"')
+        elif not isinstance(wordOfTheDayRepository, WordOfTheDayRepositoryInterface):
+            raise ValueError(f'wordOfTheDayRepository argument is malformed: \"{wordOfTheDayRepository}\"')
+        elif not utils.isValidNum(queueSleepTimeSeconds):
             raise ValueError(f'queueSleepTimeSeconds argument is malformed: \"{queueSleepTimeSeconds}\"')
-        if queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 15:
+        elif queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 15:
             raise ValueError(f'queueSleepTimeSeconds argument is out of bounds: {queueSleepTimeSeconds}')
-        if not utils.isValidNum(refreshSleepTimeSeconds):
+        elif not utils.isValidNum(refreshSleepTimeSeconds):
             raise ValueError(f'refreshSleepTimeSeconds argument is malformed: \"{refreshSleepTimeSeconds}\"')
-        if refreshSleepTimeSeconds < 30 or refreshSleepTimeSeconds > 600:
+        elif refreshSleepTimeSeconds < 30 or refreshSleepTimeSeconds > 600:
             raise ValueError(f'refreshSleepTimeSeconds argument is out of bounds: {refreshSleepTimeSeconds}')
-        if not utils.isValidInt(queueTimeoutSeconds):
+        elif not utils.isValidInt(queueTimeoutSeconds):
             raise ValueError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
+        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
-        if not utils.isValidInt(superTriviaCountdownSeconds):
+        elif not utils.isValidInt(superTriviaCountdownSeconds):
             raise ValueError(f'superTriviaCountdownSeconds argument is malformed: \"{superTriviaCountdownSeconds}\"')
-        if superTriviaCountdownSeconds < 3 or superTriviaCountdownSeconds > 10:
+        elif superTriviaCountdownSeconds < 3 or superTriviaCountdownSeconds > 10:
             raise ValueError(f'superTriviaCountdownSeconds argument is out of bounds: {superTriviaCountdownSeconds}')
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
         self.__isLiveOnTwitchRepository: IsLiveOnTwitchRepositoryInterface = isLiveOnTwitchRepository
@@ -138,7 +151,8 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         return users
 
     async def __findDueRecurringAction(self, user: UserInterface) -> Optional[RecurringAction]:
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        if not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         actionTypes: List[RecurringActionType] = list(RecurringActionType)
         action: Optional[RecurringAction] = None
@@ -178,8 +192,10 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         return action
 
     async def __processRecurringAction(self, user: UserInterface, action: RecurringAction):
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(action, RecurringAction), f"malformed {action=}"
+        if not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(action, RecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         if not action.isEnabled():
             raise RuntimeError(f'Attempting to process a disabled action: \"{action}\"')
@@ -209,8 +225,10 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         user: UserInterface,
         action: SuperTriviaRecurringAction
     ) -> bool:
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(action, SuperTriviaRecurringAction), f"malformed {action=}"
+        if not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(action, SuperTriviaRecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         newTriviaGame = await self.__triviaGameBuilder.createNewSuperTriviaGame(
             twitchChannel = user.getHandle(),
@@ -235,8 +253,10 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         user: UserInterface,
         action: WeatherRecurringAction
     ) -> bool:
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(action, WeatherRecurringAction), f"malformed {action=}"
+        if not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(action, WeatherRecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         if self.__weatherRepository is None:
             return False
@@ -271,8 +291,10 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         user: UserInterface,
         action: WordOfTheDayRecurringAction
     ) -> bool:
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(action, WordOfTheDayRecurringAction), f"malformed {action=}"
+        if not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(action, WordOfTheDayRecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         languageEntry = action.getLanguageEntry()
 
@@ -335,7 +357,8 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
             await asyncio.sleep(self.__refreshSleepTimeSeconds)
 
     def setEventListener(self, listener: Optional[RecurringActionEventListener]):
-        assert listener is None or isinstance(listener, RecurringActionEventListener), f"malformed {listener=}"
+        if listener is not None and not isinstance(listener, RecurringActionEventListener):
+            raise ValueError(f'listener argument is malformed: \"{listener}\"')
 
         self.__eventListener = listener
 
@@ -371,7 +394,8 @@ class RecurringActionsMachine(RecurringActionsMachineInterface):
         self.__backgroundTaskHelper.createTask(self.__startEventLoop())
 
     async def __submitEvent(self, event: RecurringEvent):
-        assert isinstance(event, RecurringEvent), f"malformed {event=}"
+        if not isinstance(event, RecurringEvent):
+            raise ValueError(f'event argument is malformed: \"{event}\"')
 
         try:
             self.__eventQueue.put(event, block = True, timeout = self.__queueTimeoutSeconds)

--- a/src/CynanBot/recurringActions/recurringActionsRepository.py
+++ b/src/CynanBot/recurringActions/recurringActionsRepository.py
@@ -27,12 +27,9 @@ class RecurringActionsRepository(RecurringActionsRepositoryInterface):
         recurringActionsJsonParser: RecurringActionsJsonParserInterface,
         timber: TimberInterface
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(recurringActionsJsonParser, RecurringActionsJsonParserInterface):
-            raise ValueError(f'recurringActionsJsonParser argument is malformed: \"{recurringActionsJsonParser}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(recurringActionsJsonParser, RecurringActionsJsonParserInterface), f"malformed {recurringActionsJsonParser=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__recurringActionsJsonParser: RecurringActionsJsonParserInterface = recurringActionsJsonParser
@@ -72,9 +69,8 @@ class RecurringActionsRepository(RecurringActionsRepositoryInterface):
         actionType: RecurringActionType,
         twitchChannel: str
     ) -> Optional[List[Any]]:
-        if not isinstance(actionType, RecurringActionType):
-            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert isinstance(actionType, RecurringActionType), f"malformed {actionType=}"
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -199,8 +195,7 @@ class RecurringActionsRepository(RecurringActionsRepositoryInterface):
         await connection.close()
 
     async def setRecurringAction(self, action: RecurringAction):
-        if not isinstance(action, RecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(action, RecurringAction), f"malformed {action=}"
 
         configurationJson = await self.__recurringActionsJsonParser.toJson(action)
 
@@ -216,9 +211,8 @@ class RecurringActionsRepository(RecurringActionsRepositoryInterface):
         action: RecurringAction,
         configurationJson: str
     ):
-        if not isinstance(action, RecurringAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
-        elif not utils.isValidStr(configurationJson):
+        assert isinstance(action, RecurringAction), f"malformed {action=}"
+        if not utils.isValidStr(configurationJson):
             raise ValueError(f'configurationJson argument is malformed: \"{configurationJson}\"')
 
         isEnabled = utils.boolToNum(action.isEnabled())

--- a/src/CynanBot/recurringActions/recurringActionsRepository.py
+++ b/src/CynanBot/recurringActions/recurringActionsRepository.py
@@ -27,9 +27,12 @@ class RecurringActionsRepository(RecurringActionsRepositoryInterface):
         recurringActionsJsonParser: RecurringActionsJsonParserInterface,
         timber: TimberInterface
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(recurringActionsJsonParser, RecurringActionsJsonParserInterface), f"malformed {recurringActionsJsonParser=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(recurringActionsJsonParser, RecurringActionsJsonParserInterface):
+            raise ValueError(f'recurringActionsJsonParser argument is malformed: \"{recurringActionsJsonParser}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__recurringActionsJsonParser: RecurringActionsJsonParserInterface = recurringActionsJsonParser
@@ -69,8 +72,9 @@ class RecurringActionsRepository(RecurringActionsRepositoryInterface):
         actionType: RecurringActionType,
         twitchChannel: str
     ) -> Optional[List[Any]]:
-        assert isinstance(actionType, RecurringActionType), f"malformed {actionType=}"
-        if not utils.isValidStr(twitchChannel):
+        if not isinstance(actionType, RecurringActionType):
+            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -195,7 +199,8 @@ class RecurringActionsRepository(RecurringActionsRepositoryInterface):
         await connection.close()
 
     async def setRecurringAction(self, action: RecurringAction):
-        assert isinstance(action, RecurringAction), f"malformed {action=}"
+        if not isinstance(action, RecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         configurationJson = await self.__recurringActionsJsonParser.toJson(action)
 
@@ -211,8 +216,9 @@ class RecurringActionsRepository(RecurringActionsRepositoryInterface):
         action: RecurringAction,
         configurationJson: str
     ):
-        assert isinstance(action, RecurringAction), f"malformed {action=}"
-        if not utils.isValidStr(configurationJson):
+        if not isinstance(action, RecurringAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
+        elif not utils.isValidStr(configurationJson):
             raise ValueError(f'configurationJson argument is malformed: \"{configurationJson}\"')
 
         isEnabled = utils.boolToNum(action.isEnabled())

--- a/src/CynanBot/recurringActions/weatherRecurringEvent.py
+++ b/src/CynanBot/recurringActions/weatherRecurringEvent.py
@@ -16,8 +16,7 @@ class WeatherRecurringEvent(RecurringEvent):
 
         if not utils.isValidBool(alertsOnly):
             raise ValueError(f'alertsOnly argument is malformed: \"{alertsOnly}\"')
-        elif not isinstance(weatherReport, WeatherReport):
-            raise ValueError(f'weatherReport argument is malformed: \"{weatherReport}\"')
+        assert isinstance(weatherReport, WeatherReport), f"malformed {weatherReport=}"
 
         self.__alertsOnly: bool = alertsOnly
         self.__weatherReport: WeatherReport = weatherReport

--- a/src/CynanBot/recurringActions/weatherRecurringEvent.py
+++ b/src/CynanBot/recurringActions/weatherRecurringEvent.py
@@ -16,7 +16,8 @@ class WeatherRecurringEvent(RecurringEvent):
 
         if not utils.isValidBool(alertsOnly):
             raise ValueError(f'alertsOnly argument is malformed: \"{alertsOnly}\"')
-        assert isinstance(weatherReport, WeatherReport), f"malformed {weatherReport=}"
+        elif not isinstance(weatherReport, WeatherReport):
+            raise ValueError(f'weatherReport argument is malformed: \"{weatherReport}\"')
 
         self.__alertsOnly: bool = alertsOnly
         self.__weatherReport: WeatherReport = weatherReport

--- a/src/CynanBot/recurringActions/wordOfTheDayRecurringAction.py
+++ b/src/CynanBot/recurringActions/wordOfTheDayRecurringAction.py
@@ -20,8 +20,7 @@ class WordOfTheDayRecurringAction(RecurringAction):
             minutesBetween = minutesBetween
         )
 
-        if languageEntry is not None and not isinstance(languageEntry, LanguageEntry):
-            raise ValueError(f'languageEntry argument is malformed: \"{languageEntry}\"')
+        assert languageEntry is None or isinstance(languageEntry, LanguageEntry), f"malformed {languageEntry=}"
 
         self.__languageEntry: Optional[LanguageEntry] = languageEntry
 

--- a/src/CynanBot/recurringActions/wordOfTheDayRecurringAction.py
+++ b/src/CynanBot/recurringActions/wordOfTheDayRecurringAction.py
@@ -20,7 +20,8 @@ class WordOfTheDayRecurringAction(RecurringAction):
             minutesBetween = minutesBetween
         )
 
-        assert languageEntry is None or isinstance(languageEntry, LanguageEntry), f"malformed {languageEntry=}"
+        if languageEntry is not None and not isinstance(languageEntry, LanguageEntry):
+            raise ValueError(f'languageEntry argument is malformed: \"{languageEntry}\"')
 
         self.__languageEntry: Optional[LanguageEntry] = languageEntry
 

--- a/src/CynanBot/recurringActions/wordOfTheDayRecurringEvent.py
+++ b/src/CynanBot/recurringActions/wordOfTheDayRecurringEvent.py
@@ -14,10 +14,8 @@ class WordOfTheDayRecurringEvent(RecurringEvent):
     ):
         super().__init__(twitchChannel = twitchChannel)
 
-        if not isinstance(languageEntry, LanguageEntry):
-            raise ValueError(f'languageEntry argument is malformed: \"{languageEntry}\"')
-        elif not isinstance(wordOfTheDayResponse, WordOfTheDayResponse):
-            raise ValueError(f'wordOfTheDayResponse argument is malformed: \"{wordOfTheDayResponse}\"')
+        assert isinstance(languageEntry, LanguageEntry), f"malformed {languageEntry=}"
+        assert isinstance(wordOfTheDayResponse, WordOfTheDayResponse), f"malformed {wordOfTheDayResponse=}"
 
         self.__languageEntry: LanguageEntry = languageEntry
         self.__wordOfTheDayResponse: WordOfTheDayResponse = wordOfTheDayResponse

--- a/src/CynanBot/recurringActions/wordOfTheDayRecurringEvent.py
+++ b/src/CynanBot/recurringActions/wordOfTheDayRecurringEvent.py
@@ -14,8 +14,10 @@ class WordOfTheDayRecurringEvent(RecurringEvent):
     ):
         super().__init__(twitchChannel = twitchChannel)
 
-        assert isinstance(languageEntry, LanguageEntry), f"malformed {languageEntry=}"
-        assert isinstance(wordOfTheDayResponse, WordOfTheDayResponse), f"malformed {wordOfTheDayResponse=}"
+        if not isinstance(languageEntry, LanguageEntry):
+            raise ValueError(f'languageEntry argument is malformed: \"{languageEntry}\"')
+        elif not isinstance(wordOfTheDayResponse, WordOfTheDayResponse):
+            raise ValueError(f'wordOfTheDayResponse argument is malformed: \"{wordOfTheDayResponse}\"')
 
         self.__languageEntry: LanguageEntry = languageEntry
         self.__wordOfTheDayResponse: WordOfTheDayResponse = wordOfTheDayResponse

--- a/src/CynanBot/sentMessageLogger/sentMessageLogger.py
+++ b/src/CynanBot/sentMessageLogger/sentMessageLogger.py
@@ -25,15 +25,13 @@ class SentMessageLogger(SentMessageLoggerInterface):
         sleepTimeSeconds: float = 15,
         logRootDirectory: str = 'logs/sentMessageLogger'
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidNum(sleepTimeSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        elif sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
+        if sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        elif not utils.isValidStr(logRootDirectory):
+        if not utils.isValidStr(logRootDirectory):
             raise ValueError(f'logRootDirectory argument is malformed: \"{logRootDirectory}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -45,8 +43,7 @@ class SentMessageLogger(SentMessageLoggerInterface):
         self.__messageQueue: SimpleQueue[SentMessage] = SimpleQueue()
 
     def __getLogStatement(self, message: SentMessage) -> str:
-        if not isinstance(message, SentMessage):
-            raise ValueError(f'message argument is malformed: \"{message}\"')
+        assert isinstance(message, SentMessage), f"malformed {message=}"
 
         prefix = f'{message.getSimpleDateTime().getDateAndTimeStr(True)} — '
         error = ''
@@ -71,11 +68,11 @@ class SentMessageLogger(SentMessageLoggerInterface):
     ):
         if not utils.isValidBool(successfullySent):
             raise ValueError(f'successfullySent argument is malformed: \"{successfullySent}\"')
-        elif not utils.isValidInt(numberOfRetries):
+        if not utils.isValidInt(numberOfRetries):
             raise ValueError(f'numberOfRetries argument is malformed: \"{numberOfRetries}\"')
-        elif not utils.isValidStr(msg):
+        if not utils.isValidStr(msg):
             raise ValueError(f'msg argument is malformed: \"{msg}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         sentMessage = SentMessage(

--- a/src/CynanBot/sentMessageLogger/sentMessageLogger.py
+++ b/src/CynanBot/sentMessageLogger/sentMessageLogger.py
@@ -25,13 +25,15 @@ class SentMessageLogger(SentMessageLoggerInterface):
         sleepTimeSeconds: float = 15,
         logRootDirectory: str = 'logs/sentMessageLogger'
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidNum(sleepTimeSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        if sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
+        elif sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        if not utils.isValidStr(logRootDirectory):
+        elif not utils.isValidStr(logRootDirectory):
             raise ValueError(f'logRootDirectory argument is malformed: \"{logRootDirectory}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -43,7 +45,8 @@ class SentMessageLogger(SentMessageLoggerInterface):
         self.__messageQueue: SimpleQueue[SentMessage] = SimpleQueue()
 
     def __getLogStatement(self, message: SentMessage) -> str:
-        assert isinstance(message, SentMessage), f"malformed {message=}"
+        if not isinstance(message, SentMessage):
+            raise ValueError(f'message argument is malformed: \"{message}\"')
 
         prefix = f'{message.getSimpleDateTime().getDateAndTimeStr(True)} — '
         error = ''
@@ -68,11 +71,11 @@ class SentMessageLogger(SentMessageLoggerInterface):
     ):
         if not utils.isValidBool(successfullySent):
             raise ValueError(f'successfullySent argument is malformed: \"{successfullySent}\"')
-        if not utils.isValidInt(numberOfRetries):
+        elif not utils.isValidInt(numberOfRetries):
             raise ValueError(f'numberOfRetries argument is malformed: \"{numberOfRetries}\"')
-        if not utils.isValidStr(msg):
+        elif not utils.isValidStr(msg):
             raise ValueError(f'msg argument is malformed: \"{msg}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         sentMessage = SentMessage(

--- a/src/CynanBot/soundPlayerManager/soundPlayerSettingsRepository.py
+++ b/src/CynanBot/soundPlayerManager/soundPlayerSettingsRepository.py
@@ -10,8 +10,7 @@ from CynanBot.storage.jsonReaderInterface import JsonReaderInterface
 class SoundPlayerSettingsRepository(SoundPlayerSettingsRepositoryInterface):
 
     def __init__(self, settingsJsonReader: JsonReaderInterface):
-        if not isinstance(settingsJsonReader, JsonReaderInterface):
-            raise TypeError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
+        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
 
@@ -21,8 +20,7 @@ class SoundPlayerSettingsRepository(SoundPlayerSettingsRepositoryInterface):
         self.__settingsCache = None
 
     async def getFilePathFor(self, soundAlert: SoundAlert) -> Optional[str]:
-        if not isinstance(soundAlert, SoundAlert):
-            raise TypeError(f'soundAlert argument is malformed: \"{soundAlert}\"')
+        assert isinstance(soundAlert, SoundAlert), f"malformed {soundAlert=}"
 
         jsonContents = await self.__readJson()
         filePath: Optional[str] = None

--- a/src/CynanBot/soundPlayerManager/soundPlayerSettingsRepository.py
+++ b/src/CynanBot/soundPlayerManager/soundPlayerSettingsRepository.py
@@ -10,7 +10,8 @@ from CynanBot.storage.jsonReaderInterface import JsonReaderInterface
 class SoundPlayerSettingsRepository(SoundPlayerSettingsRepositoryInterface):
 
     def __init__(self, settingsJsonReader: JsonReaderInterface):
-        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
+        if not isinstance(settingsJsonReader, JsonReaderInterface):
+            raise TypeError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
 
@@ -20,7 +21,8 @@ class SoundPlayerSettingsRepository(SoundPlayerSettingsRepositoryInterface):
         self.__settingsCache = None
 
     async def getFilePathFor(self, soundAlert: SoundAlert) -> Optional[str]:
-        assert isinstance(soundAlert, SoundAlert), f"malformed {soundAlert=}"
+        if not isinstance(soundAlert, SoundAlert):
+            raise TypeError(f'soundAlert argument is malformed: \"{soundAlert}\"')
 
         jsonContents = await self.__readJson()
         filePath: Optional[str] = None

--- a/src/CynanBot/soundPlayerManager/vlc/vlcSoundPlayerManager.py
+++ b/src/CynanBot/soundPlayerManager/vlc/vlcSoundPlayerManager.py
@@ -20,10 +20,8 @@ class VlcSoundPlayerManager(SoundPlayerManagerInterface):
         soundPlayerSettingsRepository: SoundPlayerSettingsRepositoryInterface,
         timber: TimberInterface
     ):
-        if not isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface):
-            raise TypeError(f'soundPlayerSettingsRepository argument is malformed: \"{soundPlayerSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface), f"malformed {soundPlayerSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__soundPlayerSettingsRepository: SoundPlayerSettingsRepositoryInterface = soundPlayerSettingsRepository
         self.__timber: TimberInterface = timber
@@ -35,8 +33,7 @@ class VlcSoundPlayerManager(SoundPlayerManagerInterface):
         return mediaPlayer is not None and mediaPlayer.is_playing()
 
     async def playSoundAlert(self, alert: SoundAlert) -> bool:
-        if not isinstance(alert, SoundAlert):
-            raise TypeError(f'alert argument is malformed: \"{alert}\"')
+        assert isinstance(alert, SoundAlert), f"malformed {alert=}"
 
         if not await self.__soundPlayerSettingsRepository.isEnabled():
             return False

--- a/src/CynanBot/soundPlayerManager/vlc/vlcSoundPlayerManager.py
+++ b/src/CynanBot/soundPlayerManager/vlc/vlcSoundPlayerManager.py
@@ -20,8 +20,10 @@ class VlcSoundPlayerManager(SoundPlayerManagerInterface):
         soundPlayerSettingsRepository: SoundPlayerSettingsRepositoryInterface,
         timber: TimberInterface
     ):
-        assert isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface), f"malformed {soundPlayerSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(soundPlayerSettingsRepository, SoundPlayerSettingsRepositoryInterface):
+            raise TypeError(f'soundPlayerSettingsRepository argument is malformed: \"{soundPlayerSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
 
         self.__soundPlayerSettingsRepository: SoundPlayerSettingsRepositoryInterface = soundPlayerSettingsRepository
         self.__timber: TimberInterface = timber
@@ -33,7 +35,8 @@ class VlcSoundPlayerManager(SoundPlayerManagerInterface):
         return mediaPlayer is not None and mediaPlayer.is_playing()
 
     async def playSoundAlert(self, alert: SoundAlert) -> bool:
-        assert isinstance(alert, SoundAlert), f"malformed {alert=}"
+        if not isinstance(alert, SoundAlert):
+            raise TypeError(f'alert argument is malformed: \"{alert}\"')
 
         if not await self.__soundPlayerSettingsRepository.isEnabled():
             return False

--- a/src/CynanBot/starWars/starWarsQuotesRepository.py
+++ b/src/CynanBot/starWars/starWarsQuotesRepository.py
@@ -11,8 +11,7 @@ from CynanBot.storage.jsonReaderInterface import JsonReaderInterface
 class StarWarsQuotesRepository(StarWarsQuotesRepositoryInterface):
 
     def __init__(self, quotesJsonReader: JsonReaderInterface):
-        if not isinstance(quotesJsonReader, JsonReaderInterface):
-            raise ValueError(f'quotesJsonReader argument is malformed: \"{quotesJsonReader}\"')
+        assert isinstance(quotesJsonReader, JsonReaderInterface), f"malformed {quotesJsonReader=}"
 
         self.__quotesJsonReader: JsonReaderInterface = quotesJsonReader
 

--- a/src/CynanBot/starWars/starWarsQuotesRepository.py
+++ b/src/CynanBot/starWars/starWarsQuotesRepository.py
@@ -11,7 +11,8 @@ from CynanBot.storage.jsonReaderInterface import JsonReaderInterface
 class StarWarsQuotesRepository(StarWarsQuotesRepositoryInterface):
 
     def __init__(self, quotesJsonReader: JsonReaderInterface):
-        assert isinstance(quotesJsonReader, JsonReaderInterface), f"malformed {quotesJsonReader=}"
+        if not isinstance(quotesJsonReader, JsonReaderInterface):
+            raise ValueError(f'quotesJsonReader argument is malformed: \"{quotesJsonReader}\"')
 
         self.__quotesJsonReader: JsonReaderInterface = quotesJsonReader
 

--- a/src/CynanBot/storage/backingPsqlDatabase.py
+++ b/src/CynanBot/storage/backingPsqlDatabase.py
@@ -20,12 +20,9 @@ class BackingPsqlDatabase(BackingDatabase):
         psqlCredentialsProvider: PsqlCredentialsProvider,
         timber: TimberInterface
     ):
-        if not isinstance(eventLoop, AbstractEventLoop):
-            raise TypeError(f'eventLoop argument is malformed: \"{eventLoop}\"')
-        elif not isinstance(psqlCredentialsProvider, PsqlCredentialsProvider):
-            raise TypeError(f'psqlCredentialsProvider argument is malformed: \"{psqlCredentialsProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(eventLoop, AbstractEventLoop), f"malformed {eventLoop=}"
+        assert isinstance(psqlCredentialsProvider, PsqlCredentialsProvider), f"malformed {psqlCredentialsProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__eventLoop: AbstractEventLoop = eventLoop
         self.__psqlCredentialsProvider: PsqlCredentialsProvider = psqlCredentialsProvider
@@ -34,8 +31,7 @@ class BackingPsqlDatabase(BackingDatabase):
         self.__connectionPool: Optional[asyncpg.Pool] = None
 
     async def __createCollations(self, databaseConnection: DatabaseConnection):
-        if not isinstance(databaseConnection, DatabaseConnection):
-            raise TypeError(f'databaseConnection argument is malformed: \"{databaseConnection}\"')
+        assert isinstance(databaseConnection, DatabaseConnection), f"malformed {databaseConnection=}"
 
         await databaseConnection.execute('CREATE EXTENSION IF NOT EXISTS citext')
 

--- a/src/CynanBot/storage/backingPsqlDatabase.py
+++ b/src/CynanBot/storage/backingPsqlDatabase.py
@@ -20,9 +20,12 @@ class BackingPsqlDatabase(BackingDatabase):
         psqlCredentialsProvider: PsqlCredentialsProvider,
         timber: TimberInterface
     ):
-        assert isinstance(eventLoop, AbstractEventLoop), f"malformed {eventLoop=}"
-        assert isinstance(psqlCredentialsProvider, PsqlCredentialsProvider), f"malformed {psqlCredentialsProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(eventLoop, AbstractEventLoop):
+            raise TypeError(f'eventLoop argument is malformed: \"{eventLoop}\"')
+        elif not isinstance(psqlCredentialsProvider, PsqlCredentialsProvider):
+            raise TypeError(f'psqlCredentialsProvider argument is malformed: \"{psqlCredentialsProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
 
         self.__eventLoop: AbstractEventLoop = eventLoop
         self.__psqlCredentialsProvider: PsqlCredentialsProvider = psqlCredentialsProvider
@@ -31,7 +34,8 @@ class BackingPsqlDatabase(BackingDatabase):
         self.__connectionPool: Optional[asyncpg.Pool] = None
 
     async def __createCollations(self, databaseConnection: DatabaseConnection):
-        assert isinstance(databaseConnection, DatabaseConnection), f"malformed {databaseConnection=}"
+        if not isinstance(databaseConnection, DatabaseConnection):
+            raise TypeError(f'databaseConnection argument is malformed: \"{databaseConnection}\"')
 
         await databaseConnection.execute('CREATE EXTENSION IF NOT EXISTS citext')
 

--- a/src/CynanBot/storage/backingSqliteDatabase.py
+++ b/src/CynanBot/storage/backingSqliteDatabase.py
@@ -16,9 +16,8 @@ class BackingSqliteDatabase(BackingDatabase):
         eventLoop: AbstractEventLoop,
         backingDatabaseFile: str = 'database.sqlite'
     ):
-        if not isinstance(eventLoop, AbstractEventLoop):
-            raise TypeError(f'eventLoop argument is malformed: \"{eventLoop}\"')
-        elif not utils.isValidStr(backingDatabaseFile):
+        assert isinstance(eventLoop, AbstractEventLoop), f"malformed {eventLoop=}"
+        if not utils.isValidStr(backingDatabaseFile):
             raise TypeError(f'backingDatabaseFile argument is malformed: \"{backingDatabaseFile}\"')
 
         self.__eventLoop: AbstractEventLoop = eventLoop

--- a/src/CynanBot/storage/backingSqliteDatabase.py
+++ b/src/CynanBot/storage/backingSqliteDatabase.py
@@ -16,8 +16,9 @@ class BackingSqliteDatabase(BackingDatabase):
         eventLoop: AbstractEventLoop,
         backingDatabaseFile: str = 'database.sqlite'
     ):
-        assert isinstance(eventLoop, AbstractEventLoop), f"malformed {eventLoop=}"
-        if not utils.isValidStr(backingDatabaseFile):
+        if not isinstance(eventLoop, AbstractEventLoop):
+            raise TypeError(f'eventLoop argument is malformed: \"{eventLoop}\"')
+        elif not utils.isValidStr(backingDatabaseFile):
             raise TypeError(f'backingDatabaseFile argument is malformed: \"{backingDatabaseFile}\"')
 
         self.__eventLoop: AbstractEventLoop = eventLoop

--- a/src/CynanBot/storage/psqlCredentialsProvider.py
+++ b/src/CynanBot/storage/psqlCredentialsProvider.py
@@ -8,8 +8,7 @@ from CynanBot.storage.jsonReaderInterface import JsonReaderInterface
 class PsqlCredentialsProvider(Clearable):
 
     def __init__(self, credentialsJsonReader: JsonReaderInterface):
-        if not isinstance(credentialsJsonReader, JsonReaderInterface):
-            raise ValueError(f'credentialsJsonReader argument is malformed: \"{credentialsJsonReader}\"')
+        assert isinstance(credentialsJsonReader, JsonReaderInterface), f"malformed {credentialsJsonReader=}"
 
         self.__credentialsJsonReader: JsonReaderInterface = credentialsJsonReader
 

--- a/src/CynanBot/storage/psqlCredentialsProvider.py
+++ b/src/CynanBot/storage/psqlCredentialsProvider.py
@@ -8,7 +8,8 @@ from CynanBot.storage.jsonReaderInterface import JsonReaderInterface
 class PsqlCredentialsProvider(Clearable):
 
     def __init__(self, credentialsJsonReader: JsonReaderInterface):
-        assert isinstance(credentialsJsonReader, JsonReaderInterface), f"malformed {credentialsJsonReader=}"
+        if not isinstance(credentialsJsonReader, JsonReaderInterface):
+            raise ValueError(f'credentialsJsonReader argument is malformed: \"{credentialsJsonReader}\"')
 
         self.__credentialsJsonReader: JsonReaderInterface = credentialsJsonReader
 

--- a/src/CynanBot/streamAlertsManager/currentStreamAlert.py
+++ b/src/CynanBot/streamAlertsManager/currentStreamAlert.py
@@ -9,8 +9,7 @@ from CynanBot.tts.ttsEvent import TtsEvent
 class CurrentStreamAlert():
 
     def __init__(self, streamAlert: StreamAlert):
-        if not isinstance(streamAlert, StreamAlert):
-            raise TypeError(f'streamAlert argument is malformed: \"{streamAlert}\"')
+        assert isinstance(streamAlert, StreamAlert), f"malformed {streamAlert=}"
 
         self.__streamAlert: StreamAlert = streamAlert
         self.__alertState: StreamAlertState = StreamAlertState.NOT_STARTED
@@ -35,8 +34,7 @@ class CurrentStreamAlert():
         return str(dictionary)
 
     def setAlertState(self, state: StreamAlertState):
-        if not isinstance(state, StreamAlertState):
-            raise TypeError(f'state argument is malformed: \"{state}\"')
+        assert isinstance(state, StreamAlertState), f"malformed {state=}"
 
         self.__alertState = state
 

--- a/src/CynanBot/streamAlertsManager/currentStreamAlert.py
+++ b/src/CynanBot/streamAlertsManager/currentStreamAlert.py
@@ -9,7 +9,8 @@ from CynanBot.tts.ttsEvent import TtsEvent
 class CurrentStreamAlert():
 
     def __init__(self, streamAlert: StreamAlert):
-        assert isinstance(streamAlert, StreamAlert), f"malformed {streamAlert=}"
+        if not isinstance(streamAlert, StreamAlert):
+            raise TypeError(f'streamAlert argument is malformed: \"{streamAlert}\"')
 
         self.__streamAlert: StreamAlert = streamAlert
         self.__alertState: StreamAlertState = StreamAlertState.NOT_STARTED
@@ -34,7 +35,8 @@ class CurrentStreamAlert():
         return str(dictionary)
 
     def setAlertState(self, state: StreamAlertState):
-        assert isinstance(state, StreamAlertState), f"malformed {state=}"
+        if not isinstance(state, StreamAlertState):
+            raise TypeError(f'state argument is malformed: \"{state}\"')
 
         self.__alertState = state
 

--- a/src/CynanBot/streamAlertsManager/streamAlert.py
+++ b/src/CynanBot/streamAlertsManager/streamAlert.py
@@ -13,12 +13,10 @@ class StreamAlert():
         twitchChannel: str,
         ttsEvent: Optional[TtsEvent]
     ):
-        if soundAlert is not None and not isinstance(soundAlert, SoundAlert):
-            raise TypeError(f'soundAlert argument is malformed: \"{soundAlert}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert soundAlert is None or isinstance(soundAlert, SoundAlert), f"malformed {soundAlert=}"
+        if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif ttsEvent is not None and not isinstance(ttsEvent, TtsEvent):
-            raise TypeError(f'ttsEvent argument is malformed: \"{ttsEvent}\"')
+        assert ttsEvent is None or isinstance(ttsEvent, TtsEvent), f"malformed {ttsEvent=}"
 
         self.__soundAlert: Optional[SoundAlert] = soundAlert
         self.__twitchChannel: str = twitchChannel

--- a/src/CynanBot/streamAlertsManager/streamAlert.py
+++ b/src/CynanBot/streamAlertsManager/streamAlert.py
@@ -13,10 +13,12 @@ class StreamAlert():
         twitchChannel: str,
         ttsEvent: Optional[TtsEvent]
     ):
-        assert soundAlert is None or isinstance(soundAlert, SoundAlert), f"malformed {soundAlert=}"
-        if not utils.isValidStr(twitchChannel):
+        if soundAlert is not None and not isinstance(soundAlert, SoundAlert):
+            raise TypeError(f'soundAlert argument is malformed: \"{soundAlert}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        assert ttsEvent is None or isinstance(ttsEvent, TtsEvent), f"malformed {ttsEvent=}"
+        elif ttsEvent is not None and not isinstance(ttsEvent, TtsEvent):
+            raise TypeError(f'ttsEvent argument is malformed: \"{ttsEvent}\"')
 
         self.__soundAlert: Optional[SoundAlert] = soundAlert
         self.__twitchChannel: str = twitchChannel

--- a/src/CynanBot/streamAlertsManager/streamAlertsManager.py
+++ b/src/CynanBot/streamAlertsManager/streamAlertsManager.py
@@ -31,23 +31,18 @@ class StreamAlertsManager(StreamAlertsManagerInterface):
         queueSleepTimeSeconds: float = 0.2,
         queueTimeoutSeconds: float = 3
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif soundPlayerManager is not None and not isinstance(soundPlayerManager, SoundPlayerManagerInterface):
-            raise TypeError(f'soundPlayerManager argument is malformed: \"{soundPlayerManager}\"')
-        elif not isinstance(streamAlertsSettingsRepository, StreamAlertsSettingsRepositoryInterface):
-            raise TypeError(f'streamAlertsSettingsRepository argument is malformed: \"{streamAlertsSettingsRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif ttsManager is not None and not isinstance(ttsManager, TtsManagerInterface):
-            raise TypeError(f'ttsManager argument is malformed: \"{ttsManager}\"')
-        elif not utils.isValidNum(queueSleepTimeSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert soundPlayerManager is None or isinstance(soundPlayerManager, SoundPlayerManagerInterface), f"malformed {soundPlayerManager=}"
+        assert isinstance(streamAlertsSettingsRepository, StreamAlertsSettingsRepositoryInterface), f"malformed {streamAlertsSettingsRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert ttsManager is None or isinstance(ttsManager, TtsManagerInterface), f"malformed {ttsManager=}"
+        if not utils.isValidNum(queueSleepTimeSeconds):
             raise TypeError(f'queueSleepTimeSeconds argument is malformed: \"{queueSleepTimeSeconds}\"')
-        elif queueSleepTimeSeconds < 0.10 or queueSleepTimeSeconds > 8:
+        if queueSleepTimeSeconds < 0.10 or queueSleepTimeSeconds > 8:
             raise ValueError(f'queueSleepTimeSeconds argument is out of bounds: {queueSleepTimeSeconds}')
-        elif not utils.isValidNum(queueTimeoutSeconds):
+        if not utils.isValidNum(queueTimeoutSeconds):
             raise TypeError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 3:
+        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 3:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -128,8 +123,7 @@ class StreamAlertsManager(StreamAlertsManagerInterface):
             await asyncio.sleep(await self.__streamAlertsSettingsRepository.getAlertsDelayBetweenSeconds())
 
     def submitAlert(self, alert: StreamAlert):
-        if not isinstance(alert, StreamAlert):
-            raise TypeError(f'alert argument is malformed: \"{alert}\"')
+        assert isinstance(alert, StreamAlert), f"malformed {alert=}"
 
         try:
             self.__alertQueue.put(alert, block = True, timeout = self.__queueTimeoutSeconds)

--- a/src/CynanBot/streamAlertsManager/streamAlertsManager.py
+++ b/src/CynanBot/streamAlertsManager/streamAlertsManager.py
@@ -31,18 +31,23 @@ class StreamAlertsManager(StreamAlertsManagerInterface):
         queueSleepTimeSeconds: float = 0.2,
         queueTimeoutSeconds: float = 3
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert soundPlayerManager is None or isinstance(soundPlayerManager, SoundPlayerManagerInterface), f"malformed {soundPlayerManager=}"
-        assert isinstance(streamAlertsSettingsRepository, StreamAlertsSettingsRepositoryInterface), f"malformed {streamAlertsSettingsRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert ttsManager is None or isinstance(ttsManager, TtsManagerInterface), f"malformed {ttsManager=}"
-        if not utils.isValidNum(queueSleepTimeSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif soundPlayerManager is not None and not isinstance(soundPlayerManager, SoundPlayerManagerInterface):
+            raise TypeError(f'soundPlayerManager argument is malformed: \"{soundPlayerManager}\"')
+        elif not isinstance(streamAlertsSettingsRepository, StreamAlertsSettingsRepositoryInterface):
+            raise TypeError(f'streamAlertsSettingsRepository argument is malformed: \"{streamAlertsSettingsRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif ttsManager is not None and not isinstance(ttsManager, TtsManagerInterface):
+            raise TypeError(f'ttsManager argument is malformed: \"{ttsManager}\"')
+        elif not utils.isValidNum(queueSleepTimeSeconds):
             raise TypeError(f'queueSleepTimeSeconds argument is malformed: \"{queueSleepTimeSeconds}\"')
-        if queueSleepTimeSeconds < 0.10 or queueSleepTimeSeconds > 8:
+        elif queueSleepTimeSeconds < 0.10 or queueSleepTimeSeconds > 8:
             raise ValueError(f'queueSleepTimeSeconds argument is out of bounds: {queueSleepTimeSeconds}')
-        if not utils.isValidNum(queueTimeoutSeconds):
+        elif not utils.isValidNum(queueTimeoutSeconds):
             raise TypeError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 3:
+        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 3:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -123,7 +128,8 @@ class StreamAlertsManager(StreamAlertsManagerInterface):
             await asyncio.sleep(await self.__streamAlertsSettingsRepository.getAlertsDelayBetweenSeconds())
 
     def submitAlert(self, alert: StreamAlert):
-        assert isinstance(alert, StreamAlert), f"malformed {alert=}"
+        if not isinstance(alert, StreamAlert):
+            raise TypeError(f'alert argument is malformed: \"{alert}\"')
 
         try:
             self.__alertQueue.put(alert, block = True, timeout = self.__queueTimeoutSeconds)

--- a/src/CynanBot/streamAlertsManager/streamAlertsSettingsRepository.py
+++ b/src/CynanBot/streamAlertsManager/streamAlertsSettingsRepository.py
@@ -9,8 +9,7 @@ from CynanBot.streamAlertsManager.streamAlertsSettingsRepositoryInterface import
 class StreamAlertsSettingsRepository(StreamAlertsSettingsRepositoryInterface):
 
     def __init__(self, settingsJsonReader: JsonReaderInterface):
-        if not isinstance(settingsJsonReader, JsonReaderInterface):
-            raise TypeError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
+        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
 

--- a/src/CynanBot/streamAlertsManager/streamAlertsSettingsRepository.py
+++ b/src/CynanBot/streamAlertsManager/streamAlertsSettingsRepository.py
@@ -9,7 +9,8 @@ from CynanBot.streamAlertsManager.streamAlertsSettingsRepositoryInterface import
 class StreamAlertsSettingsRepository(StreamAlertsSettingsRepositoryInterface):
 
     def __init__(self, settingsJsonReader: JsonReaderInterface):
-        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
+        if not isinstance(settingsJsonReader, JsonReaderInterface):
+            raise TypeError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
 

--- a/src/CynanBot/supStreamer/supStreamerAction.py
+++ b/src/CynanBot/supStreamer/supStreamerAction.py
@@ -12,11 +12,10 @@ class SupStreamerAction():
         broadcasterUserId: str,
         broadcasterUserName: str
     ):
-        if not isinstance(chatters, Dict):
-            raise ValueError(f'chatters argument is malformed: \"{chatters}\"')
-        elif not utils.isValidStr(broadcasterUserId):
+        assert isinstance(chatters, Dict), f"malformed {chatters=}"
+        if not utils.isValidStr(broadcasterUserId):
             raise ValueError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif not utils.isValidStr(broadcasterUserName):
+        if not utils.isValidStr(broadcasterUserName):
             raise ValueError(f'broadcasterUserName argument is malformed: \"{broadcasterUserName}\"')
 
         self.__chatters: Dict[str, Optional[SupStreamerChatter]] = chatters

--- a/src/CynanBot/supStreamer/supStreamerAction.py
+++ b/src/CynanBot/supStreamer/supStreamerAction.py
@@ -12,10 +12,11 @@ class SupStreamerAction():
         broadcasterUserId: str,
         broadcasterUserName: str
     ):
-        assert isinstance(chatters, Dict), f"malformed {chatters=}"
-        if not utils.isValidStr(broadcasterUserId):
+        if not isinstance(chatters, Dict):
+            raise ValueError(f'chatters argument is malformed: \"{chatters}\"')
+        elif not utils.isValidStr(broadcasterUserId):
             raise ValueError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        if not utils.isValidStr(broadcasterUserName):
+        elif not utils.isValidStr(broadcasterUserName):
             raise ValueError(f'broadcasterUserName argument is malformed: \"{broadcasterUserName}\"')
 
         self.__chatters: Dict[str, Optional[SupStreamerChatter]] = chatters

--- a/src/CynanBot/supStreamer/supStreamerChatter.py
+++ b/src/CynanBot/supStreamer/supStreamerChatter.py
@@ -11,9 +11,8 @@ class SupStreamerChatter():
         mostRecentSup: Optional[SimpleDateTime],
         userId: str
     ):
-        if mostRecentSup is not None and not isinstance(mostRecentSup, SimpleDateTime):
-            raise ValueError(f'mostRecentSup argument is malformed: \"{mostRecentSup}\"')
-        elif not utils.isValidStr(userId):
+        assert mostRecentSup is None or isinstance(mostRecentSup, SimpleDateTime), f"malformed {mostRecentSup=}"
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__mostRecentSup: Optional[SimpleDateTime] = mostRecentSup

--- a/src/CynanBot/supStreamer/supStreamerChatter.py
+++ b/src/CynanBot/supStreamer/supStreamerChatter.py
@@ -11,8 +11,9 @@ class SupStreamerChatter():
         mostRecentSup: Optional[SimpleDateTime],
         userId: str
     ):
-        assert mostRecentSup is None or isinstance(mostRecentSup, SimpleDateTime), f"malformed {mostRecentSup=}"
-        if not utils.isValidStr(userId):
+        if mostRecentSup is not None and not isinstance(mostRecentSup, SimpleDateTime):
+            raise ValueError(f'mostRecentSup argument is malformed: \"{mostRecentSup}\"')
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__mostRecentSup: Optional[SimpleDateTime] = mostRecentSup

--- a/src/CynanBot/supStreamer/supStreamerRepository.py
+++ b/src/CynanBot/supStreamer/supStreamerRepository.py
@@ -19,10 +19,8 @@ class SupStreamerRepository(SupStreamerRepositoryInterface):
         backingDatabase: BackingDatabase,
         timber: TimberInterface
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -124,7 +122,7 @@ class SupStreamerRepository(SupStreamerRepositoryInterface):
     async def update(self, chatterUserId: str, twitchChannelId: str):
         if not utils.isValidStr(chatterUserId):
             raise ValueError(f'chatterUserId argument is malformed: \"{chatterUserId}\"')
-        elif not utils.isValidStr(twitchChannelId):
+        if not utils.isValidStr(twitchChannelId):
             raise ValueError(f'twitchChannelId argument is malformed: \"{twitchChannelId}\"')
 
         now = SimpleDateTime()

--- a/src/CynanBot/supStreamer/supStreamerRepository.py
+++ b/src/CynanBot/supStreamer/supStreamerRepository.py
@@ -19,8 +19,10 @@ class SupStreamerRepository(SupStreamerRepositoryInterface):
         backingDatabase: BackingDatabase,
         timber: TimberInterface
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -122,7 +124,7 @@ class SupStreamerRepository(SupStreamerRepositoryInterface):
     async def update(self, chatterUserId: str, twitchChannelId: str):
         if not utils.isValidStr(chatterUserId):
             raise ValueError(f'chatterUserId argument is malformed: \"{chatterUserId}\"')
-        if not utils.isValidStr(twitchChannelId):
+        elif not utils.isValidStr(twitchChannelId):
             raise ValueError(f'twitchChannelId argument is malformed: \"{twitchChannelId}\"')
 
         now = SimpleDateTime()

--- a/src/CynanBot/systemCommandHelper/systemCommandHelper.py
+++ b/src/CynanBot/systemCommandHelper/systemCommandHelper.py
@@ -16,8 +16,7 @@ from CynanBot.timber.timberInterface import TimberInterface
 class SystemCommandHelper(SystemCommandHelperInterface):
 
     def __init__(self, timber: TimberInterface):
-        if not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__timber: TimberInterface = timber
 
@@ -27,7 +26,7 @@ class SystemCommandHelper(SystemCommandHelperInterface):
             return
         elif not utils.isValidNum(timeoutSeconds):
             raise TypeError(f'timeoutSeconds argument is malformed: \"{timeoutSeconds}\"')
-        elif timeoutSeconds < 3 or timeoutSeconds > utils.getIntMaxSafeSize():
+        if timeoutSeconds < 3 or timeoutSeconds > utils.getIntMaxSafeSize():
             raise ValueError(f'timeoutSeconds argument is out of bounds: {timeoutSeconds}')
 
         process: Optional[Process] = None
@@ -61,9 +60,8 @@ class SystemCommandHelper(SystemCommandHelperInterface):
     async def __killProcess(self, process: Optional[Process]):
         if process is None:
             return
-        elif not isinstance(process, Process):
-            raise ValueError(f'process argument is malformed: \"{process}\"')
-        elif process.returncode is not None:
+        elassert isinstance(process, Process), f"malformed {process=}"
+        if process.returncode is not None:
             return
 
         self.__timber.log('SystemCommandHelper', f'Killing process \"{process}\"...')

--- a/src/CynanBot/systemCommandHelper/systemCommandHelper.py
+++ b/src/CynanBot/systemCommandHelper/systemCommandHelper.py
@@ -16,7 +16,8 @@ from CynanBot.timber.timberInterface import TimberInterface
 class SystemCommandHelper(SystemCommandHelperInterface):
 
     def __init__(self, timber: TimberInterface):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
 
         self.__timber: TimberInterface = timber
 
@@ -26,7 +27,7 @@ class SystemCommandHelper(SystemCommandHelperInterface):
             return
         elif not utils.isValidNum(timeoutSeconds):
             raise TypeError(f'timeoutSeconds argument is malformed: \"{timeoutSeconds}\"')
-        if timeoutSeconds < 3 or timeoutSeconds > utils.getIntMaxSafeSize():
+        elif timeoutSeconds < 3 or timeoutSeconds > utils.getIntMaxSafeSize():
             raise ValueError(f'timeoutSeconds argument is out of bounds: {timeoutSeconds}')
 
         process: Optional[Process] = None
@@ -60,8 +61,9 @@ class SystemCommandHelper(SystemCommandHelperInterface):
     async def __killProcess(self, process: Optional[Process]):
         if process is None:
             return
-        elassert isinstance(process, Process), f"malformed {process=}"
-        if process.returncode is not None:
+        elif not isinstance(process, Process):
+            raise ValueError(f'process argument is malformed: \"{process}\"')
+        elif process.returncode is not None:
             return
 
         self.__timber.log('SystemCommandHelper', f'Killing process \"{process}\"...')

--- a/src/CynanBot/timber/timber.py
+++ b/src/CynanBot/timber/timber.py
@@ -22,13 +22,12 @@ class Timber(TimberInterface):
         sleepTimeSeconds: float = 15,
         timberRootDirectory: str = 'logs/timber'
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not utils.isValidNum(sleepTimeSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        if not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        elif sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
+        if sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        elif not utils.isValidStr(timberRootDirectory):
+        if not utils.isValidStr(timberRootDirectory):
             raise ValueError(f'timberRootDirectory argument is malformed: \"{timberRootDirectory}\"')
 
         self.__sleepTimeSeconds: float = sleepTimeSeconds
@@ -40,8 +39,7 @@ class Timber(TimberInterface):
     def __getErrorStatement(self, ensureNewLine: bool, timberEntry: TimberEntry) -> Optional[str]:
         if not utils.isValidBool(ensureNewLine):
             raise ValueError(f'ensureNewLine argument is malformed: \"{ensureNewLine}\"')
-        elif not isinstance(timberEntry, TimberEntry):
-            raise ValueError(f'timberEntry argument is malformed: \"{timberEntry}\"')
+        assert isinstance(timberEntry, TimberEntry), f"malformed {timberEntry=}"
 
         if not timberEntry.hasException():
             return None
@@ -59,8 +57,7 @@ class Timber(TimberInterface):
     def __getLogStatement(self, ensureNewLine: bool, timberEntry: TimberEntry) -> str:
         if not utils.isValidBool(ensureNewLine):
             raise ValueError(f'ensureNewLine argument is malformed: \"{ensureNewLine}\"')
-        elif not isinstance(timberEntry, TimberEntry):
-            raise ValueError(f'timberEntry argument is malformed: \"{timberEntry}\"')
+        assert isinstance(timberEntry, TimberEntry), f"malformed {timberEntry=}"
 
         logStatement = f'{timberEntry.getSimpleDateTime().getDateAndTimeStr(True)} — {timberEntry.getTag()} — {timberEntry.getMsg()}'.strip()
 
@@ -81,12 +78,10 @@ class Timber(TimberInterface):
     ):
         if not utils.isValidStr(tag):
             raise ValueError(f'tag argument is malformed: \"{tag}\"')
-        elif not utils.isValidStr(msg):
+        if not utils.isValidStr(msg):
             raise ValueError(f'msg argument is malformed: \"{msg}\"')
-        elif exception is not None and not isinstance(exception, Exception):
-            raise ValueError(f'exception argument is malformed: \"{exception}\"')
-        elif traceback is not None and not isinstance(traceback, str):
-            raise ValueError(f'traceback argument is malformed: \"{traceback}\"')
+        assert exception is None or isinstance(exception, Exception), f"malformed {exception=}"
+        assert traceback is None or isinstance(traceback, str), f"malformed {traceback=}"
 
         timberEntry = TimberEntry(
             tag = tag,

--- a/src/CynanBot/timber/timber.py
+++ b/src/CynanBot/timber/timber.py
@@ -22,12 +22,13 @@ class Timber(TimberInterface):
         sleepTimeSeconds: float = 15,
         timberRootDirectory: str = 'logs/timber'
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        if not utils.isValidNum(sleepTimeSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        if sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
+        elif sleepTimeSeconds < 1 or sleepTimeSeconds > 60:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        if not utils.isValidStr(timberRootDirectory):
+        elif not utils.isValidStr(timberRootDirectory):
             raise ValueError(f'timberRootDirectory argument is malformed: \"{timberRootDirectory}\"')
 
         self.__sleepTimeSeconds: float = sleepTimeSeconds
@@ -39,7 +40,8 @@ class Timber(TimberInterface):
     def __getErrorStatement(self, ensureNewLine: bool, timberEntry: TimberEntry) -> Optional[str]:
         if not utils.isValidBool(ensureNewLine):
             raise ValueError(f'ensureNewLine argument is malformed: \"{ensureNewLine}\"')
-        assert isinstance(timberEntry, TimberEntry), f"malformed {timberEntry=}"
+        elif not isinstance(timberEntry, TimberEntry):
+            raise ValueError(f'timberEntry argument is malformed: \"{timberEntry}\"')
 
         if not timberEntry.hasException():
             return None
@@ -57,7 +59,8 @@ class Timber(TimberInterface):
     def __getLogStatement(self, ensureNewLine: bool, timberEntry: TimberEntry) -> str:
         if not utils.isValidBool(ensureNewLine):
             raise ValueError(f'ensureNewLine argument is malformed: \"{ensureNewLine}\"')
-        assert isinstance(timberEntry, TimberEntry), f"malformed {timberEntry=}"
+        elif not isinstance(timberEntry, TimberEntry):
+            raise ValueError(f'timberEntry argument is malformed: \"{timberEntry}\"')
 
         logStatement = f'{timberEntry.getSimpleDateTime().getDateAndTimeStr(True)} — {timberEntry.getTag()} — {timberEntry.getMsg()}'.strip()
 
@@ -78,10 +81,12 @@ class Timber(TimberInterface):
     ):
         if not utils.isValidStr(tag):
             raise ValueError(f'tag argument is malformed: \"{tag}\"')
-        if not utils.isValidStr(msg):
+        elif not utils.isValidStr(msg):
             raise ValueError(f'msg argument is malformed: \"{msg}\"')
-        assert exception is None or isinstance(exception, Exception), f"malformed {exception=}"
-        assert traceback is None or isinstance(traceback, str), f"malformed {traceback=}"
+        elif exception is not None and not isinstance(exception, Exception):
+            raise ValueError(f'exception argument is malformed: \"{exception}\"')
+        elif traceback is not None and not isinstance(traceback, str):
+            raise ValueError(f'traceback argument is malformed: \"{traceback}\"')
 
         timberEntry = TimberEntry(
             tag = tag,

--- a/src/CynanBot/timber/timberEntry.py
+++ b/src/CynanBot/timber/timberEntry.py
@@ -15,12 +15,10 @@ class TimberEntry():
     ):
         if not utils.isValidStr(tag):
             raise ValueError(f'tag argument is malformed: \"{tag}\"')
-        elif not utils.isValidStr(msg):
+        if not utils.isValidStr(msg):
             raise ValueError(f'msg argument is malformed: \"{msg}\"')
-        elif exception is not None and not isinstance(exception, Exception):
-            raise ValueError(f'exception argument is malformed: \"{exception}\"')
-        elif traceback is not None and not isinstance(traceback, str):
-            raise ValueError(f'traceback argument is malformed: \"{traceback}\"')
+        assert exception is None or isinstance(exception, Exception), f"malformed {exception=}"
+        assert traceback is None or isinstance(traceback, str), f"malformed {traceback=}"
 
         self.__tag: str = tag.strip()
         self.__msg: str = msg.strip()

--- a/src/CynanBot/timber/timberEntry.py
+++ b/src/CynanBot/timber/timberEntry.py
@@ -15,10 +15,12 @@ class TimberEntry():
     ):
         if not utils.isValidStr(tag):
             raise ValueError(f'tag argument is malformed: \"{tag}\"')
-        if not utils.isValidStr(msg):
+        elif not utils.isValidStr(msg):
             raise ValueError(f'msg argument is malformed: \"{msg}\"')
-        assert exception is None or isinstance(exception, Exception), f"malformed {exception=}"
-        assert traceback is None or isinstance(traceback, str), f"malformed {traceback=}"
+        elif exception is not None and not isinstance(exception, Exception):
+            raise ValueError(f'exception argument is malformed: \"{exception}\"')
+        elif traceback is not None and not isinstance(traceback, str):
+            raise ValueError(f'traceback argument is malformed: \"{traceback}\"')
 
         self.__tag: str = tag.strip()
         self.__msg: str = msg.strip()

--- a/src/CynanBot/trivia/actions/checkAnswerTriviaAction.py
+++ b/src/CynanBot/trivia/actions/checkAnswerTriviaAction.py
@@ -17,13 +17,12 @@ class CheckAnswerTriviaAction(AbsTriviaAction):
     ):
         super().__init__(actionId = actionId)
 
-        if answer is not None and not isinstance(answer, str):
-            raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__answer: Optional[str] = answer

--- a/src/CynanBot/trivia/actions/checkAnswerTriviaAction.py
+++ b/src/CynanBot/trivia/actions/checkAnswerTriviaAction.py
@@ -17,12 +17,13 @@ class CheckAnswerTriviaAction(AbsTriviaAction):
     ):
         super().__init__(actionId = actionId)
 
-        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
-        if not utils.isValidStr(twitchChannel):
+        if answer is not None and not isinstance(answer, str):
+            raise ValueError(f'answer argument is malformed: \"{answer}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__answer: Optional[str] = answer

--- a/src/CynanBot/trivia/actions/checkSuperAnswerTriviaAction.py
+++ b/src/CynanBot/trivia/actions/checkSuperAnswerTriviaAction.py
@@ -17,13 +17,12 @@ class CheckSuperAnswerTriviaAction(AbsTriviaAction):
     ):
         super().__init__(actionId = actionId)
 
-        if answer is not None and not isinstance(answer, str):
-            raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__answer: Optional[str] = answer

--- a/src/CynanBot/trivia/actions/checkSuperAnswerTriviaAction.py
+++ b/src/CynanBot/trivia/actions/checkSuperAnswerTriviaAction.py
@@ -17,12 +17,13 @@ class CheckSuperAnswerTriviaAction(AbsTriviaAction):
     ):
         super().__init__(actionId = actionId)
 
-        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
-        if not utils.isValidStr(twitchChannel):
+        if answer is not None and not isinstance(answer, str):
+            raise ValueError(f'answer argument is malformed: \"{answer}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__answer: Optional[str] = answer

--- a/src/CynanBot/trivia/actions/startNewSuperTriviaGameAction.py
+++ b/src/CynanBot/trivia/actions/startNewSuperTriviaGameAction.py
@@ -30,46 +30,45 @@ class StartNewSuperTriviaGameAction(AbsTriviaAction):
 
         if not utils.isValidBool(isQueueActionConsumed):
             raise TypeError(f'isQueueActionConsumed argument is malformed: \"{isQueueActionConsumed}\"')
-        elif not utils.isValidBool(isShinyTriviaEnabled):
+        if not utils.isValidBool(isShinyTriviaEnabled):
             raise TypeError(f'isShinyTriviaEnabled argument is malformed: \"{isShinyTriviaEnabled}\"')
-        elif not utils.isValidBool(isToxicTriviaEnabled):
+        if not utils.isValidBool(isToxicTriviaEnabled):
             raise TypeError(f'isToxicTriviaEnabled argument is malformed: \"{isToxicTriviaEnabled}\"')
-        elif not utils.isValidInt(numberOfGames):
+        if not utils.isValidInt(numberOfGames):
             raise TypeError(f'numberOfGames argument is malformed: \"{numberOfGames}\"')
-        elif numberOfGames < 1 or numberOfGames > utils.getIntMaxSafeSize():
+        if numberOfGames < 1 or numberOfGames > utils.getIntMaxSafeSize():
             raise ValueError(f'numberOfGames argument is out of bounds: {numberOfGames}')
-        elif not utils.isValidInt(perUserAttempts):
+        if not utils.isValidInt(perUserAttempts):
             raise TypeError(f'perUserAttempts argument is malformed: \"{perUserAttempts}\"')
-        elif perUserAttempts < 1 or perUserAttempts > 5:
+        if perUserAttempts < 1 or perUserAttempts > 5:
             raise ValueError(f'perUserAttempts argument is out of bounds: {perUserAttempts}')
-        elif not utils.isValidInt(pointsForWinning):
+        if not utils.isValidInt(pointsForWinning):
             raise TypeError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        elif not utils.isValidInt(regularTriviaPointsForWinning):
+        if not utils.isValidInt(regularTriviaPointsForWinning):
             raise TypeError(f'regularTriviaPointsForWinning argument is malformed: \"{regularTriviaPointsForWinning}\"')
-        elif regularTriviaPointsForWinning < 1 or regularTriviaPointsForWinning > utils.getIntMaxSafeSize():
+        if regularTriviaPointsForWinning < 1 or regularTriviaPointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'regularTriviaPointsForWinning argument is out of bounds: {regularTriviaPointsForWinning}')
-        elif not utils.isValidInt(secondsToLive):
+        if not utils.isValidInt(secondsToLive):
             raise TypeError(f'secondsToLive argument is malformed: \"{secondsToLive}\"')
-        elif secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
+        if secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
             raise ValueError(f'secondsToLive argument is out of bounds: {secondsToLive}')
-        elif not utils.isValidInt(shinyMultiplier):
+        if not utils.isValidInt(shinyMultiplier):
             raise TypeError(f'shinyMultiplier argument is malformed: \"{shinyMultiplier}\"')
-        elif shinyMultiplier < 1 or shinyMultiplier > utils.getIntMaxSafeSize():
+        if shinyMultiplier < 1 or shinyMultiplier > utils.getIntMaxSafeSize():
             raise ValueError(f'shinyMultiplier argument is out of bounds: {shinyMultiplier}')
-        elif not utils.isValidInt(toxicMultiplier):
+        if not utils.isValidInt(toxicMultiplier):
             raise TypeError(f'toxicMultiplier argument is malformed: \"{toxicMultiplier}\"')
-        elif toxicMultiplier < 1 or toxicMultiplier > utils.getIntMaxSafeSize():
+        if toxicMultiplier < 1 or toxicMultiplier > utils.getIntMaxSafeSize():
             raise ValueError(f'toxicMultiplier argument is out of bounds: {toxicMultiplier}')
-        elif not utils.isValidInt(toxicTriviaPunishmentMultiplier):
+        if not utils.isValidInt(toxicTriviaPunishmentMultiplier):
             raise TypeError(f'toxicTriviaPunishmentMultiplier argument is malformed: \"{toxicTriviaPunishmentMultiplier}\"')
-        elif toxicTriviaPunishmentMultiplier < 0 or toxicTriviaPunishmentMultiplier > utils.getIntMaxSafeSize():
+        if toxicTriviaPunishmentMultiplier < 0 or toxicTriviaPunishmentMultiplier > utils.getIntMaxSafeSize():
             raise ValueError(f'toxicTriviaPunishmentMultiplier argument is out of bounds: {toxicTriviaPunishmentMultiplier}')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
-            raise TypeError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
+        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
 
         self.__isQueueActionConsumed: bool = isQueueActionConsumed
         self.__isShinyTriviaEnabled: bool = isShinyTriviaEnabled

--- a/src/CynanBot/trivia/actions/startNewSuperTriviaGameAction.py
+++ b/src/CynanBot/trivia/actions/startNewSuperTriviaGameAction.py
@@ -30,45 +30,46 @@ class StartNewSuperTriviaGameAction(AbsTriviaAction):
 
         if not utils.isValidBool(isQueueActionConsumed):
             raise TypeError(f'isQueueActionConsumed argument is malformed: \"{isQueueActionConsumed}\"')
-        if not utils.isValidBool(isShinyTriviaEnabled):
+        elif not utils.isValidBool(isShinyTriviaEnabled):
             raise TypeError(f'isShinyTriviaEnabled argument is malformed: \"{isShinyTriviaEnabled}\"')
-        if not utils.isValidBool(isToxicTriviaEnabled):
+        elif not utils.isValidBool(isToxicTriviaEnabled):
             raise TypeError(f'isToxicTriviaEnabled argument is malformed: \"{isToxicTriviaEnabled}\"')
-        if not utils.isValidInt(numberOfGames):
+        elif not utils.isValidInt(numberOfGames):
             raise TypeError(f'numberOfGames argument is malformed: \"{numberOfGames}\"')
-        if numberOfGames < 1 or numberOfGames > utils.getIntMaxSafeSize():
+        elif numberOfGames < 1 or numberOfGames > utils.getIntMaxSafeSize():
             raise ValueError(f'numberOfGames argument is out of bounds: {numberOfGames}')
-        if not utils.isValidInt(perUserAttempts):
+        elif not utils.isValidInt(perUserAttempts):
             raise TypeError(f'perUserAttempts argument is malformed: \"{perUserAttempts}\"')
-        if perUserAttempts < 1 or perUserAttempts > 5:
+        elif perUserAttempts < 1 or perUserAttempts > 5:
             raise ValueError(f'perUserAttempts argument is out of bounds: {perUserAttempts}')
-        if not utils.isValidInt(pointsForWinning):
+        elif not utils.isValidInt(pointsForWinning):
             raise TypeError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        if not utils.isValidInt(regularTriviaPointsForWinning):
+        elif not utils.isValidInt(regularTriviaPointsForWinning):
             raise TypeError(f'regularTriviaPointsForWinning argument is malformed: \"{regularTriviaPointsForWinning}\"')
-        if regularTriviaPointsForWinning < 1 or regularTriviaPointsForWinning > utils.getIntMaxSafeSize():
+        elif regularTriviaPointsForWinning < 1 or regularTriviaPointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'regularTriviaPointsForWinning argument is out of bounds: {regularTriviaPointsForWinning}')
-        if not utils.isValidInt(secondsToLive):
+        elif not utils.isValidInt(secondsToLive):
             raise TypeError(f'secondsToLive argument is malformed: \"{secondsToLive}\"')
-        if secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
+        elif secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
             raise ValueError(f'secondsToLive argument is out of bounds: {secondsToLive}')
-        if not utils.isValidInt(shinyMultiplier):
+        elif not utils.isValidInt(shinyMultiplier):
             raise TypeError(f'shinyMultiplier argument is malformed: \"{shinyMultiplier}\"')
-        if shinyMultiplier < 1 or shinyMultiplier > utils.getIntMaxSafeSize():
+        elif shinyMultiplier < 1 or shinyMultiplier > utils.getIntMaxSafeSize():
             raise ValueError(f'shinyMultiplier argument is out of bounds: {shinyMultiplier}')
-        if not utils.isValidInt(toxicMultiplier):
+        elif not utils.isValidInt(toxicMultiplier):
             raise TypeError(f'toxicMultiplier argument is malformed: \"{toxicMultiplier}\"')
-        if toxicMultiplier < 1 or toxicMultiplier > utils.getIntMaxSafeSize():
+        elif toxicMultiplier < 1 or toxicMultiplier > utils.getIntMaxSafeSize():
             raise ValueError(f'toxicMultiplier argument is out of bounds: {toxicMultiplier}')
-        if not utils.isValidInt(toxicTriviaPunishmentMultiplier):
+        elif not utils.isValidInt(toxicTriviaPunishmentMultiplier):
             raise TypeError(f'toxicTriviaPunishmentMultiplier argument is malformed: \"{toxicTriviaPunishmentMultiplier}\"')
-        if toxicTriviaPunishmentMultiplier < 0 or toxicTriviaPunishmentMultiplier > utils.getIntMaxSafeSize():
+        elif toxicTriviaPunishmentMultiplier < 0 or toxicTriviaPunishmentMultiplier > utils.getIntMaxSafeSize():
             raise ValueError(f'toxicTriviaPunishmentMultiplier argument is out of bounds: {toxicTriviaPunishmentMultiplier}')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
+        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
+            raise TypeError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
 
         self.__isQueueActionConsumed: bool = isQueueActionConsumed
         self.__isShinyTriviaEnabled: bool = isShinyTriviaEnabled

--- a/src/CynanBot/trivia/actions/startNewTriviaGameAction.py
+++ b/src/CynanBot/trivia/actions/startNewTriviaGameAction.py
@@ -24,26 +24,25 @@ class StartNewTriviaGameAction(AbsTriviaAction):
 
         if not utils.isValidBool(isShinyTriviaEnabled):
             raise ValueError(f'isShinyTriviaEnabled argument is malformed: \"{isShinyTriviaEnabled}\"')
-        elif not utils.isValidInt(pointsForWinning):
+        if not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        elif not utils.isValidInt(secondsToLive):
+        if not utils.isValidInt(secondsToLive):
             raise ValueError(f'secondsToLive argument is malformed: \"{secondsToLive}\"')
-        elif secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
+        if secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
             raise ValueError(f'secondsToLive argument is out of bounds: {secondsToLive}')
-        elif not utils.isValidInt(shinyMultiplier):
+        if not utils.isValidInt(shinyMultiplier):
             raise ValueError(f'shinyMultiplier argument is malformed: \"{shinyMultiplier}\"')
-        elif shinyMultiplier < 1 or shinyMultiplier > utils.getIntMaxSafeSize():
+        if shinyMultiplier < 1 or shinyMultiplier > utils.getIntMaxSafeSize():
             raise ValueError(f'shinyMultiplier argument is out of bounds: {shinyMultiplier}')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
-            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
+        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
 
         self.__isShinyTriviaEnabled: bool = isShinyTriviaEnabled
         self.__pointsForWinning: int = pointsForWinning

--- a/src/CynanBot/trivia/actions/startNewTriviaGameAction.py
+++ b/src/CynanBot/trivia/actions/startNewTriviaGameAction.py
@@ -24,25 +24,26 @@ class StartNewTriviaGameAction(AbsTriviaAction):
 
         if not utils.isValidBool(isShinyTriviaEnabled):
             raise ValueError(f'isShinyTriviaEnabled argument is malformed: \"{isShinyTriviaEnabled}\"')
-        if not utils.isValidInt(pointsForWinning):
+        elif not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        if not utils.isValidInt(secondsToLive):
+        elif not utils.isValidInt(secondsToLive):
             raise ValueError(f'secondsToLive argument is malformed: \"{secondsToLive}\"')
-        if secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
+        elif secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
             raise ValueError(f'secondsToLive argument is out of bounds: {secondsToLive}')
-        if not utils.isValidInt(shinyMultiplier):
+        elif not utils.isValidInt(shinyMultiplier):
             raise ValueError(f'shinyMultiplier argument is malformed: \"{shinyMultiplier}\"')
-        if shinyMultiplier < 1 or shinyMultiplier > utils.getIntMaxSafeSize():
+        elif shinyMultiplier < 1 or shinyMultiplier > utils.getIntMaxSafeSize():
             raise ValueError(f'shinyMultiplier argument is out of bounds: {shinyMultiplier}')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
+        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
+            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
 
         self.__isShinyTriviaEnabled: bool = isShinyTriviaEnabled
         self.__pointsForWinning: int = pointsForWinning

--- a/src/CynanBot/trivia/additionalAnswers/additionalTriviaAnswers.py
+++ b/src/CynanBot/trivia/additionalAnswers/additionalTriviaAnswers.py
@@ -18,12 +18,10 @@ class AdditionalTriviaAnswers():
     ):
         if not utils.hasItems(additionalAnswers):
             raise ValueError(f'additionalAnswers argument is malformed: \"{additionalAnswers}\"')
-        elif not utils.isValidStr(triviaId):
+        if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
-        elif not isinstance(triviaType, TriviaQuestionType):
-            raise ValueError(f'triviaType argument is malformed: \"{triviaType}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
 
         self.__additionalAnswers: List[AdditionalTriviaAnswer] = additionalAnswers
         self.__triviaId: str = triviaId

--- a/src/CynanBot/trivia/additionalAnswers/additionalTriviaAnswers.py
+++ b/src/CynanBot/trivia/additionalAnswers/additionalTriviaAnswers.py
@@ -18,10 +18,12 @@ class AdditionalTriviaAnswers():
     ):
         if not utils.hasItems(additionalAnswers):
             raise ValueError(f'additionalAnswers argument is malformed: \"{additionalAnswers}\"')
-        if not utils.isValidStr(triviaId):
+        elif not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
-        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        elif not isinstance(triviaType, TriviaQuestionType):
+            raise ValueError(f'triviaType argument is malformed: \"{triviaType}\"')
 
         self.__additionalAnswers: List[AdditionalTriviaAnswer] = additionalAnswers
         self.__triviaId: str = triviaId

--- a/src/CynanBot/trivia/additionalAnswers/additionalTriviaAnswersRepository.py
+++ b/src/CynanBot/trivia/additionalAnswers/additionalTriviaAnswersRepository.py
@@ -39,18 +39,12 @@ class AdditionalTriviaAnswersRepository(AdditionalTriviaAnswersRepositoryInterfa
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
-        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
-            raise ValueError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -71,14 +65,12 @@ class AdditionalTriviaAnswersRepository(AdditionalTriviaAnswersRepositoryInterfa
     ) -> AdditionalTriviaAnswers:
         if not utils.isValidStr(additionalAnswer):
             raise AdditionalTriviaAnswerIsMalformedException(f'additionalAnswer argument is malformed: \"{additionalAnswer}\"')
-        elif not utils.isValidStr(triviaId):
+        if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
-        elif not isinstance(triviaType, TriviaQuestionType):
-            raise ValueError(f'triviaType argument is malformed: \"{triviaType}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
 
         additionalAnswerLength = len(additionalAnswer)
         maxAdditionalTriviaAnswerLength = await self.__triviaSettingsRepository.getMaxAdditionalTriviaAnswerLength()
@@ -160,14 +152,11 @@ class AdditionalTriviaAnswersRepository(AdditionalTriviaAnswersRepositoryInterfa
         triviaSource: TriviaSource,
         triviaType: TriviaQuestionType
     ) -> bool:
-        if not isinstance(currentAnswers, List):
-            raise ValueError(f'currentAnswers argument is malformed: \"{currentAnswers}\"')
-        elif not utils.isValidStr(triviaId):
+        assert isinstance(currentAnswers, List), f"malformed {currentAnswers=}"
+        if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
-        elif not isinstance(triviaType, TriviaQuestionType):
-            raise ValueError(f'triviaType argument is malformed: \"{triviaType}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
 
         reference = await self.getAdditionalTriviaAnswers(
             triviaId = triviaId,
@@ -189,8 +178,7 @@ class AdditionalTriviaAnswersRepository(AdditionalTriviaAnswersRepositoryInterfa
     ) -> Optional[AdditionalTriviaAnswers]:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
 
         reference = await self.getAdditionalTriviaAnswers(
             triviaId = triviaId,
@@ -224,10 +212,8 @@ class AdditionalTriviaAnswersRepository(AdditionalTriviaAnswersRepositoryInterfa
     ) -> Optional[AdditionalTriviaAnswers]:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
-        elif not isinstance(triviaType, TriviaQuestionType):
-            raise ValueError(f'triviaType argument is malformed: \"{triviaType}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
 
         if not await self.__triviaSettingsRepository.areAdditionalTriviaAnswersEnabled():
             return None

--- a/src/CynanBot/trivia/additionalAnswers/additionalTriviaAnswersRepository.py
+++ b/src/CynanBot/trivia/additionalAnswers/additionalTriviaAnswersRepository.py
@@ -39,12 +39,18 @@ class AdditionalTriviaAnswersRepository(AdditionalTriviaAnswersRepositoryInterfa
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
-        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
+            raise ValueError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -65,12 +71,14 @@ class AdditionalTriviaAnswersRepository(AdditionalTriviaAnswersRepositoryInterfa
     ) -> AdditionalTriviaAnswers:
         if not utils.isValidStr(additionalAnswer):
             raise AdditionalTriviaAnswerIsMalformedException(f'additionalAnswer argument is malformed: \"{additionalAnswer}\"')
-        if not utils.isValidStr(triviaId):
+        elif not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
-        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        elif not isinstance(triviaType, TriviaQuestionType):
+            raise ValueError(f'triviaType argument is malformed: \"{triviaType}\"')
 
         additionalAnswerLength = len(additionalAnswer)
         maxAdditionalTriviaAnswerLength = await self.__triviaSettingsRepository.getMaxAdditionalTriviaAnswerLength()
@@ -152,11 +160,14 @@ class AdditionalTriviaAnswersRepository(AdditionalTriviaAnswersRepositoryInterfa
         triviaSource: TriviaSource,
         triviaType: TriviaQuestionType
     ) -> bool:
-        assert isinstance(currentAnswers, List), f"malformed {currentAnswers=}"
-        if not utils.isValidStr(triviaId):
+        if not isinstance(currentAnswers, List):
+            raise ValueError(f'currentAnswers argument is malformed: \"{currentAnswers}\"')
+        elif not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
-        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        elif not isinstance(triviaType, TriviaQuestionType):
+            raise ValueError(f'triviaType argument is malformed: \"{triviaType}\"')
 
         reference = await self.getAdditionalTriviaAnswers(
             triviaId = triviaId,
@@ -178,7 +189,8 @@ class AdditionalTriviaAnswersRepository(AdditionalTriviaAnswersRepositoryInterfa
     ) -> Optional[AdditionalTriviaAnswers]:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
 
         reference = await self.getAdditionalTriviaAnswers(
             triviaId = triviaId,
@@ -212,8 +224,10 @@ class AdditionalTriviaAnswersRepository(AdditionalTriviaAnswersRepositoryInterfa
     ) -> Optional[AdditionalTriviaAnswers]:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
-        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        elif not isinstance(triviaType, TriviaQuestionType):
+            raise ValueError(f'triviaType argument is malformed: \"{triviaType}\"')
 
         if not await self.__triviaSettingsRepository.areAdditionalTriviaAnswersEnabled():
             return None

--- a/src/CynanBot/trivia/banned/bannedTriviaGameControllersRepository.py
+++ b/src/CynanBot/trivia/banned/bannedTriviaGameControllersRepository.py
@@ -31,16 +31,11 @@ class BannedTriviaGameControllersRepository(BannedTriviaGameControllersRepositor
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProviderInterface argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__backingDatabase: BackingDatabase = backingDatabase

--- a/src/CynanBot/trivia/banned/bannedTriviaGameControllersRepository.py
+++ b/src/CynanBot/trivia/banned/bannedTriviaGameControllersRepository.py
@@ -31,11 +31,16 @@ class BannedTriviaGameControllersRepository(BannedTriviaGameControllersRepositor
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProviderInterface argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__backingDatabase: BackingDatabase = backingDatabase

--- a/src/CynanBot/trivia/banned/bannedTriviaIdsRepository.py
+++ b/src/CynanBot/trivia/banned/bannedTriviaIdsRepository.py
@@ -20,10 +20,8 @@ class BannedTriviaIdsRepository(BannedTriviaIdsRepositoryInterface):
         backingDatabase: BackingDatabase,
         timber: TimberInterface
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -38,10 +36,9 @@ class BannedTriviaIdsRepository(BannedTriviaIdsRepositoryInterface):
     ) -> BanTriviaQuestionResult:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
 
         info = await self.getInfo(triviaId = triviaId, triviaSource = triviaSource)
 
@@ -76,8 +73,7 @@ class BannedTriviaIdsRepository(BannedTriviaIdsRepositoryInterface):
     ) -> Optional[BannedTriviaQuestion]:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
 
         connection = await self.__getDatabaseConnection()
         record = await connection.fetchRow(
@@ -139,8 +135,7 @@ class BannedTriviaIdsRepository(BannedTriviaIdsRepositoryInterface):
     async def isBanned(self, triviaId: str, triviaSource: TriviaSource) -> bool:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
 
         info = await self.getInfo(
             triviaId = triviaId,
@@ -160,8 +155,7 @@ class BannedTriviaIdsRepository(BannedTriviaIdsRepositoryInterface):
     ) -> BanTriviaQuestionResult:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
 
         info = await self.getInfo(triviaId = triviaId, triviaSource = triviaSource)
 

--- a/src/CynanBot/trivia/banned/bannedTriviaIdsRepository.py
+++ b/src/CynanBot/trivia/banned/bannedTriviaIdsRepository.py
@@ -20,8 +20,10 @@ class BannedTriviaIdsRepository(BannedTriviaIdsRepositoryInterface):
         backingDatabase: BackingDatabase,
         timber: TimberInterface
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -36,9 +38,10 @@ class BannedTriviaIdsRepository(BannedTriviaIdsRepositoryInterface):
     ) -> BanTriviaQuestionResult:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
 
         info = await self.getInfo(triviaId = triviaId, triviaSource = triviaSource)
 
@@ -73,7 +76,8 @@ class BannedTriviaIdsRepository(BannedTriviaIdsRepositoryInterface):
     ) -> Optional[BannedTriviaQuestion]:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
 
         connection = await self.__getDatabaseConnection()
         record = await connection.fetchRow(
@@ -135,7 +139,8 @@ class BannedTriviaIdsRepository(BannedTriviaIdsRepositoryInterface):
     async def isBanned(self, triviaId: str, triviaSource: TriviaSource) -> bool:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
 
         info = await self.getInfo(
             triviaId = triviaId,
@@ -155,7 +160,8 @@ class BannedTriviaIdsRepository(BannedTriviaIdsRepositoryInterface):
     ) -> BanTriviaQuestionResult:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
 
         info = await self.getInfo(triviaId = triviaId, triviaSource = triviaSource)
 

--- a/src/CynanBot/trivia/banned/bannedTriviaQuestion.py
+++ b/src/CynanBot/trivia/banned/bannedTriviaQuestion.py
@@ -13,12 +13,11 @@ class BannedTriviaQuestion():
     ):
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
 
         self.__triviaId: str = triviaId
         self.__userId: str = userId

--- a/src/CynanBot/trivia/banned/bannedTriviaQuestion.py
+++ b/src/CynanBot/trivia/banned/bannedTriviaQuestion.py
@@ -13,11 +13,12 @@ class BannedTriviaQuestion():
     ):
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
 
         self.__triviaId: str = triviaId
         self.__userId: str = userId

--- a/src/CynanBot/trivia/banned/triviaBanHelper.py
+++ b/src/CynanBot/trivia/banned/triviaBanHelper.py
@@ -20,12 +20,9 @@ class TriviaBanHelper(TriviaBanHelperInterface):
         funtoonRepository: FuntoonRepositoryInterface,
         triviaSettingsRepository: TriviaSettingsRepositoryInterface
     ):
-        if not isinstance(bannedTriviaIdsRepository, BannedTriviaIdsRepositoryInterface):
-            raise ValueError(f'bannedTriviaIdsRepository argument is malformed: \"{bannedTriviaIdsRepository}\"')
-        elif not isinstance(funtoonRepository, FuntoonRepositoryInterface):
-            raise ValueError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        assert isinstance(bannedTriviaIdsRepository, BannedTriviaIdsRepositoryInterface), f"malformed {bannedTriviaIdsRepository=}"
+        assert isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
 
         self.__bannedTriviaIdsRepository: BannedTriviaIdsRepositoryInterface = bannedTriviaIdsRepository
         self.__funtoonRepository: FuntoonRepositoryInterface = funtoonRepository
@@ -39,10 +36,9 @@ class TriviaBanHelper(TriviaBanHelperInterface):
     ) -> BanTriviaQuestionResult:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
 
         if triviaSource is TriviaSource.FUNTOON:
             await self.__funtoonRepository.banTriviaQuestion(triviaId)
@@ -57,8 +53,7 @@ class TriviaBanHelper(TriviaBanHelperInterface):
     async def isBanned(self, triviaId: str, triviaSource: TriviaSource) -> bool:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
 
         if not await self.__triviaSettingsRepository.isBanListEnabled():
             return False
@@ -75,8 +70,7 @@ class TriviaBanHelper(TriviaBanHelperInterface):
     ) -> BanTriviaQuestionResult:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
 
         return await self.__bannedTriviaIdsRepository.unban(
             triviaId = triviaId,

--- a/src/CynanBot/trivia/banned/triviaBanHelper.py
+++ b/src/CynanBot/trivia/banned/triviaBanHelper.py
@@ -20,9 +20,12 @@ class TriviaBanHelper(TriviaBanHelperInterface):
         funtoonRepository: FuntoonRepositoryInterface,
         triviaSettingsRepository: TriviaSettingsRepositoryInterface
     ):
-        assert isinstance(bannedTriviaIdsRepository, BannedTriviaIdsRepositoryInterface), f"malformed {bannedTriviaIdsRepository=}"
-        assert isinstance(funtoonRepository, FuntoonRepositoryInterface), f"malformed {funtoonRepository=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        if not isinstance(bannedTriviaIdsRepository, BannedTriviaIdsRepositoryInterface):
+            raise ValueError(f'bannedTriviaIdsRepository argument is malformed: \"{bannedTriviaIdsRepository}\"')
+        elif not isinstance(funtoonRepository, FuntoonRepositoryInterface):
+            raise ValueError(f'funtoonRepository argument is malformed: \"{funtoonRepository}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
 
         self.__bannedTriviaIdsRepository: BannedTriviaIdsRepositoryInterface = bannedTriviaIdsRepository
         self.__funtoonRepository: FuntoonRepositoryInterface = funtoonRepository
@@ -36,9 +39,10 @@ class TriviaBanHelper(TriviaBanHelperInterface):
     ) -> BanTriviaQuestionResult:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
 
         if triviaSource is TriviaSource.FUNTOON:
             await self.__funtoonRepository.banTriviaQuestion(triviaId)
@@ -53,7 +57,8 @@ class TriviaBanHelper(TriviaBanHelperInterface):
     async def isBanned(self, triviaId: str, triviaSource: TriviaSource) -> bool:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
 
         if not await self.__triviaSettingsRepository.isBanListEnabled():
             return False
@@ -70,7 +75,8 @@ class TriviaBanHelper(TriviaBanHelperInterface):
     ) -> BanTriviaQuestionResult:
         if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
 
         return await self.__bannedTriviaIdsRepository.unban(
             triviaId = triviaId,

--- a/src/CynanBot/trivia/builder/triviaGameBuilder.py
+++ b/src/CynanBot/trivia/builder/triviaGameBuilder.py
@@ -25,12 +25,9 @@ class TriviaGameBuilder(TriviaGameBuilderInterface):
         triviaIdGenerator: TriviaIdGeneratorInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(triviaGameBuilderSettings, TriviaGameBuilderSettingsInterface):
-            raise TypeError(f'triviaGameBuilderSettings argument is malformed: \"{triviaGameBuilderSettings}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise TypeError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(triviaGameBuilderSettings, TriviaGameBuilderSettingsInterface), f"malformed {triviaGameBuilderSettings=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__triviaGameBuilderSettings: TriviaGameBuilderSettingsInterface = triviaGameBuilderSettings
         self.__triviaIdGenerator: TriviaIdGeneratorInterface = triviaIdGenerator
@@ -44,9 +41,9 @@ class TriviaGameBuilder(TriviaGameBuilderInterface):
     ) -> Optional[StartNewTriviaGameAction]:
         if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         if not await self.__triviaGameBuilderSettings.isTriviaGameEnabled():
@@ -97,9 +94,9 @@ class TriviaGameBuilder(TriviaGameBuilderInterface):
     ) -> Optional[StartNewSuperTriviaGameAction]:
         if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidInt(numberOfGames):
+        if not utils.isValidInt(numberOfGames):
             raise TypeError(f'numberOfGames argument is malformed: \"{numberOfGames}\"')
-        elif numberOfGames < 1 or numberOfGames > utils.getIntMaxSafeSize():
+        if numberOfGames < 1 or numberOfGames > utils.getIntMaxSafeSize():
             raise ValueError(f'numberOfGames argument is out of bounds: {numberOfGames}')
 
         if not await self.__triviaGameBuilderSettings.isSuperTriviaGameEnabled():

--- a/src/CynanBot/trivia/builder/triviaGameBuilder.py
+++ b/src/CynanBot/trivia/builder/triviaGameBuilder.py
@@ -25,9 +25,12 @@ class TriviaGameBuilder(TriviaGameBuilderInterface):
         triviaIdGenerator: TriviaIdGeneratorInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(triviaGameBuilderSettings, TriviaGameBuilderSettingsInterface), f"malformed {triviaGameBuilderSettings=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(triviaGameBuilderSettings, TriviaGameBuilderSettingsInterface):
+            raise TypeError(f'triviaGameBuilderSettings argument is malformed: \"{triviaGameBuilderSettings}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise TypeError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__triviaGameBuilderSettings: TriviaGameBuilderSettingsInterface = triviaGameBuilderSettings
         self.__triviaIdGenerator: TriviaIdGeneratorInterface = triviaIdGenerator
@@ -41,9 +44,9 @@ class TriviaGameBuilder(TriviaGameBuilderInterface):
     ) -> Optional[StartNewTriviaGameAction]:
         if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         if not await self.__triviaGameBuilderSettings.isTriviaGameEnabled():
@@ -94,9 +97,9 @@ class TriviaGameBuilder(TriviaGameBuilderInterface):
     ) -> Optional[StartNewSuperTriviaGameAction]:
         if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidInt(numberOfGames):
+        elif not utils.isValidInt(numberOfGames):
             raise TypeError(f'numberOfGames argument is malformed: \"{numberOfGames}\"')
-        if numberOfGames < 1 or numberOfGames > utils.getIntMaxSafeSize():
+        elif numberOfGames < 1 or numberOfGames > utils.getIntMaxSafeSize():
             raise ValueError(f'numberOfGames argument is out of bounds: {numberOfGames}')
 
         if not await self.__triviaGameBuilderSettings.isSuperTriviaGameEnabled():

--- a/src/CynanBot/trivia/compilers/triviaAnswerCompiler.py
+++ b/src/CynanBot/trivia/compilers/triviaAnswerCompiler.py
@@ -16,8 +16,7 @@ from CynanBot.trivia.triviaExceptions import BadTriviaAnswerException
 class TriviaAnswerCompiler(TriviaAnswerCompilerInterface):
 
     def __init__(self, timber: TimberInterface):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__timber: TimberInterface = timber
 

--- a/src/CynanBot/trivia/compilers/triviaAnswerCompiler.py
+++ b/src/CynanBot/trivia/compilers/triviaAnswerCompiler.py
@@ -16,7 +16,8 @@ from CynanBot.trivia.triviaExceptions import BadTriviaAnswerException
 class TriviaAnswerCompiler(TriviaAnswerCompilerInterface):
 
     def __init__(self, timber: TimberInterface):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__timber: TimberInterface = timber
 

--- a/src/CynanBot/trivia/compilers/triviaQuestionCompiler.py
+++ b/src/CynanBot/trivia/compilers/triviaQuestionCompiler.py
@@ -18,8 +18,7 @@ class TriviaQuestionCompiler(TriviaQuestionCompilerInterface):
     """
 
     def __init__(self, timber: TimberInterface):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__timber: TimberInterface = timber
 
@@ -39,9 +38,8 @@ class TriviaQuestionCompiler(TriviaQuestionCompilerInterface):
         category: Optional[str],
         htmlUnescape: bool = False
     ) -> str:
-        if category is not None and not isinstance(category, str):
-            raise ValueError(f'category argument is malformed: \"{category}\"')
-        elif not utils.isValidBool(htmlUnescape):
+        assert category is None or isinstance(category, str), f"malformed {category=}"
+        if not utils.isValidBool(htmlUnescape):
             raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
 
         return await self.__compileText(
@@ -54,9 +52,8 @@ class TriviaQuestionCompiler(TriviaQuestionCompilerInterface):
         question: Optional[str],
         htmlUnescape: bool = False
     ) -> str:
-        if question is not None and not isinstance(question, str):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif not utils.isValidBool(htmlUnescape):
+        assert question is None or isinstance(question, str), f"malformed {question=}"
+        if not utils.isValidBool(htmlUnescape):
             raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
 
         return await self.__compileText(
@@ -69,9 +66,8 @@ class TriviaQuestionCompiler(TriviaQuestionCompilerInterface):
         response: Optional[str],
         htmlUnescape: bool = False
     ) -> str:
-        if response is not None and not isinstance(response, str):
-            raise ValueError(f'response argument is malformed: \"{response}\"')
-        elif not utils.isValidBool(htmlUnescape):
+        assert response is None or isinstance(response, str), f"malformed {response=}"
+        if not utils.isValidBool(htmlUnescape):
             raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
 
         return await self.__compileText(
@@ -108,9 +104,8 @@ class TriviaQuestionCompiler(TriviaQuestionCompilerInterface):
         text: Optional[str],
         htmlUnescape: bool
     ) -> str:
-        if text is not None and not isinstance(text, str):
-            raise ValueError(f'text argument is malformed: \"{text}\"')
-        elif not utils.isValidBool(htmlUnescape):
+        assert text is None or isinstance(text, str), f"malformed {text=}"
+        if not utils.isValidBool(htmlUnescape):
             raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
 
         if not utils.isValidStr(text):

--- a/src/CynanBot/trivia/compilers/triviaQuestionCompiler.py
+++ b/src/CynanBot/trivia/compilers/triviaQuestionCompiler.py
@@ -18,7 +18,8 @@ class TriviaQuestionCompiler(TriviaQuestionCompilerInterface):
     """
 
     def __init__(self, timber: TimberInterface):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__timber: TimberInterface = timber
 
@@ -38,8 +39,9 @@ class TriviaQuestionCompiler(TriviaQuestionCompilerInterface):
         category: Optional[str],
         htmlUnescape: bool = False
     ) -> str:
-        assert category is None or isinstance(category, str), f"malformed {category=}"
-        if not utils.isValidBool(htmlUnescape):
+        if category is not None and not isinstance(category, str):
+            raise ValueError(f'category argument is malformed: \"{category}\"')
+        elif not utils.isValidBool(htmlUnescape):
             raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
 
         return await self.__compileText(
@@ -52,8 +54,9 @@ class TriviaQuestionCompiler(TriviaQuestionCompilerInterface):
         question: Optional[str],
         htmlUnescape: bool = False
     ) -> str:
-        assert question is None or isinstance(question, str), f"malformed {question=}"
-        if not utils.isValidBool(htmlUnescape):
+        if question is not None and not isinstance(question, str):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
+        elif not utils.isValidBool(htmlUnescape):
             raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
 
         return await self.__compileText(
@@ -66,8 +69,9 @@ class TriviaQuestionCompiler(TriviaQuestionCompilerInterface):
         response: Optional[str],
         htmlUnescape: bool = False
     ) -> str:
-        assert response is None or isinstance(response, str), f"malformed {response=}"
-        if not utils.isValidBool(htmlUnescape):
+        if response is not None and not isinstance(response, str):
+            raise ValueError(f'response argument is malformed: \"{response}\"')
+        elif not utils.isValidBool(htmlUnescape):
             raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
 
         return await self.__compileText(
@@ -104,8 +108,9 @@ class TriviaQuestionCompiler(TriviaQuestionCompilerInterface):
         text: Optional[str],
         htmlUnescape: bool
     ) -> str:
-        assert text is None or isinstance(text, str), f"malformed {text=}"
-        if not utils.isValidBool(htmlUnescape):
+        if text is not None and not isinstance(text, str):
+            raise ValueError(f'text argument is malformed: \"{text}\"')
+        elif not utils.isValidBool(htmlUnescape):
             raise ValueError(f'htmlUnescape argument is malformed: \"{htmlUnescape}\"')
 
         if not utils.isValidStr(text):

--- a/src/CynanBot/trivia/content/triviaContentScanner.py
+++ b/src/CynanBot/trivia/content/triviaContentScanner.py
@@ -27,14 +27,10 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         timber: TimberInterface,
         triviaSettingsRepository: TriviaSettingsRepositoryInterface
     ):
-        if not isinstance(bannedWordsRepository, BannedWordsRepositoryInterface):
-            raise ValueError(f'bannedWordsRepository argument is malformed: \"{bannedWordsRepository}\"')
-        elif not isinstance(contentScanner, ContentScannerInterface):
-            raise ValueError(f'contentScanner argument is malformed: \"{contentScanner}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        assert isinstance(bannedWordsRepository, BannedWordsRepositoryInterface), f"malformed {bannedWordsRepository=}"
+        assert isinstance(contentScanner, ContentScannerInterface), f"malformed {contentScanner=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
 
         self.__bannedWordsRepository: BannedWordsRepositoryInterface = bannedWordsRepository
         self.__contentScanner: ContentScannerInterface = contentScanner
@@ -42,8 +38,7 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         self.__triviaSettingsRepository: TriviaSettingsRepositoryInterface = triviaSettingsRepository
 
     async def __getAllPhrasesFromQuestion(self, question: AbsTriviaQuestion) -> Set[Optional[str]]:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
 
         phrases: Set[Optional[str]] = set()
         await self.__contentScanner.updatePhrasesContent(phrases, question.getQuestion())
@@ -61,8 +56,7 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return phrases
 
     async def __getAllWordsFromQuestion(self, question: AbsTriviaQuestion) -> Set[Optional[str]]:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
 
         words: Set[Optional[str]] = set()
         await self.__contentScanner.updateWordsContent(words, question.getQuestion())
@@ -83,8 +77,7 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         if question is None:
             return TriviaContentCode.IS_NONE
 
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
 
         coreContentCode = await self.__verifyQuestionCoreContent(question)
         if coreContentCode is not TriviaContentCode.OK:
@@ -109,8 +102,7 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return TriviaContentCode.OK
 
     async def __verifyQuestionContentLengths(self, question: AbsTriviaQuestion) -> TriviaContentCode:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
 
         maxQuestionLength = await self.__triviaSettingsRepository.getMaxQuestionLength()
 
@@ -136,8 +128,7 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return TriviaContentCode.OK
 
     async def __verifyQuestionContentProfanity(self, question: AbsTriviaQuestion) -> TriviaContentCode:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
 
         phrases = await self.__getAllPhrasesFromQuestion(question)
         words = await self.__getAllWordsFromQuestion(question)
@@ -163,8 +154,7 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return TriviaContentCode.OK
 
     async def __verifyQuestionCoreContent(self, question: AbsTriviaQuestion) -> TriviaContentCode:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
 
         if not utils.isValidStr(question.getQuestion()):
             self.__timber.log('TriviaContentScanner', f'Trivia question ({question}) contains an empty question: \"{question.getQuestion()}\"')
@@ -184,8 +174,7 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return TriviaContentCode.OK
 
     async def __verifyQuestionDoesNotContainUrl(self, question: AbsTriviaQuestion):
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
 
         if utils.containsUrl(question.getQuestion()):
             self.__timber.log('TriviaContentScanner', f'Trivia question\'s ({question}) question contains a URL: \"{question.getQuestion()}\"')
@@ -203,8 +192,7 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return TriviaContentCode.OK
 
     async def __verifyQuestionResponseCount(self, question: AbsTriviaQuestion) -> TriviaContentCode:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
 
         if question.getTriviaType() is not TriviaQuestionType.MULTIPLE_CHOICE:
             return TriviaContentCode.OK

--- a/src/CynanBot/trivia/content/triviaContentScanner.py
+++ b/src/CynanBot/trivia/content/triviaContentScanner.py
@@ -27,10 +27,14 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         timber: TimberInterface,
         triviaSettingsRepository: TriviaSettingsRepositoryInterface
     ):
-        assert isinstance(bannedWordsRepository, BannedWordsRepositoryInterface), f"malformed {bannedWordsRepository=}"
-        assert isinstance(contentScanner, ContentScannerInterface), f"malformed {contentScanner=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        if not isinstance(bannedWordsRepository, BannedWordsRepositoryInterface):
+            raise ValueError(f'bannedWordsRepository argument is malformed: \"{bannedWordsRepository}\"')
+        elif not isinstance(contentScanner, ContentScannerInterface):
+            raise ValueError(f'contentScanner argument is malformed: \"{contentScanner}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
 
         self.__bannedWordsRepository: BannedWordsRepositoryInterface = bannedWordsRepository
         self.__contentScanner: ContentScannerInterface = contentScanner
@@ -38,7 +42,8 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         self.__triviaSettingsRepository: TriviaSettingsRepositoryInterface = triviaSettingsRepository
 
     async def __getAllPhrasesFromQuestion(self, question: AbsTriviaQuestion) -> Set[Optional[str]]:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
 
         phrases: Set[Optional[str]] = set()
         await self.__contentScanner.updatePhrasesContent(phrases, question.getQuestion())
@@ -56,7 +61,8 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return phrases
 
     async def __getAllWordsFromQuestion(self, question: AbsTriviaQuestion) -> Set[Optional[str]]:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
 
         words: Set[Optional[str]] = set()
         await self.__contentScanner.updateWordsContent(words, question.getQuestion())
@@ -77,7 +83,8 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         if question is None:
             return TriviaContentCode.IS_NONE
 
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
 
         coreContentCode = await self.__verifyQuestionCoreContent(question)
         if coreContentCode is not TriviaContentCode.OK:
@@ -102,7 +109,8 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return TriviaContentCode.OK
 
     async def __verifyQuestionContentLengths(self, question: AbsTriviaQuestion) -> TriviaContentCode:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
 
         maxQuestionLength = await self.__triviaSettingsRepository.getMaxQuestionLength()
 
@@ -128,7 +136,8 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return TriviaContentCode.OK
 
     async def __verifyQuestionContentProfanity(self, question: AbsTriviaQuestion) -> TriviaContentCode:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
 
         phrases = await self.__getAllPhrasesFromQuestion(question)
         words = await self.__getAllWordsFromQuestion(question)
@@ -154,7 +163,8 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return TriviaContentCode.OK
 
     async def __verifyQuestionCoreContent(self, question: AbsTriviaQuestion) -> TriviaContentCode:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
 
         if not utils.isValidStr(question.getQuestion()):
             self.__timber.log('TriviaContentScanner', f'Trivia question ({question}) contains an empty question: \"{question.getQuestion()}\"')
@@ -174,7 +184,8 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return TriviaContentCode.OK
 
     async def __verifyQuestionDoesNotContainUrl(self, question: AbsTriviaQuestion):
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
 
         if utils.containsUrl(question.getQuestion()):
             self.__timber.log('TriviaContentScanner', f'Trivia question\'s ({question}) question contains a URL: \"{question.getQuestion()}\"')
@@ -192,7 +203,8 @@ class TriviaContentScanner(TriviaContentScannerInterface):
         return TriviaContentCode.OK
 
     async def __verifyQuestionResponseCount(self, question: AbsTriviaQuestion) -> TriviaContentCode:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
 
         if question.getTriviaType() is not TriviaQuestionType.MULTIPLE_CHOICE:
             return TriviaContentCode.OK

--- a/src/CynanBot/trivia/events/correctAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/correctAnswerTriviaEvent.py
@@ -33,30 +33,26 @@ class CorrectAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif not isinstance(cutenessResult, CutenessResult):
-            raise ValueError(f'cutenessResult argument is malformed: \"{cutenessResult}\"')
-        elif not utils.isValidInt(pointsForWinning):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        assert isinstance(cutenessResult, CutenessResult), f"malformed {cutenessResult=}"
+        if not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not utils.isValidStr(answer):
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        if not utils.isValidStr(answer):
             raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        elif not utils.isValidStr(emote):
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(gameId):
+        if not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif not isinstance(triviaScoreResult, TriviaScoreResult):
-            raise ValueError(f'triviaScoreResult argument is malformed: \"{triviaScoreResult}\"')
+        assert isinstance(triviaScoreResult, TriviaScoreResult), f"malformed {triviaScoreResult=}"
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion
         self.__cutenessResult: CutenessResult = cutenessResult

--- a/src/CynanBot/trivia/events/correctAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/correctAnswerTriviaEvent.py
@@ -33,26 +33,30 @@ class CorrectAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        assert isinstance(cutenessResult, CutenessResult), f"malformed {cutenessResult=}"
-        if not utils.isValidInt(pointsForWinning):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif not isinstance(cutenessResult, CutenessResult):
+            raise ValueError(f'cutenessResult argument is malformed: \"{cutenessResult}\"')
+        elif not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        if not utils.isValidStr(answer):
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not utils.isValidStr(answer):
             raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        if not utils.isValidStr(emote):
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(gameId):
+        elif not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert isinstance(triviaScoreResult, TriviaScoreResult), f"malformed {triviaScoreResult=}"
+        elif not isinstance(triviaScoreResult, TriviaScoreResult):
+            raise ValueError(f'triviaScoreResult argument is malformed: \"{triviaScoreResult}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion
         self.__cutenessResult: CutenessResult = cutenessResult

--- a/src/CynanBot/trivia/events/correctSuperAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/correctSuperAnswerTriviaEvent.py
@@ -37,36 +37,32 @@ class CorrectSuperAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif not isinstance(cutenessResult, CutenessResult):
-            raise ValueError(f'cutenessResult argument is malformed: \"{cutenessResult}\"')
-        elif not utils.isValidInt(pointsForWinning):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        assert isinstance(cutenessResult, CutenessResult), f"malformed {cutenessResult=}"
+        if not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        elif not utils.isValidInt(remainingQueueSize):
+        if not utils.isValidInt(remainingQueueSize):
             raise ValueError(f'remainingQueueSize argument is malformed: \"{remainingQueueSize}\"')
-        elif remainingQueueSize < 0 or remainingQueueSize > utils.getIntMaxSafeSize():
+        if remainingQueueSize < 0 or remainingQueueSize > utils.getIntMaxSafeSize():
             raise ValueError(f'remainingQueueSize argument is out of bounds: {remainingQueueSize}')
-        elif toxicTriviaPunishmentResult is not None and not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
+        if toxicTriviaPunishmentResult is not None and not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
             raise ValueError(f'toxicTriviaPunishmentResult argument is out of bounds: {toxicTriviaPunishmentResult}')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not utils.isValidStr(answer):
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        if not utils.isValidStr(answer):
             raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        elif not utils.isValidStr(emote):
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(gameId):
+        if not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif not isinstance(triviaScoreResult, TriviaScoreResult):
-            raise ValueError(f'triviaScoreResult argument is malformed: \"{triviaScoreResult}\"')
+        assert isinstance(triviaScoreResult, TriviaScoreResult), f"malformed {triviaScoreResult=}"
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion
         self.__cutenessResult: CutenessResult = cutenessResult

--- a/src/CynanBot/trivia/events/correctSuperAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/correctSuperAnswerTriviaEvent.py
@@ -37,32 +37,36 @@ class CorrectSuperAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        assert isinstance(cutenessResult, CutenessResult), f"malformed {cutenessResult=}"
-        if not utils.isValidInt(pointsForWinning):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif not isinstance(cutenessResult, CutenessResult):
+            raise ValueError(f'cutenessResult argument is malformed: \"{cutenessResult}\"')
+        elif not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        if not utils.isValidInt(remainingQueueSize):
+        elif not utils.isValidInt(remainingQueueSize):
             raise ValueError(f'remainingQueueSize argument is malformed: \"{remainingQueueSize}\"')
-        if remainingQueueSize < 0 or remainingQueueSize > utils.getIntMaxSafeSize():
+        elif remainingQueueSize < 0 or remainingQueueSize > utils.getIntMaxSafeSize():
             raise ValueError(f'remainingQueueSize argument is out of bounds: {remainingQueueSize}')
-        if toxicTriviaPunishmentResult is not None and not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
+        elif toxicTriviaPunishmentResult is not None and not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
             raise ValueError(f'toxicTriviaPunishmentResult argument is out of bounds: {toxicTriviaPunishmentResult}')
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        if not utils.isValidStr(answer):
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not utils.isValidStr(answer):
             raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        if not utils.isValidStr(emote):
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(gameId):
+        elif not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert isinstance(triviaScoreResult, TriviaScoreResult), f"malformed {triviaScoreResult=}"
+        elif not isinstance(triviaScoreResult, TriviaScoreResult):
+            raise ValueError(f'triviaScoreResult argument is malformed: \"{triviaScoreResult}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion
         self.__cutenessResult: CutenessResult = cutenessResult

--- a/src/CynanBot/trivia/events/gameNotReadyCheckAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/gameNotReadyCheckAnswerTriviaEvent.py
@@ -21,13 +21,12 @@ class GameNotReadyCheckAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if answer is not None and not isinstance(answer, str):
-            raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__answer: Optional[str] = answer

--- a/src/CynanBot/trivia/events/gameNotReadyCheckAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/gameNotReadyCheckAnswerTriviaEvent.py
@@ -21,12 +21,13 @@ class GameNotReadyCheckAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
-        if not utils.isValidStr(twitchChannel):
+        if answer is not None and not isinstance(answer, str):
+            raise ValueError(f'answer argument is malformed: \"{answer}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__answer: Optional[str] = answer

--- a/src/CynanBot/trivia/events/incorrectAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/incorrectAnswerTriviaEvent.py
@@ -29,24 +29,20 @@ class IncorrectAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif answer is not None and not isinstance(answer, str):
-            raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(gameId):
+        if not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif not isinstance(triviaScoreResult, TriviaScoreResult):
-            raise ValueError(f'triviaScoreResult argument is malformed: \"{triviaScoreResult}\"')
+        assert isinstance(triviaScoreResult, TriviaScoreResult), f"malformed {triviaScoreResult=}"
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion
         self.__specialTriviaStatus: Optional[SpecialTriviaStatus] = specialTriviaStatus

--- a/src/CynanBot/trivia/events/incorrectAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/incorrectAnswerTriviaEvent.py
@@ -29,20 +29,24 @@ class IncorrectAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif answer is not None and not isinstance(answer, str):
+            raise ValueError(f'answer argument is malformed: \"{answer}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(gameId):
+        elif not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert isinstance(triviaScoreResult, TriviaScoreResult), f"malformed {triviaScoreResult=}"
+        elif not isinstance(triviaScoreResult, TriviaScoreResult):
+            raise ValueError(f'triviaScoreResult argument is malformed: \"{triviaScoreResult}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion
         self.__specialTriviaStatus: Optional[SpecialTriviaStatus] = specialTriviaStatus

--- a/src/CynanBot/trivia/events/incorrectSuperAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/incorrectSuperAnswerTriviaEvent.py
@@ -27,21 +27,18 @@ class IncorrectSuperAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif answer is not None and not isinstance(answer, str):
-            raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(gameId):
+        if not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/incorrectSuperAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/incorrectSuperAnswerTriviaEvent.py
@@ -27,18 +27,21 @@ class IncorrectSuperAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif answer is not None and not isinstance(answer, str):
+            raise ValueError(f'answer argument is malformed: \"{answer}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(gameId):
+        elif not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/invalidAnswerInputTriviaEvent.py
+++ b/src/CynanBot/trivia/events/invalidAnswerInputTriviaEvent.py
@@ -27,21 +27,18 @@ class InvalidAnswerInputTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif answer is not None and not isinstance(answer, str):
-            raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(gameId):
+        if not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/invalidAnswerInputTriviaEvent.py
+++ b/src/CynanBot/trivia/events/invalidAnswerInputTriviaEvent.py
@@ -27,18 +27,21 @@ class InvalidAnswerInputTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif answer is not None and not isinstance(answer, str):
+            raise ValueError(f'answer argument is malformed: \"{answer}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(gameId):
+        elif not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/newSuperTriviaGameEvent.py
+++ b/src/CynanBot/trivia/events/newSuperTriviaGameEvent.py
@@ -27,23 +27,21 @@ class NewSuperTriviaGameEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif not utils.isValidInt(pointsForWinning):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        if not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        elif not utils.isValidInt(secondsToLive):
+        if not utils.isValidInt(secondsToLive):
             raise ValueError(f'secondsToLive argument is malformed: \"{secondsToLive}\"')
-        elif secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
+        if secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
             raise ValueError(f'secondsToLive argument is out of bounds: {secondsToLive}')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not utils.isValidStr(emote):
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(gameId):
+        if not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/newSuperTriviaGameEvent.py
+++ b/src/CynanBot/trivia/events/newSuperTriviaGameEvent.py
@@ -27,21 +27,23 @@ class NewSuperTriviaGameEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        if not utils.isValidInt(pointsForWinning):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        if not utils.isValidInt(secondsToLive):
+        elif not utils.isValidInt(secondsToLive):
             raise ValueError(f'secondsToLive argument is malformed: \"{secondsToLive}\"')
-        if secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
+        elif secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
             raise ValueError(f'secondsToLive argument is out of bounds: {secondsToLive}')
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        if not utils.isValidStr(emote):
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(gameId):
+        elif not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/newTriviaGameEvent.py
+++ b/src/CynanBot/trivia/events/newTriviaGameEvent.py
@@ -29,27 +29,25 @@ class NewTriviaGameEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif not utils.isValidInt(pointsForWinning):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        if not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        elif not utils.isValidInt(secondsToLive):
+        if not utils.isValidInt(secondsToLive):
             raise ValueError(f'secondsToLive argument is malformed: \"{secondsToLive}\"')
-        elif secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
+        if secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
             raise ValueError(f'secondsToLive argument is out of bounds: {secondsToLive}')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not utils.isValidStr(emote):
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(gameId):
+        if not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/newTriviaGameEvent.py
+++ b/src/CynanBot/trivia/events/newTriviaGameEvent.py
@@ -29,25 +29,27 @@ class NewTriviaGameEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        if not utils.isValidInt(pointsForWinning):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        if not utils.isValidInt(secondsToLive):
+        elif not utils.isValidInt(secondsToLive):
             raise ValueError(f'secondsToLive argument is malformed: \"{secondsToLive}\"')
-        if secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
+        elif secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
             raise ValueError(f'secondsToLive argument is out of bounds: {secondsToLive}')
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        if not utils.isValidStr(emote):
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(gameId):
+        elif not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/outOfTimeSuperTriviaEvent.py
+++ b/src/CynanBot/trivia/events/outOfTimeSuperTriviaEvent.py
@@ -30,25 +30,22 @@ class OutOfTimeSuperTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif not utils.isValidInt(pointsForWinning):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        if not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        elif not utils.isValidInt(remainingQueueSize):
+        if not utils.isValidInt(remainingQueueSize):
             raise ValueError(f'remainingQueueSize argument is malformed: \"{remainingQueueSize}\"')
-        elif remainingQueueSize < 0 or remainingQueueSize > utils.getIntMaxSafeSize():
+        if remainingQueueSize < 0 or remainingQueueSize > utils.getIntMaxSafeSize():
             raise ValueError(f'remainingQueueSize argument is out of bounds: {remainingQueueSize}')
-        elif toxicTriviaPunishmentResult is not None and not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
-            raise ValueError(f'toxicTriviaPunishmentResult argument is malformed: \"{toxicTriviaPunishmentResult}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not utils.isValidStr(emote):
+        assert toxicTriviaPunishmentResult is None or isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult), f"malformed {toxicTriviaPunishmentResult=}"
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(gameId):
+        if not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/outOfTimeSuperTriviaEvent.py
+++ b/src/CynanBot/trivia/events/outOfTimeSuperTriviaEvent.py
@@ -30,22 +30,25 @@ class OutOfTimeSuperTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        if not utils.isValidInt(pointsForWinning):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        if not utils.isValidInt(remainingQueueSize):
+        elif not utils.isValidInt(remainingQueueSize):
             raise ValueError(f'remainingQueueSize argument is malformed: \"{remainingQueueSize}\"')
-        if remainingQueueSize < 0 or remainingQueueSize > utils.getIntMaxSafeSize():
+        elif remainingQueueSize < 0 or remainingQueueSize > utils.getIntMaxSafeSize():
             raise ValueError(f'remainingQueueSize argument is out of bounds: {remainingQueueSize}')
-        assert toxicTriviaPunishmentResult is None or isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult), f"malformed {toxicTriviaPunishmentResult=}"
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        if not utils.isValidStr(emote):
+        elif toxicTriviaPunishmentResult is not None and not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
+            raise ValueError(f'toxicTriviaPunishmentResult argument is malformed: \"{toxicTriviaPunishmentResult}\"')
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(gameId):
+        elif not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/outOfTimeTriviaEvent.py
+++ b/src/CynanBot/trivia/events/outOfTimeTriviaEvent.py
@@ -30,26 +30,23 @@ class OutOfTimeTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif not utils.isValidInt(pointsForWinning):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        if not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not utils.isValidStr(emote):
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(gameId):
+        if not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif not isinstance(triviaScoreResult, TriviaScoreResult):
-            raise ValueError(f'triviaScoreResult argument is malformed: \"{triviaScoreResult}\"')
+        assert isinstance(triviaScoreResult, TriviaScoreResult), f"malformed {triviaScoreResult=}"
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion
         self.__specialTriviaStatus: Optional[SpecialTriviaStatus] = specialTriviaStatus

--- a/src/CynanBot/trivia/events/outOfTimeTriviaEvent.py
+++ b/src/CynanBot/trivia/events/outOfTimeTriviaEvent.py
@@ -30,23 +30,26 @@ class OutOfTimeTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        if not utils.isValidInt(pointsForWinning):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        if not utils.isValidStr(emote):
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(gameId):
+        elif not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert isinstance(triviaScoreResult, TriviaScoreResult), f"malformed {triviaScoreResult=}"
+        elif not isinstance(triviaScoreResult, TriviaScoreResult):
+            raise ValueError(f'triviaScoreResult argument is malformed: \"{triviaScoreResult}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion
         self.__specialTriviaStatus: Optional[SpecialTriviaStatus] = specialTriviaStatus

--- a/src/CynanBot/trivia/events/superGameNotReadyCheckAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/superGameNotReadyCheckAnswerTriviaEvent.py
@@ -21,13 +21,12 @@ class SuperGameNotReadyCheckAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if answer is not None and not isinstance(answer, str):
-            raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__answer: Optional[str] = answer

--- a/src/CynanBot/trivia/events/superGameNotReadyCheckAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/superGameNotReadyCheckAnswerTriviaEvent.py
@@ -21,12 +21,13 @@ class SuperGameNotReadyCheckAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
-        if not utils.isValidStr(twitchChannel):
+        if answer is not None and not isinstance(answer, str):
+            raise ValueError(f'answer argument is malformed: \"{answer}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__answer: Optional[str] = answer

--- a/src/CynanBot/trivia/events/wrongUserCheckAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/wrongUserCheckAnswerTriviaEvent.py
@@ -25,19 +25,17 @@ class WrongUserCheckAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif answer is not None and not isinstance(answer, str):
-            raise ValueError(f'answer argument is malformed: \"{answer}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(gameId):
+        if not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/events/wrongUserCheckAnswerTriviaEvent.py
+++ b/src/CynanBot/trivia/events/wrongUserCheckAnswerTriviaEvent.py
@@ -25,17 +25,19 @@ class WrongUserCheckAnswerTriviaEvent(AbsTriviaEvent):
             eventId = eventId
         )
 
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        assert answer is None or isinstance(answer, str), f"malformed {answer=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif answer is not None and not isinstance(answer, str):
+            raise ValueError(f'answer argument is malformed: \"{answer}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(gameId):
+        elif not utils.isValidStr(gameId):
             raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/gameController/triviaGameControllersRepository.py
+++ b/src/CynanBot/trivia/gameController/triviaGameControllersRepository.py
@@ -28,14 +28,10 @@ class TriviaGameControllersRepository(TriviaGameControllersRepositoryInterface):
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -51,7 +47,7 @@ class TriviaGameControllersRepository(TriviaGameControllersRepositoryInterface):
     ) -> AddTriviaGameControllerResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         twitchAccessToken = await self.__twitchTokensRepository.getAccessToken(twitchChannel)
@@ -172,7 +168,7 @@ class TriviaGameControllersRepository(TriviaGameControllersRepositoryInterface):
     ) -> RemoveTriviaGameControllerResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         userId = await self.__userIdsRepository.fetchUserId(userName = userName)

--- a/src/CynanBot/trivia/gameController/triviaGameControllersRepository.py
+++ b/src/CynanBot/trivia/gameController/triviaGameControllersRepository.py
@@ -28,10 +28,14 @@ class TriviaGameControllersRepository(TriviaGameControllersRepositoryInterface):
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -47,7 +51,7 @@ class TriviaGameControllersRepository(TriviaGameControllersRepositoryInterface):
     ) -> AddTriviaGameControllerResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         twitchAccessToken = await self.__twitchTokensRepository.getAccessToken(twitchChannel)
@@ -168,7 +172,7 @@ class TriviaGameControllersRepository(TriviaGameControllersRepositoryInterface):
     ) -> RemoveTriviaGameControllerResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         userId = await self.__userIdsRepository.fetchUserId(userName = userName)

--- a/src/CynanBot/trivia/gameController/triviaGameGlobalControllersRepository.py
+++ b/src/CynanBot/trivia/gameController/triviaGameGlobalControllersRepository.py
@@ -31,16 +31,11 @@ class TriviaGameGlobalControllersRepository(TriviaGameGlobalControllersRepositor
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__backingDatabase: BackingDatabase = backingDatabase

--- a/src/CynanBot/trivia/gameController/triviaGameGlobalControllersRepository.py
+++ b/src/CynanBot/trivia/gameController/triviaGameGlobalControllersRepository.py
@@ -31,11 +31,16 @@ class TriviaGameGlobalControllersRepository(TriviaGameGlobalControllersRepositor
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__backingDatabase: BackingDatabase = backingDatabase

--- a/src/CynanBot/trivia/games/absTriviaGameState.py
+++ b/src/CynanBot/trivia/games/absTriviaGameState.py
@@ -23,27 +23,25 @@ class AbsTriviaGameState(ABC):
         emote: str,
         twitchChannel: str
     ):
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif not utils.isValidInt(basePointsForWinning):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        if not utils.isValidInt(basePointsForWinning):
             raise ValueError(f'basePointsForWinning argument is malformed: \"{basePointsForWinning}\"')
-        elif basePointsForWinning < 1 or basePointsForWinning > utils.getIntMaxSafeSize():
+        if basePointsForWinning < 1 or basePointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'basePointsForWinning argument is out of bounds: {basePointsForWinning}')
-        elif not utils.isValidInt(pointsForWinning):
+        if not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        elif not utils.isValidInt(secondsToLive):
+        if not utils.isValidInt(secondsToLive):
             raise ValueError(f'secondsToLive argument is malformed: \"{secondsToLive}\"')
-        elif secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
+        if secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
             raise ValueError(f'secondsToLive argument is out of bounds: {secondsToLive}')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not utils.isValidStr(actionId):
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        if not utils.isValidStr(actionId):
             raise ValueError(f'actionId argument is malformed: \"{actionId}\"')
-        elif not utils.isValidStr(emote):
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/games/absTriviaGameState.py
+++ b/src/CynanBot/trivia/games/absTriviaGameState.py
@@ -23,25 +23,27 @@ class AbsTriviaGameState(ABC):
         emote: str,
         twitchChannel: str
     ):
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        if not utils.isValidInt(basePointsForWinning):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif not utils.isValidInt(basePointsForWinning):
             raise ValueError(f'basePointsForWinning argument is malformed: \"{basePointsForWinning}\"')
-        if basePointsForWinning < 1 or basePointsForWinning > utils.getIntMaxSafeSize():
+        elif basePointsForWinning < 1 or basePointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'basePointsForWinning argument is out of bounds: {basePointsForWinning}')
-        if not utils.isValidInt(pointsForWinning):
+        elif not utils.isValidInt(pointsForWinning):
             raise ValueError(f'pointsForWinning argument is malformed: \"{pointsForWinning}\"')
-        if pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
+        elif pointsForWinning < 1 or pointsForWinning > utils.getIntMaxSafeSize():
             raise ValueError(f'pointsForWinning argument is out of bounds: {pointsForWinning}')
-        if not utils.isValidInt(secondsToLive):
+        elif not utils.isValidInt(secondsToLive):
             raise ValueError(f'secondsToLive argument is malformed: \"{secondsToLive}\"')
-        if secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
+        elif secondsToLive < 1 or secondsToLive > utils.getIntMaxSafeSize():
             raise ValueError(f'secondsToLive argument is out of bounds: {secondsToLive}')
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        if not utils.isValidStr(actionId):
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not utils.isValidStr(actionId):
             raise ValueError(f'actionId argument is malformed: \"{actionId}\"')
-        if not utils.isValidStr(emote):
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__triviaQuestion: AbsTriviaQuestion = triviaQuestion

--- a/src/CynanBot/trivia/games/queuedTriviaGameStore.py
+++ b/src/CynanBot/trivia/games/queuedTriviaGameStore.py
@@ -26,15 +26,12 @@ class QueuedTriviaGameStore(QueuedTriviaGameStoreInterface):
         triviaSettingsRepository: TriviaSettingsRepositoryInterface,
         queueTimeoutSeconds: float = 3
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
-        elif not utils.isValidNum(queueTimeoutSeconds):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        if not utils.isValidNum(queueTimeoutSeconds):
             raise ValueError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
+        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
 
         self.__timber: TimberInterface = timber
@@ -51,8 +48,7 @@ class QueuedTriviaGameStore(QueuedTriviaGameStoreInterface):
     ) -> AddQueuedGamesResult:
         if not utils.isValidBool(isSuperTriviaGameCurrentlyInProgress):
             raise ValueError(f'isSuperTriviaGameCurrentlyInProgress argument is malformed: \"{isSuperTriviaGameCurrentlyInProgress}\"')
-        elif not isinstance(action, StartNewSuperTriviaGameAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(action, StartNewSuperTriviaGameAction), f"malformed {action=}"
 
         queuedSuperGames = self.__queuedSuperGames[action.getTwitchChannel().lower()]
         oldQueueSize = queuedSuperGames.qsize()

--- a/src/CynanBot/trivia/games/queuedTriviaGameStore.py
+++ b/src/CynanBot/trivia/games/queuedTriviaGameStore.py
@@ -26,12 +26,15 @@ class QueuedTriviaGameStore(QueuedTriviaGameStoreInterface):
         triviaSettingsRepository: TriviaSettingsRepositoryInterface,
         queueTimeoutSeconds: float = 3
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
-        if not utils.isValidNum(queueTimeoutSeconds):
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        elif not utils.isValidNum(queueTimeoutSeconds):
             raise ValueError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
+        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
 
         self.__timber: TimberInterface = timber
@@ -48,7 +51,8 @@ class QueuedTriviaGameStore(QueuedTriviaGameStoreInterface):
     ) -> AddQueuedGamesResult:
         if not utils.isValidBool(isSuperTriviaGameCurrentlyInProgress):
             raise ValueError(f'isSuperTriviaGameCurrentlyInProgress argument is malformed: \"{isSuperTriviaGameCurrentlyInProgress}\"')
-        assert isinstance(action, StartNewSuperTriviaGameAction), f"malformed {action=}"
+        elif not isinstance(action, StartNewSuperTriviaGameAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         queuedSuperGames = self.__queuedSuperGames[action.getTwitchChannel().lower()]
         oldQueueSize = queuedSuperGames.qsize()

--- a/src/CynanBot/trivia/games/triviaGameStore.py
+++ b/src/CynanBot/trivia/games/triviaGameStore.py
@@ -17,8 +17,7 @@ class TriviaGameStore(TriviaGameStoreInterface):
         self.__superGameStates: List[SuperTriviaGameState] = list()
 
     async def add(self, state: AbsTriviaGameState):
-        if not isinstance(state, AbsTriviaGameState):
-            raise ValueError(f'state argument is malformed: \"{state}\"')
+        assert isinstance(state, AbsTriviaGameState), f"malformed {state=}"
 
         if state.getTriviaGameType() is TriviaGameType.NORMAL:
             await self.__addNormalGame(state)
@@ -28,14 +27,12 @@ class TriviaGameStore(TriviaGameStoreInterface):
             raise UnknownTriviaGameTypeException(f'Unknown TriviaGameType: \"{state.getTriviaGameType()}\"')
 
     async def __addNormalGame(self, state: TriviaGameState):
-        if not isinstance(state, TriviaGameState):
-            raise ValueError(f'state argument is malformed: \"{state}\"')
+        assert isinstance(state, TriviaGameState), f"malformed {state=}"
 
         self.__normalGameStates.append(state)
 
     async def __addSuperGame(self, state: SuperTriviaGameState):
-        if not isinstance(state, SuperTriviaGameState):
-            raise ValueError(f'state argument is malformed: \"{state}\"')
+        assert isinstance(state, SuperTriviaGameState), f"malformed {state=}"
 
         self.__superGameStates.append(state)
 
@@ -52,7 +49,7 @@ class TriviaGameStore(TriviaGameStoreInterface):
     async def getNormalGame(self, twitchChannel: str, userId: str) -> Optional[TriviaGameState]:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         normalGames = await self.getNormalGames()
@@ -96,7 +93,7 @@ class TriviaGameStore(TriviaGameStoreInterface):
     async def removeNormalGame(self, twitchChannel: str, userId: str) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         normalGames = await self.getNormalGames()

--- a/src/CynanBot/trivia/games/triviaGameStore.py
+++ b/src/CynanBot/trivia/games/triviaGameStore.py
@@ -17,7 +17,8 @@ class TriviaGameStore(TriviaGameStoreInterface):
         self.__superGameStates: List[SuperTriviaGameState] = list()
 
     async def add(self, state: AbsTriviaGameState):
-        assert isinstance(state, AbsTriviaGameState), f"malformed {state=}"
+        if not isinstance(state, AbsTriviaGameState):
+            raise ValueError(f'state argument is malformed: \"{state}\"')
 
         if state.getTriviaGameType() is TriviaGameType.NORMAL:
             await self.__addNormalGame(state)
@@ -27,12 +28,14 @@ class TriviaGameStore(TriviaGameStoreInterface):
             raise UnknownTriviaGameTypeException(f'Unknown TriviaGameType: \"{state.getTriviaGameType()}\"')
 
     async def __addNormalGame(self, state: TriviaGameState):
-        assert isinstance(state, TriviaGameState), f"malformed {state=}"
+        if not isinstance(state, TriviaGameState):
+            raise ValueError(f'state argument is malformed: \"{state}\"')
 
         self.__normalGameStates.append(state)
 
     async def __addSuperGame(self, state: SuperTriviaGameState):
-        assert isinstance(state, SuperTriviaGameState), f"malformed {state=}"
+        if not isinstance(state, SuperTriviaGameState):
+            raise ValueError(f'state argument is malformed: \"{state}\"')
 
         self.__superGameStates.append(state)
 
@@ -49,7 +52,7 @@ class TriviaGameStore(TriviaGameStoreInterface):
     async def getNormalGame(self, twitchChannel: str, userId: str) -> Optional[TriviaGameState]:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         normalGames = await self.getNormalGames()
@@ -93,7 +96,7 @@ class TriviaGameStore(TriviaGameStoreInterface):
     async def removeNormalGame(self, twitchChannel: str, userId: str) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         normalGames = await self.getNormalGames()

--- a/src/CynanBot/trivia/questions/absTriviaQuestion.py
+++ b/src/CynanBot/trivia/questions/absTriviaQuestion.py
@@ -26,14 +26,11 @@ class AbsTriviaQuestion(ABC):
     ):
         if not utils.isValidStr(question):
             raise NoTriviaQuestionException(f'question argument is malformed: \"{question}\"')
-        elif not utils.isValidStr(triviaId):
+        if not utils.isValidStr(triviaId):
             raise BadTriviaIdException(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not isinstance(triviaDifficulty, TriviaDifficulty):
-            raise BadTriviaDifficultyException(f'triviaDifficulty argument is malformed: \"{triviaDifficulty}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise BadTriviaSourceException(f'triviaSource argument is malformed: \"{triviaSource}\"')
-        elif not isinstance(triviaType, TriviaQuestionType):
-            raise BadTriviaTypeException(f'triviaType argument is malformed: \"{triviaType}\"')
+        assert isinstance(triviaDifficulty, TriviaDifficulty), f"malformed {triviaDifficulty=}"
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
 
         self.__category: Optional[str] = category
         self.__categoryId: Optional[str] = categoryId

--- a/src/CynanBot/trivia/questions/absTriviaQuestion.py
+++ b/src/CynanBot/trivia/questions/absTriviaQuestion.py
@@ -26,11 +26,14 @@ class AbsTriviaQuestion(ABC):
     ):
         if not utils.isValidStr(question):
             raise NoTriviaQuestionException(f'question argument is malformed: \"{question}\"')
-        if not utils.isValidStr(triviaId):
+        elif not utils.isValidStr(triviaId):
             raise BadTriviaIdException(f'triviaId argument is malformed: \"{triviaId}\"')
-        assert isinstance(triviaDifficulty, TriviaDifficulty), f"malformed {triviaDifficulty=}"
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
-        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
+        elif not isinstance(triviaDifficulty, TriviaDifficulty):
+            raise BadTriviaDifficultyException(f'triviaDifficulty argument is malformed: \"{triviaDifficulty}\"')
+        elif not isinstance(triviaSource, TriviaSource):
+            raise BadTriviaSourceException(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        elif not isinstance(triviaType, TriviaQuestionType):
+            raise BadTriviaTypeException(f'triviaType argument is malformed: \"{triviaType}\"')
 
         self.__category: Optional[str] = category
         self.__categoryId: Optional[str] = categoryId

--- a/src/CynanBot/trivia/questions/multipleChoiceTriviaQuestion.py
+++ b/src/CynanBot/trivia/questions/multipleChoiceTriviaQuestion.py
@@ -34,7 +34,7 @@ class MultipleChoiceTriviaQuestion(AbsTriviaQuestion):
 
         if not utils.areValidStrs(correctAnswers):
             raise NoTriviaCorrectAnswersException(f'correctAnswers argument is malformed: \"{correctAnswers}\"')
-        elif not utils.hasItems(multipleChoiceResponses):
+        if not utils.hasItems(multipleChoiceResponses):
             raise NoTriviaMultipleChoiceResponsesException(f'multipleChoiceResponses argument is malformed: \"{multipleChoiceResponses}\"')
 
         self.__correctAnswers: List[str] = correctAnswers
@@ -65,7 +65,7 @@ class MultipleChoiceTriviaQuestion(AbsTriviaQuestion):
 
         if not utils.hasItems(correctAnswerChars):
             raise RuntimeError(f'Couldn\'t find any correct answer chars within \"{self.__correctAnswers}\"')
-        elif len(correctAnswerChars) != len(self.__correctAnswers):
+        if len(correctAnswerChars) != len(self.__correctAnswers):
             raise RuntimeError(f'The length of correctAnswerChars \"{correctAnswerChars}\" ({len(correctAnswerChars)}) is not equal to \"{self.__correctAnswers}\" ({len(self.__correctAnswers)})')
 
         correctAnswerChars.sort()
@@ -82,15 +82,14 @@ class MultipleChoiceTriviaQuestion(AbsTriviaQuestion):
 
         if not utils.hasItems(ordinals):
             raise RuntimeError(f'Couldn\'t find any correct answer ordinals within \"{self.__correctAnswers}\"!')
-        elif len(ordinals) != len(self.__correctAnswers):
+        if len(ordinals) != len(self.__correctAnswers):
             raise RuntimeError(f'The length of ordinals \"{ordinals}\" ({len(ordinals)}) is not equal to \"{self.__correctAnswers}\" ({len(self.__correctAnswers)})')
 
         ordinals.sort()
         return ordinals
 
     def getPrompt(self, delimiter: str = ' ') -> str:
-        if not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         responsesList: List[str] = list()
         entryChar = 'A'

--- a/src/CynanBot/trivia/questions/multipleChoiceTriviaQuestion.py
+++ b/src/CynanBot/trivia/questions/multipleChoiceTriviaQuestion.py
@@ -34,7 +34,7 @@ class MultipleChoiceTriviaQuestion(AbsTriviaQuestion):
 
         if not utils.areValidStrs(correctAnswers):
             raise NoTriviaCorrectAnswersException(f'correctAnswers argument is malformed: \"{correctAnswers}\"')
-        if not utils.hasItems(multipleChoiceResponses):
+        elif not utils.hasItems(multipleChoiceResponses):
             raise NoTriviaMultipleChoiceResponsesException(f'multipleChoiceResponses argument is malformed: \"{multipleChoiceResponses}\"')
 
         self.__correctAnswers: List[str] = correctAnswers
@@ -65,7 +65,7 @@ class MultipleChoiceTriviaQuestion(AbsTriviaQuestion):
 
         if not utils.hasItems(correctAnswerChars):
             raise RuntimeError(f'Couldn\'t find any correct answer chars within \"{self.__correctAnswers}\"')
-        if len(correctAnswerChars) != len(self.__correctAnswers):
+        elif len(correctAnswerChars) != len(self.__correctAnswers):
             raise RuntimeError(f'The length of correctAnswerChars \"{correctAnswerChars}\" ({len(correctAnswerChars)}) is not equal to \"{self.__correctAnswers}\" ({len(self.__correctAnswers)})')
 
         correctAnswerChars.sort()
@@ -82,14 +82,15 @@ class MultipleChoiceTriviaQuestion(AbsTriviaQuestion):
 
         if not utils.hasItems(ordinals):
             raise RuntimeError(f'Couldn\'t find any correct answer ordinals within \"{self.__correctAnswers}\"!')
-        if len(ordinals) != len(self.__correctAnswers):
+        elif len(ordinals) != len(self.__correctAnswers):
             raise RuntimeError(f'The length of ordinals \"{ordinals}\" ({len(ordinals)}) is not equal to \"{self.__correctAnswers}\" ({len(self.__correctAnswers)})')
 
         ordinals.sort()
         return ordinals
 
     def getPrompt(self, delimiter: str = ' ') -> str:
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         responsesList: List[str] = list()
         entryChar = 'A'

--- a/src/CynanBot/trivia/questions/triviaQuestionReference.py
+++ b/src/CynanBot/trivia/questions/triviaQuestionReference.py
@@ -15,14 +15,12 @@ class TriviaQuestionReference():
     ):
         if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(triviaId):
+        if not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not isinstance(triviaSource, TriviaSource):
-            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
-        elif not isinstance(triviaType, TriviaQuestionType):
-            raise ValueError(f'triviaType argument is malformed: \"{triviaType}\"')
+        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
+        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
 
         self.__emote: str = emote
         self.__triviaId: str = triviaId

--- a/src/CynanBot/trivia/questions/triviaQuestionReference.py
+++ b/src/CynanBot/trivia/questions/triviaQuestionReference.py
@@ -15,12 +15,14 @@ class TriviaQuestionReference():
     ):
         if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(triviaId):
+        elif not utils.isValidStr(triviaId):
             raise ValueError(f'triviaId argument is malformed: \"{triviaId}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        assert isinstance(triviaSource, TriviaSource), f"malformed {triviaSource=}"
-        assert isinstance(triviaType, TriviaQuestionType), f"malformed {triviaType=}"
+        elif not isinstance(triviaSource, TriviaSource):
+            raise ValueError(f'triviaSource argument is malformed: \"{triviaSource}\"')
+        elif not isinstance(triviaType, TriviaQuestionType):
+            raise ValueError(f'triviaType argument is malformed: \"{triviaType}\"')
 
         self.__emote: str = emote
         self.__triviaId: str = triviaId

--- a/src/CynanBot/trivia/score/triviaScoreRepository.py
+++ b/src/CynanBot/trivia/score/triviaScoreRepository.py
@@ -10,8 +10,7 @@ from CynanBot.trivia.score.triviaScoreResult import TriviaScoreResult
 class TriviaScoreRepository(TriviaScoreRepositoryInterface):
 
     def __init__(self, backingDatabase: BackingDatabase):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
 
@@ -24,7 +23,7 @@ class TriviaScoreRepository(TriviaScoreRepositoryInterface):
     ) -> TriviaScoreResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -79,7 +78,7 @@ class TriviaScoreRepository(TriviaScoreRepositoryInterface):
     ) -> TriviaScoreResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         result = await self.fetchTriviaScore(
@@ -116,7 +115,7 @@ class TriviaScoreRepository(TriviaScoreRepositoryInterface):
     ) -> TriviaScoreResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         result = await self.fetchTriviaScore(
@@ -159,7 +158,7 @@ class TriviaScoreRepository(TriviaScoreRepositoryInterface):
     ) -> TriviaScoreResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         result = await self.fetchTriviaScore(
@@ -246,23 +245,23 @@ class TriviaScoreRepository(TriviaScoreRepositoryInterface):
     ):
         if not utils.isValidInt(newStreak):
             raise ValueError(f'newStreak argument is malformed: \"{newStreak}\"')
-        elif newStreak < utils.getIntMinSafeSize() or newStreak > utils.getIntMaxSafeSize():
+        if newStreak < utils.getIntMinSafeSize() or newStreak > utils.getIntMaxSafeSize():
             raise ValueError(f'newStreak argument is out of boudns: {newStreak}')
-        elif not utils.isValidInt(newSuperTriviaWins):
+        if not utils.isValidInt(newSuperTriviaWins):
             raise ValueError(f'newSuperTriviaWins argument is malformed: \"{newSuperTriviaWins}\"')
-        elif newSuperTriviaWins < 0 or newSuperTriviaWins > utils.getIntMaxSafeSize():
+        if newSuperTriviaWins < 0 or newSuperTriviaWins > utils.getIntMaxSafeSize():
             raise ValueError(f'newSuperTriviaWins argument is out of bounds: {newSuperTriviaWins}')
-        elif not utils.isValidInt(newTriviaLosses):
+        if not utils.isValidInt(newTriviaLosses):
             raise ValueError(f'newTriviaLosses argument is malformed: \"{newTriviaLosses}\"')
-        elif newTriviaLosses < 0 or newTriviaLosses > utils.getIntMaxSafeSize():
+        if newTriviaLosses < 0 or newTriviaLosses > utils.getIntMaxSafeSize():
             raise ValueError(f'newTriviaLosses argument is out of bounds: {newTriviaLosses}')
-        elif not utils.isValidInt(newTriviaWins):
+        if not utils.isValidInt(newTriviaWins):
             raise ValueError(f'newTriviaWins argument is malformed: \"{newTriviaWins}\"')
-        elif newTriviaWins < 0 or newTriviaLosses > utils.getIntMaxSafeSize():
+        if newTriviaWins < 0 or newTriviaLosses > utils.getIntMaxSafeSize():
             raise ValueError(f'newTriviaWins argument is out of bounds: {newTriviaWins}')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         connection = await self.__backingDatabase.getConnection()

--- a/src/CynanBot/trivia/score/triviaScoreRepository.py
+++ b/src/CynanBot/trivia/score/triviaScoreRepository.py
@@ -10,7 +10,8 @@ from CynanBot.trivia.score.triviaScoreResult import TriviaScoreResult
 class TriviaScoreRepository(TriviaScoreRepositoryInterface):
 
     def __init__(self, backingDatabase: BackingDatabase):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
 
@@ -23,7 +24,7 @@ class TriviaScoreRepository(TriviaScoreRepositoryInterface):
     ) -> TriviaScoreResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -78,7 +79,7 @@ class TriviaScoreRepository(TriviaScoreRepositoryInterface):
     ) -> TriviaScoreResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         result = await self.fetchTriviaScore(
@@ -115,7 +116,7 @@ class TriviaScoreRepository(TriviaScoreRepositoryInterface):
     ) -> TriviaScoreResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         result = await self.fetchTriviaScore(
@@ -158,7 +159,7 @@ class TriviaScoreRepository(TriviaScoreRepositoryInterface):
     ) -> TriviaScoreResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         result = await self.fetchTriviaScore(
@@ -245,23 +246,23 @@ class TriviaScoreRepository(TriviaScoreRepositoryInterface):
     ):
         if not utils.isValidInt(newStreak):
             raise ValueError(f'newStreak argument is malformed: \"{newStreak}\"')
-        if newStreak < utils.getIntMinSafeSize() or newStreak > utils.getIntMaxSafeSize():
+        elif newStreak < utils.getIntMinSafeSize() or newStreak > utils.getIntMaxSafeSize():
             raise ValueError(f'newStreak argument is out of boudns: {newStreak}')
-        if not utils.isValidInt(newSuperTriviaWins):
+        elif not utils.isValidInt(newSuperTriviaWins):
             raise ValueError(f'newSuperTriviaWins argument is malformed: \"{newSuperTriviaWins}\"')
-        if newSuperTriviaWins < 0 or newSuperTriviaWins > utils.getIntMaxSafeSize():
+        elif newSuperTriviaWins < 0 or newSuperTriviaWins > utils.getIntMaxSafeSize():
             raise ValueError(f'newSuperTriviaWins argument is out of bounds: {newSuperTriviaWins}')
-        if not utils.isValidInt(newTriviaLosses):
+        elif not utils.isValidInt(newTriviaLosses):
             raise ValueError(f'newTriviaLosses argument is malformed: \"{newTriviaLosses}\"')
-        if newTriviaLosses < 0 or newTriviaLosses > utils.getIntMaxSafeSize():
+        elif newTriviaLosses < 0 or newTriviaLosses > utils.getIntMaxSafeSize():
             raise ValueError(f'newTriviaLosses argument is out of bounds: {newTriviaLosses}')
-        if not utils.isValidInt(newTriviaWins):
+        elif not utils.isValidInt(newTriviaWins):
             raise ValueError(f'newTriviaWins argument is malformed: \"{newTriviaWins}\"')
-        if newTriviaWins < 0 or newTriviaLosses > utils.getIntMaxSafeSize():
+        elif newTriviaWins < 0 or newTriviaLosses > utils.getIntMaxSafeSize():
             raise ValueError(f'newTriviaWins argument is out of bounds: {newTriviaWins}')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         connection = await self.__backingDatabase.getConnection()

--- a/src/CynanBot/trivia/specialStatus/shinyTriviaHelper.py
+++ b/src/CynanBot/trivia/specialStatus/shinyTriviaHelper.py
@@ -23,18 +23,12 @@ class ShinyTriviaHelper():
         cooldown: timedelta = timedelta(hours = 3),
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
-            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
-        elif not isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface):
-            raise ValueError(f'shinyTriviaOccurencesRepository argument is malformed: \"{shinyTriviaOccurencesRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
-        elif not isinstance(cooldown, timedelta):
-            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
+        assert isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface), f"malformed {shinyTriviaOccurencesRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__shinyTriviaOccurencesRepository: ShinyTriviaOccurencesRepositoryInterface = shinyTriviaOccurencesRepository
@@ -67,7 +61,7 @@ class ShinyTriviaHelper():
     ) -> Optional[int]:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         cutenessLeaderboard = await self.__cutenessRepository.fetchCutenessLeaderboard(
@@ -94,9 +88,9 @@ class ShinyTriviaHelper():
     ) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         if not await self.__triviaSettingsRepository.areShinyTriviasEnabled():
@@ -162,9 +156,9 @@ class ShinyTriviaHelper():
     ):
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         result = await self.__shinyTriviaOccurencesRepository.incrementShinyCount(

--- a/src/CynanBot/trivia/specialStatus/shinyTriviaHelper.py
+++ b/src/CynanBot/trivia/specialStatus/shinyTriviaHelper.py
@@ -23,12 +23,18 @@ class ShinyTriviaHelper():
         cooldown: timedelta = timedelta(hours = 3),
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
-        assert isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface), f"malformed {shinyTriviaOccurencesRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
-        assert isinstance(cooldown, timedelta), f"malformed {cooldown=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        if not isinstance(cutenessRepository, CutenessRepositoryInterface):
+            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
+        elif not isinstance(shinyTriviaOccurencesRepository, ShinyTriviaOccurencesRepositoryInterface):
+            raise ValueError(f'shinyTriviaOccurencesRepository argument is malformed: \"{shinyTriviaOccurencesRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        elif not isinstance(cooldown, timedelta):
+            raise ValueError(f'cooldown argument is malformed: \"{cooldown}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
         self.__shinyTriviaOccurencesRepository: ShinyTriviaOccurencesRepositoryInterface = shinyTriviaOccurencesRepository
@@ -61,7 +67,7 @@ class ShinyTriviaHelper():
     ) -> Optional[int]:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         cutenessLeaderboard = await self.__cutenessRepository.fetchCutenessLeaderboard(
@@ -88,9 +94,9 @@ class ShinyTriviaHelper():
     ) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         if not await self.__triviaSettingsRepository.areShinyTriviasEnabled():
@@ -156,9 +162,9 @@ class ShinyTriviaHelper():
     ):
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         result = await self.__shinyTriviaOccurencesRepository.incrementShinyCount(

--- a/src/CynanBot/trivia/specialStatus/shinyTriviaOccurencesRepository.py
+++ b/src/CynanBot/trivia/specialStatus/shinyTriviaOccurencesRepository.py
@@ -17,10 +17,8 @@ class ShinyTriviaOccurencesRepository(ShinyTriviaOccurencesRepositoryInterface):
         backingDatabase: BackingDatabase,
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timeZone: timezone = timeZone
@@ -34,9 +32,9 @@ class ShinyTriviaOccurencesRepository(ShinyTriviaOccurencesRepositoryInterface):
     ) -> ShinyTriviaResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif userId == '0':
+        if userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -77,9 +75,9 @@ class ShinyTriviaOccurencesRepository(ShinyTriviaOccurencesRepositoryInterface):
     ) -> ShinyTriviaResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif userId == '0':
+        if userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
 
         result = await self.fetchDetails(
@@ -149,13 +147,13 @@ class ShinyTriviaOccurencesRepository(ShinyTriviaOccurencesRepositoryInterface):
     ):
         if not utils.isValidInt(newShinyCount):
             raise ValueError(f'newShinyCount argument is malformed: \"{newShinyCount}\"')
-        elif newShinyCount < 0 or newShinyCount > utils.getIntMaxSafeSize():
+        if newShinyCount < 0 or newShinyCount > utils.getIntMaxSafeSize():
             raise ValueError(f'newShinyCount argument is out of bounds: {newShinyCount}')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif userId == '0':
+        if userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
 
         nowDateTime = datetime.now(self.__timeZone)

--- a/src/CynanBot/trivia/specialStatus/shinyTriviaOccurencesRepository.py
+++ b/src/CynanBot/trivia/specialStatus/shinyTriviaOccurencesRepository.py
@@ -17,8 +17,10 @@ class ShinyTriviaOccurencesRepository(ShinyTriviaOccurencesRepositoryInterface):
         backingDatabase: BackingDatabase,
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timeZone: timezone = timeZone
@@ -32,9 +34,9 @@ class ShinyTriviaOccurencesRepository(ShinyTriviaOccurencesRepositoryInterface):
     ) -> ShinyTriviaResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if userId == '0':
+        elif userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -75,9 +77,9 @@ class ShinyTriviaOccurencesRepository(ShinyTriviaOccurencesRepositoryInterface):
     ) -> ShinyTriviaResult:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if userId == '0':
+        elif userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
 
         result = await self.fetchDetails(
@@ -147,13 +149,13 @@ class ShinyTriviaOccurencesRepository(ShinyTriviaOccurencesRepositoryInterface):
     ):
         if not utils.isValidInt(newShinyCount):
             raise ValueError(f'newShinyCount argument is malformed: \"{newShinyCount}\"')
-        if newShinyCount < 0 or newShinyCount > utils.getIntMaxSafeSize():
+        elif newShinyCount < 0 or newShinyCount > utils.getIntMaxSafeSize():
             raise ValueError(f'newShinyCount argument is out of bounds: {newShinyCount}')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if userId == '0':
+        elif userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
 
         nowDateTime = datetime.now(self.__timeZone)

--- a/src/CynanBot/trivia/specialStatus/shinyTriviaResult.py
+++ b/src/CynanBot/trivia/specialStatus/shinyTriviaResult.py
@@ -15,19 +15,18 @@ class ShinyTriviaResult():
         twitchChannel: str,
         userId: str
     ):
-        if mostRecent is not None and not isinstance(mostRecent, datetime):
-            raise ValueError(f'mostRecent argument is malformed: \"{mostRecent}\"')
-        elif not utils.isValidInt(newShinyCount):
+        assert mostRecent is None or isinstance(mostRecent, datetime), f"malformed {mostRecent=}"
+        if not utils.isValidInt(newShinyCount):
             raise ValueError(f'newShinyCount argument is malformed: \"{newShinyCount}\"')
-        elif newShinyCount < 0 or newShinyCount > utils.getIntMaxSafeSize():
+        if newShinyCount < 0 or newShinyCount > utils.getIntMaxSafeSize():
             raise ValueError(f'newShinyCount argument is out of bounds: {newShinyCount}')
-        elif not utils.isValidInt(oldShinyCount):
+        if not utils.isValidInt(oldShinyCount):
             raise ValueError(f'oldShinyCount argument is malformed: \"{oldShinyCount}\"')
-        elif oldShinyCount < 0 or oldShinyCount > utils.getIntMaxSafeSize():
+        if oldShinyCount < 0 or oldShinyCount > utils.getIntMaxSafeSize():
             raise ValueError(f'oldShinyCount argument is out of bounds: {oldShinyCount}')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__mostRecent: Optional[datetime] = mostRecent

--- a/src/CynanBot/trivia/specialStatus/shinyTriviaResult.py
+++ b/src/CynanBot/trivia/specialStatus/shinyTriviaResult.py
@@ -15,18 +15,19 @@ class ShinyTriviaResult():
         twitchChannel: str,
         userId: str
     ):
-        assert mostRecent is None or isinstance(mostRecent, datetime), f"malformed {mostRecent=}"
-        if not utils.isValidInt(newShinyCount):
+        if mostRecent is not None and not isinstance(mostRecent, datetime):
+            raise ValueError(f'mostRecent argument is malformed: \"{mostRecent}\"')
+        elif not utils.isValidInt(newShinyCount):
             raise ValueError(f'newShinyCount argument is malformed: \"{newShinyCount}\"')
-        if newShinyCount < 0 or newShinyCount > utils.getIntMaxSafeSize():
+        elif newShinyCount < 0 or newShinyCount > utils.getIntMaxSafeSize():
             raise ValueError(f'newShinyCount argument is out of bounds: {newShinyCount}')
-        if not utils.isValidInt(oldShinyCount):
+        elif not utils.isValidInt(oldShinyCount):
             raise ValueError(f'oldShinyCount argument is malformed: \"{oldShinyCount}\"')
-        if oldShinyCount < 0 or oldShinyCount > utils.getIntMaxSafeSize():
+        elif oldShinyCount < 0 or oldShinyCount > utils.getIntMaxSafeSize():
             raise ValueError(f'oldShinyCount argument is out of bounds: {oldShinyCount}')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__mostRecent: Optional[datetime] = mostRecent

--- a/src/CynanBot/trivia/specialStatus/toxicTriviaHelper.py
+++ b/src/CynanBot/trivia/specialStatus/toxicTriviaHelper.py
@@ -16,12 +16,9 @@ class ToxicTriviaHelper():
         timber: TimberInterface,
         triviaSettingsRepository: TriviaSettingsRepositoryInterface
     ):
-        if not isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface):
-            raise ValueError(f'toxicTriviaOccurencesRepository argument is malformed: \"{toxicTriviaOccurencesRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        assert isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface), f"malformed {toxicTriviaOccurencesRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
 
         self.__toxicTriviaOccurencesRepository: ToxicTriviaOccurencesRepositoryInterface = toxicTriviaOccurencesRepository
         self.__timber: TimberInterface = timber
@@ -51,9 +48,9 @@ class ToxicTriviaHelper():
     ):
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         result = await self.__toxicTriviaOccurencesRepository.incrementToxicCount(

--- a/src/CynanBot/trivia/specialStatus/toxicTriviaHelper.py
+++ b/src/CynanBot/trivia/specialStatus/toxicTriviaHelper.py
@@ -16,9 +16,12 @@ class ToxicTriviaHelper():
         timber: TimberInterface,
         triviaSettingsRepository: TriviaSettingsRepositoryInterface
     ):
-        assert isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface), f"malformed {toxicTriviaOccurencesRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        if not isinstance(toxicTriviaOccurencesRepository, ToxicTriviaOccurencesRepositoryInterface):
+            raise ValueError(f'toxicTriviaOccurencesRepository argument is malformed: \"{toxicTriviaOccurencesRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
 
         self.__toxicTriviaOccurencesRepository: ToxicTriviaOccurencesRepositoryInterface = toxicTriviaOccurencesRepository
         self.__timber: TimberInterface = timber
@@ -48,9 +51,9 @@ class ToxicTriviaHelper():
     ):
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         result = await self.__toxicTriviaOccurencesRepository.incrementToxicCount(

--- a/src/CynanBot/trivia/specialStatus/toxicTriviaOccurencesRepository.py
+++ b/src/CynanBot/trivia/specialStatus/toxicTriviaOccurencesRepository.py
@@ -17,10 +17,8 @@ class ToxicTriviaOccurencesRepository(ToxicTriviaOccurencesRepositoryInterface):
         backingDatabase: BackingDatabase,
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise TypeError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timeZone, timezone):
-            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timeZone: timezone = timeZone
@@ -34,7 +32,7 @@ class ToxicTriviaOccurencesRepository(ToxicTriviaOccurencesRepositoryInterface):
     ) -> ToxicTriviaResult:
         if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -75,7 +73,7 @@ class ToxicTriviaOccurencesRepository(ToxicTriviaOccurencesRepositoryInterface):
     ) -> ToxicTriviaResult:
         if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         result = await self.fetchDetails(
@@ -145,11 +143,11 @@ class ToxicTriviaOccurencesRepository(ToxicTriviaOccurencesRepositoryInterface):
     ):
         if not utils.isValidInt(newToxicCount):
             raise TypeError(f'newToxicCount argument is malformed: \"{newToxicCount}\"')
-        elif newToxicCount < 0 or newToxicCount > utils.getIntMaxSafeSize():
+        if newToxicCount < 0 or newToxicCount > utils.getIntMaxSafeSize():
             raise ValueError(f'newToxicCount argument is out of bounds: {newToxicCount}')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         nowDateTime = datetime.now(self.__timeZone)

--- a/src/CynanBot/trivia/specialStatus/toxicTriviaOccurencesRepository.py
+++ b/src/CynanBot/trivia/specialStatus/toxicTriviaOccurencesRepository.py
@@ -17,8 +17,10 @@ class ToxicTriviaOccurencesRepository(ToxicTriviaOccurencesRepositoryInterface):
         backingDatabase: BackingDatabase,
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise TypeError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timeZone, timezone):
+            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timeZone: timezone = timeZone
@@ -32,7 +34,7 @@ class ToxicTriviaOccurencesRepository(ToxicTriviaOccurencesRepositoryInterface):
     ) -> ToxicTriviaResult:
         if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -73,7 +75,7 @@ class ToxicTriviaOccurencesRepository(ToxicTriviaOccurencesRepositoryInterface):
     ) -> ToxicTriviaResult:
         if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         result = await self.fetchDetails(
@@ -143,11 +145,11 @@ class ToxicTriviaOccurencesRepository(ToxicTriviaOccurencesRepositoryInterface):
     ):
         if not utils.isValidInt(newToxicCount):
             raise TypeError(f'newToxicCount argument is malformed: \"{newToxicCount}\"')
-        if newToxicCount < 0 or newToxicCount > utils.getIntMaxSafeSize():
+        elif newToxicCount < 0 or newToxicCount > utils.getIntMaxSafeSize():
             raise ValueError(f'newToxicCount argument is out of bounds: {newToxicCount}')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         nowDateTime = datetime.now(self.__timeZone)

--- a/src/CynanBot/trivia/specialStatus/toxicTriviaPunishment.py
+++ b/src/CynanBot/trivia/specialStatus/toxicTriviaPunishment.py
@@ -14,19 +14,18 @@ class ToxicTriviaPunishment():
         userId: str,
         userName: str
     ):
-        if not isinstance(cutenessResult, CutenessResult):
-            raise ValueError(f'cutenessResult argument is malformed: \"{cutenessResult}\"')
-        elif not utils.isValidInt(numberOfPunishments):
+        assert isinstance(cutenessResult, CutenessResult), f"malformed {cutenessResult=}"
+        if not utils.isValidInt(numberOfPunishments):
             raise ValueError(f'numberOfPunishments argument is malformed: \"{numberOfPunishments}\"')
-        elif numberOfPunishments < 1 or numberOfPunishments > utils.getIntMaxSafeSize():
+        if numberOfPunishments < 1 or numberOfPunishments > utils.getIntMaxSafeSize():
             raise ValueError(f'numberOfPunishments argument is malformed: {numberOfPunishments}')
-        elif not utils.isValidInt(punishedByPoints):
+        if not utils.isValidInt(punishedByPoints):
             raise ValueError(f'punishedByPoints argument is malformed: \"{punishedByPoints}\"')
-        elif punishedByPoints > 0 or punishedByPoints < utils.getIntMinSafeSize():
+        if punishedByPoints > 0 or punishedByPoints < utils.getIntMinSafeSize():
             raise ValueError(f'punishedByPoints argument is out of bounds: {punishedByPoints}')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__cutenessResult: CutenessResult = cutenessResult

--- a/src/CynanBot/trivia/specialStatus/toxicTriviaPunishment.py
+++ b/src/CynanBot/trivia/specialStatus/toxicTriviaPunishment.py
@@ -14,18 +14,19 @@ class ToxicTriviaPunishment():
         userId: str,
         userName: str
     ):
-        assert isinstance(cutenessResult, CutenessResult), f"malformed {cutenessResult=}"
-        if not utils.isValidInt(numberOfPunishments):
+        if not isinstance(cutenessResult, CutenessResult):
+            raise ValueError(f'cutenessResult argument is malformed: \"{cutenessResult}\"')
+        elif not utils.isValidInt(numberOfPunishments):
             raise ValueError(f'numberOfPunishments argument is malformed: \"{numberOfPunishments}\"')
-        if numberOfPunishments < 1 or numberOfPunishments > utils.getIntMaxSafeSize():
+        elif numberOfPunishments < 1 or numberOfPunishments > utils.getIntMaxSafeSize():
             raise ValueError(f'numberOfPunishments argument is malformed: {numberOfPunishments}')
-        if not utils.isValidInt(punishedByPoints):
+        elif not utils.isValidInt(punishedByPoints):
             raise ValueError(f'punishedByPoints argument is malformed: \"{punishedByPoints}\"')
-        if punishedByPoints > 0 or punishedByPoints < utils.getIntMinSafeSize():
+        elif punishedByPoints > 0 or punishedByPoints < utils.getIntMinSafeSize():
             raise ValueError(f'punishedByPoints argument is out of bounds: {punishedByPoints}')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__cutenessResult: CutenessResult = cutenessResult

--- a/src/CynanBot/trivia/specialStatus/toxicTriviaResult.py
+++ b/src/CynanBot/trivia/specialStatus/toxicTriviaResult.py
@@ -15,19 +15,18 @@ class ToxicTriviaResult():
         twitchChannel: str,
         userId: str
     ):
-        if mostRecent is not None and not isinstance(mostRecent, datetime):
-            raise ValueError(f'mostRecent argument is malformed: \"{mostRecent}\"')
-        elif not utils.isValidInt(newToxicCount):
+        assert mostRecent is None or isinstance(mostRecent, datetime), f"malformed {mostRecent=}"
+        if not utils.isValidInt(newToxicCount):
             raise ValueError(f'newToxicCount argument is malformed: \"{newToxicCount}\"')
-        elif newToxicCount < 0 or newToxicCount > utils.getIntMaxSafeSize():
+        if newToxicCount < 0 or newToxicCount > utils.getIntMaxSafeSize():
             raise ValueError(f'newToxicCount argument is out of bounds: {newToxicCount}')
-        elif not utils.isValidInt(oldToxicCount):
+        if not utils.isValidInt(oldToxicCount):
             raise ValueError(f'oldToxicCount argument is malformed: \"{oldToxicCount}\"')
-        elif oldToxicCount < 0 or oldToxicCount > utils.getIntMaxSafeSize():
+        if oldToxicCount < 0 or oldToxicCount > utils.getIntMaxSafeSize():
             raise ValueError(f'oldToxicCount argument is out of bounds: {oldToxicCount}')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__mostRecent: Optional[datetime] = mostRecent

--- a/src/CynanBot/trivia/specialStatus/toxicTriviaResult.py
+++ b/src/CynanBot/trivia/specialStatus/toxicTriviaResult.py
@@ -15,18 +15,19 @@ class ToxicTriviaResult():
         twitchChannel: str,
         userId: str
     ):
-        assert mostRecent is None or isinstance(mostRecent, datetime), f"malformed {mostRecent=}"
-        if not utils.isValidInt(newToxicCount):
+        if mostRecent is not None and not isinstance(mostRecent, datetime):
+            raise ValueError(f'mostRecent argument is malformed: \"{mostRecent}\"')
+        elif not utils.isValidInt(newToxicCount):
             raise ValueError(f'newToxicCount argument is malformed: \"{newToxicCount}\"')
-        if newToxicCount < 0 or newToxicCount > utils.getIntMaxSafeSize():
+        elif newToxicCount < 0 or newToxicCount > utils.getIntMaxSafeSize():
             raise ValueError(f'newToxicCount argument is out of bounds: {newToxicCount}')
-        if not utils.isValidInt(oldToxicCount):
+        elif not utils.isValidInt(oldToxicCount):
             raise ValueError(f'oldToxicCount argument is malformed: \"{oldToxicCount}\"')
-        if oldToxicCount < 0 or oldToxicCount > utils.getIntMaxSafeSize():
+        elif oldToxicCount < 0 or oldToxicCount > utils.getIntMaxSafeSize():
             raise ValueError(f'oldToxicCount argument is out of bounds: {oldToxicCount}')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__mostRecent: Optional[datetime] = mostRecent

--- a/src/CynanBot/trivia/superTriviaCooldownHelper.py
+++ b/src/CynanBot/trivia/superTriviaCooldownHelper.py
@@ -16,10 +16,8 @@ class SuperTriviaCooldownHelper(SuperTriviaCooldownHelperInterface):
         triviaSettingsRepository: TriviaSettingsRepositoryInterface,
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__triviaSettingsRepository: TriviaSettingsRepositoryInterface = triviaSettingsRepository
         self.__timeZone: timezone = timeZone

--- a/src/CynanBot/trivia/superTriviaCooldownHelper.py
+++ b/src/CynanBot/trivia/superTriviaCooldownHelper.py
@@ -16,8 +16,10 @@ class SuperTriviaCooldownHelper(SuperTriviaCooldownHelperInterface):
         triviaSettingsRepository: TriviaSettingsRepositoryInterface,
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        if not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__triviaSettingsRepository: TriviaSettingsRepositoryInterface = triviaSettingsRepository
         self.__timeZone: timezone = timeZone

--- a/src/CynanBot/trivia/triviaAnswerChecker.py
+++ b/src/CynanBot/trivia/triviaAnswerChecker.py
@@ -34,12 +34,9 @@ class TriviaAnswerChecker(TriviaAnswerCheckerInterface):
         triviaAnswerCompiler: TriviaAnswerCompilerInterface,
         triviaSettingsRepository: TriviaSettingsRepositoryInterface,
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface):
-            raise ValueError(f'triviaAnswerCompiler argument is malformed: \"{triviaAnswerCompiler}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface), f"malformed {triviaAnswerCompiler=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
 
         self.__timber: TimberInterface = timber
         self.__triviaAnswerCompiler: TriviaAnswerCompilerInterface = triviaAnswerCompiler
@@ -90,8 +87,7 @@ class TriviaAnswerChecker(TriviaAnswerCheckerInterface):
         triviaQuestion: AbsTriviaQuestion,
         extras: Optional[Dict[str, Any]] = None
     ) -> TriviaAnswerCheckResult:
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
 
         if not utils.isValidStr(answer):
             return TriviaAnswerCheckResult.INVALID_INPUT
@@ -110,9 +106,8 @@ class TriviaAnswerChecker(TriviaAnswerCheckerInterface):
         answer: Optional[str],
         triviaQuestion: MultipleChoiceTriviaQuestion
     ) -> TriviaAnswerCheckResult:
-        if not isinstance(triviaQuestion, MultipleChoiceTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif triviaQuestion.getTriviaType() is not TriviaQuestionType.MULTIPLE_CHOICE:
+        assert isinstance(triviaQuestion, MultipleChoiceTriviaQuestion), f"malformed {triviaQuestion=}"
+        if triviaQuestion.getTriviaType() is not TriviaQuestionType.MULTIPLE_CHOICE:
             raise RuntimeError(f'TriviaType is not {TriviaQuestionType.MULTIPLE_CHOICE}: \"{triviaQuestion.getTriviaType()}\"')
 
         answerOrdinal: Optional[int] = None
@@ -147,9 +142,8 @@ class TriviaAnswerChecker(TriviaAnswerCheckerInterface):
         triviaQuestion: QuestionAnswerTriviaQuestion,
         extras: Optional[Dict[str, Any]] = None
     ) -> TriviaAnswerCheckResult:
-        if not isinstance(triviaQuestion, QuestionAnswerTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif triviaQuestion.getTriviaType() is not TriviaQuestionType.QUESTION_ANSWER:
+        assert isinstance(triviaQuestion, QuestionAnswerTriviaQuestion), f"malformed {triviaQuestion=}"
+        if triviaQuestion.getTriviaType() is not TriviaQuestionType.QUESTION_ANSWER:
             raise RuntimeError(f'TriviaType is not {TriviaQuestionType.QUESTION_ANSWER}: \"{triviaQuestion.getTriviaType()}\"')
 
         # prevent potential for insane answer lengths
@@ -195,9 +189,8 @@ class TriviaAnswerChecker(TriviaAnswerCheckerInterface):
         answer: Optional[str],
         triviaQuestion: TrueFalseTriviaQuestion
     ) -> TriviaAnswerCheckResult:
-        if not isinstance(triviaQuestion, TrueFalseTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif triviaQuestion.getTriviaType() is not TriviaQuestionType.TRUE_FALSE:
+        assert isinstance(triviaQuestion, TrueFalseTriviaQuestion), f"malformed {triviaQuestion=}"
+        if triviaQuestion.getTriviaType() is not TriviaQuestionType.TRUE_FALSE:
             raise RuntimeError(f'TriviaType is not {TriviaQuestionType.TRUE_FALSE}: \"{triviaQuestion.getTriviaType()}\"')
 
         answerBool: Optional[bool] = None

--- a/src/CynanBot/trivia/triviaAnswerChecker.py
+++ b/src/CynanBot/trivia/triviaAnswerChecker.py
@@ -34,9 +34,12 @@ class TriviaAnswerChecker(TriviaAnswerCheckerInterface):
         triviaAnswerCompiler: TriviaAnswerCompilerInterface,
         triviaSettingsRepository: TriviaSettingsRepositoryInterface,
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface), f"malformed {triviaAnswerCompiler=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface):
+            raise ValueError(f'triviaAnswerCompiler argument is malformed: \"{triviaAnswerCompiler}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
 
         self.__timber: TimberInterface = timber
         self.__triviaAnswerCompiler: TriviaAnswerCompilerInterface = triviaAnswerCompiler
@@ -87,7 +90,8 @@ class TriviaAnswerChecker(TriviaAnswerCheckerInterface):
         triviaQuestion: AbsTriviaQuestion,
         extras: Optional[Dict[str, Any]] = None
     ) -> TriviaAnswerCheckResult:
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
 
         if not utils.isValidStr(answer):
             return TriviaAnswerCheckResult.INVALID_INPUT
@@ -106,8 +110,9 @@ class TriviaAnswerChecker(TriviaAnswerCheckerInterface):
         answer: Optional[str],
         triviaQuestion: MultipleChoiceTriviaQuestion
     ) -> TriviaAnswerCheckResult:
-        assert isinstance(triviaQuestion, MultipleChoiceTriviaQuestion), f"malformed {triviaQuestion=}"
-        if triviaQuestion.getTriviaType() is not TriviaQuestionType.MULTIPLE_CHOICE:
+        if not isinstance(triviaQuestion, MultipleChoiceTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif triviaQuestion.getTriviaType() is not TriviaQuestionType.MULTIPLE_CHOICE:
             raise RuntimeError(f'TriviaType is not {TriviaQuestionType.MULTIPLE_CHOICE}: \"{triviaQuestion.getTriviaType()}\"')
 
         answerOrdinal: Optional[int] = None
@@ -142,8 +147,9 @@ class TriviaAnswerChecker(TriviaAnswerCheckerInterface):
         triviaQuestion: QuestionAnswerTriviaQuestion,
         extras: Optional[Dict[str, Any]] = None
     ) -> TriviaAnswerCheckResult:
-        assert isinstance(triviaQuestion, QuestionAnswerTriviaQuestion), f"malformed {triviaQuestion=}"
-        if triviaQuestion.getTriviaType() is not TriviaQuestionType.QUESTION_ANSWER:
+        if not isinstance(triviaQuestion, QuestionAnswerTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif triviaQuestion.getTriviaType() is not TriviaQuestionType.QUESTION_ANSWER:
             raise RuntimeError(f'TriviaType is not {TriviaQuestionType.QUESTION_ANSWER}: \"{triviaQuestion.getTriviaType()}\"')
 
         # prevent potential for insane answer lengths
@@ -189,8 +195,9 @@ class TriviaAnswerChecker(TriviaAnswerCheckerInterface):
         answer: Optional[str],
         triviaQuestion: TrueFalseTriviaQuestion
     ) -> TriviaAnswerCheckResult:
-        assert isinstance(triviaQuestion, TrueFalseTriviaQuestion), f"malformed {triviaQuestion=}"
-        if triviaQuestion.getTriviaType() is not TriviaQuestionType.TRUE_FALSE:
+        if not isinstance(triviaQuestion, TrueFalseTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif triviaQuestion.getTriviaType() is not TriviaQuestionType.TRUE_FALSE:
             raise RuntimeError(f'TriviaType is not {TriviaQuestionType.TRUE_FALSE}: \"{triviaQuestion.getTriviaType()}\"')
 
         answerBool: Optional[bool] = None

--- a/src/CynanBot/trivia/triviaEmoteGenerator.py
+++ b/src/CynanBot/trivia/triviaEmoteGenerator.py
@@ -17,10 +17,8 @@ class TriviaEmoteGenerator(TriviaEmoteGeneratorInterface):
         backingDatabase: BackingDatabase,
         timber: TimberInterface
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber arguent is malformed: \"{timber}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/trivia/triviaEmoteGenerator.py
+++ b/src/CynanBot/trivia/triviaEmoteGenerator.py
@@ -17,8 +17,10 @@ class TriviaEmoteGenerator(TriviaEmoteGeneratorInterface):
         backingDatabase: BackingDatabase,
         timber: TimberInterface
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber arguent is malformed: \"{timber}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/trivia/triviaFetchOptions.py
+++ b/src/CynanBot/trivia/triviaFetchOptions.py
@@ -14,8 +14,7 @@ class TriviaFetchOptions():
     ):
         if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not isinstance(questionAnswerTriviaConditions, QuestionAnswerTriviaConditions):
-            raise TypeError(f'questionAnswerTriviaConditions argument is malformed: \"{questionAnswerTriviaConditions}\"')
+        assert isinstance(questionAnswerTriviaConditions, QuestionAnswerTriviaConditions), f"malformed {questionAnswerTriviaConditions=}"
 
         self.__twitchChannel: str = twitchChannel
         self.__questionAnswerTriviaConditions: QuestionAnswerTriviaConditions = questionAnswerTriviaConditions

--- a/src/CynanBot/trivia/triviaFetchOptions.py
+++ b/src/CynanBot/trivia/triviaFetchOptions.py
@@ -14,7 +14,8 @@ class TriviaFetchOptions():
     ):
         if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        assert isinstance(questionAnswerTriviaConditions, QuestionAnswerTriviaConditions), f"malformed {questionAnswerTriviaConditions=}"
+        elif not isinstance(questionAnswerTriviaConditions, QuestionAnswerTriviaConditions):
+            raise TypeError(f'questionAnswerTriviaConditions argument is malformed: \"{questionAnswerTriviaConditions}\"')
 
         self.__twitchChannel: str = twitchChannel
         self.__questionAnswerTriviaConditions: QuestionAnswerTriviaConditions = questionAnswerTriviaConditions

--- a/src/CynanBot/trivia/triviaGameMachine.py
+++ b/src/CynanBot/trivia/triviaGameMachine.py
@@ -123,48 +123,31 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         sleepTimeSeconds: float = 0.5,
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(cutenessRepository, CutenessRepositoryInterface):
-            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
-        elif not isinstance(queuedTriviaGameStore, QueuedTriviaGameStoreInterface):
-            raise ValueError(f'queuedTriviaGameStore argument is malformed: \"{queuedTriviaGameStore}\"')
-        elif not isinstance(shinyTriviaHelper, ShinyTriviaHelper):
-            raise ValueError(f'shinyTriviaHelper argument is malformed: \"{shinyTriviaHelper}\"')
-        elif not isinstance(superTriviaCooldownHelper, SuperTriviaCooldownHelperInterface):
-            raise ValueError(f'superTriviaCooldownHelper argument is malformed: \"{superTriviaCooldownHelper}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(toxicTriviaHelper, ToxicTriviaHelper):
-            raise ValueError(f'toxicTriviaHelper argument is malformed: \"{toxicTriviaHelper}\"')
-        elif not isinstance(triviaAnswerChecker, TriviaAnswerCheckerInterface):
-            raise ValueError(f'triviaAnswerChecker argument is malformed: \"{triviaAnswerChecker}\"')
-        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
-            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
-        elif not isinstance(triviaGameStore, TriviaGameStoreInterface):
-            raise ValueError(f'triviaGameStore argument is malformed: \"{triviaGameStore}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(triviaRepository, TriviaRepositoryInterface):
-            raise ValueError(f'triviaRepository argument is malformed: \"{triviaRepository}\"')
-        elif not isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface):
-            raise ValueError(f'triviaScoreRepository argument is malformed: \"{triviaScoreRepository}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not utils.isValidNum(queueTimeoutSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
+        assert isinstance(queuedTriviaGameStore, QueuedTriviaGameStoreInterface), f"malformed {queuedTriviaGameStore=}"
+        assert isinstance(shinyTriviaHelper, ShinyTriviaHelper), f"malformed {shinyTriviaHelper=}"
+        assert isinstance(superTriviaCooldownHelper, SuperTriviaCooldownHelperInterface), f"malformed {superTriviaCooldownHelper=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(toxicTriviaHelper, ToxicTriviaHelper), f"malformed {toxicTriviaHelper=}"
+        assert isinstance(triviaAnswerChecker, TriviaAnswerCheckerInterface), f"malformed {triviaAnswerChecker=}"
+        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
+        assert isinstance(triviaGameStore, TriviaGameStoreInterface), f"malformed {triviaGameStore=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(triviaRepository, TriviaRepositoryInterface), f"malformed {triviaRepository=}"
+        assert isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface), f"malformed {triviaScoreRepository=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not utils.isValidNum(queueTimeoutSeconds):
             raise ValueError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
+        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
-        elif not utils.isValidNum(sleepTimeSeconds):
+        if not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        elif sleepTimeSeconds < 0.25 or sleepTimeSeconds > 3:
+        if sleepTimeSeconds < 0.25 or sleepTimeSeconds > 3:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
@@ -196,10 +179,8 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         action: Optional[CheckSuperAnswerTriviaAction],
         state: SuperTriviaGameState
     ) -> Optional[ToxicTriviaPunishmentResult]:
-        if action is not None and not isinstance(action, CheckSuperAnswerTriviaAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
-        elif not isinstance(state, SuperTriviaGameState):
-            raise ValueError(f'state argument is malformed: \"{state}\"')
+        assert action is None or isinstance(action, CheckSuperAnswerTriviaAction), f"malformed {action=}"
+        assert isinstance(state, SuperTriviaGameState), f"malformed {state=}"
 
         if not state.isToxic():
             return None
@@ -275,15 +256,13 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         triviaQuestion: AbsTriviaQuestion,
         extras: Optional[Dict[str, Any]] = None
     ) -> TriviaAnswerCheckResult:
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
 
         return await self.__triviaAnswerChecker.checkAnswer(answer, triviaQuestion, extras)
 
     async def __handleActionCheckAnswer(self, action: CheckAnswerTriviaAction):
-        if not isinstance(action, CheckAnswerTriviaAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
-        elif action.getTriviaActionType() is not TriviaActionType.CHECK_ANSWER:
+        assert isinstance(action, CheckAnswerTriviaAction), f"malformed {action=}"
+        if action.getTriviaActionType() is not TriviaActionType.CHECK_ANSWER:
             raise RuntimeError(f'TriviaActionType is not {TriviaActionType.CHECK_ANSWER}: \"{action.getTriviaActionType()}\"')
 
         state = await self.__triviaGameStore.getNormalGame(
@@ -410,9 +389,8 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         ))
 
     async def __handleActionCheckSuperAnswer(self, action: CheckSuperAnswerTriviaAction):
-        if not isinstance(action, CheckSuperAnswerTriviaAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
-        elif action.getTriviaActionType() is not TriviaActionType.CHECK_SUPER_ANSWER:
+        assert isinstance(action, CheckSuperAnswerTriviaAction), f"malformed {action=}"
+        if action.getTriviaActionType() is not TriviaActionType.CHECK_SUPER_ANSWER:
             raise RuntimeError(f'TriviaActionType is not {TriviaActionType.CHECK_SUPER_ANSWER}: \"{action.getTriviaActionType()}\"')
 
         state = await self.__triviaGameStore.getSuperGame(action.getTwitchChannel())
@@ -520,9 +498,8 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         ))
 
     async def __handleActionClearSuperTriviaQueue(self, action: ClearSuperTriviaQueueTriviaAction):
-        if not isinstance(action, ClearSuperTriviaQueueTriviaAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
-        elif action.getTriviaActionType() is not TriviaActionType.CLEAR_SUPER_TRIVIA_QUEUE:
+        assert isinstance(action, ClearSuperTriviaQueueTriviaAction), f"malformed {action=}"
+        if action.getTriviaActionType() is not TriviaActionType.CLEAR_SUPER_TRIVIA_QUEUE:
             raise RuntimeError(f'TriviaActionType is not {TriviaActionType.CLEAR_SUPER_TRIVIA_QUEUE}: \"{action.getTriviaActionType()}\"')
 
         result = await self.__queuedTriviaGameStore.clearQueuedSuperGames(
@@ -540,9 +517,8 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         ))
 
     async def __handleActionStartNewTriviaGame(self, action: StartNewTriviaGameAction):
-        if not isinstance(action, StartNewTriviaGameAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
-        elif action.getTriviaActionType() is not TriviaActionType.START_NEW_GAME:
+        assert isinstance(action, StartNewTriviaGameAction), f"malformed {action=}"
+        if action.getTriviaActionType() is not TriviaActionType.START_NEW_GAME:
             raise RuntimeError(f'TriviaActionType is not {TriviaActionType.START_NEW_GAME}: \"{action.getTriviaActionType()}\"')
 
         now = datetime.now(self.__timeZone)
@@ -623,9 +599,8 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         ))
 
     async def __handleActionStartNewSuperTriviaGame(self, action: StartNewSuperTriviaGameAction):
-        if not isinstance(action, StartNewSuperTriviaGameAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
-        elif action.getTriviaActionType() is not TriviaActionType.START_NEW_SUPER_GAME:
+        assert isinstance(action, StartNewSuperTriviaGameAction), f"malformed {action=}"
+        if action.getTriviaActionType() is not TriviaActionType.START_NEW_SUPER_GAME:
             raise RuntimeError(f'TriviaActionType is not {TriviaActionType.START_NEW_SUPER_GAME}: \"{action.getTriviaActionType()}\"')
 
         now = datetime.now(self.__timeZone)
@@ -754,8 +729,7 @@ class TriviaGameMachine(TriviaGameMachineInterface):
                 raise UnknownTriviaGameTypeException(f'Unknown TriviaGameType (gameId=\"{state.getGameId()}\") (twitchChannel=\"{state.getTwitchChannel()}\") (actionId=\"{state.getActionId()}\"): \"{state.getTriviaGameType()}\"')
 
     async def __removeDeadNormalTriviaGame(self, state: TriviaGameState):
-        if not isinstance(state, TriviaGameState):
-            raise ValueError(f'state argument is malformed: \"{state}\"')
+        assert isinstance(state, TriviaGameState), f"malformed {state=}"
 
         await self.__removeNormalTriviaGame(
             twitchChannel = state.getTwitchChannel(),
@@ -782,8 +756,7 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         ))
 
     async def __removeDeadSuperTriviaGame(self, state: SuperTriviaGameState):
-        if not isinstance(state, SuperTriviaGameState):
-            raise ValueError(f'state argument is malformed: \"{state}\"')
+        assert isinstance(state, SuperTriviaGameState), f"malformed {state=}"
 
         await self.__removeSuperTriviaGame(state.getTwitchChannel())
         toxicTriviaPunishmentResult: Optional[ToxicTriviaPunishmentResult] = None
@@ -818,7 +791,7 @@ class TriviaGameMachine(TriviaGameMachineInterface):
     async def __removeNormalTriviaGame(self, twitchChannel: str, userId: str):
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         await self.__triviaGameStore.removeNormalGame(
@@ -834,8 +807,7 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         await self.__superTriviaCooldownHelper.update(twitchChannel)
 
     def setEventListener(self, listener: Optional[TriviaEventListener]):
-        if listener is not None and not isinstance(listener, TriviaEventListener):
-            raise ValueError(f'listener argument is malformed: \"{listener}\"')
+        assert listener is None or isinstance(listener, TriviaEventListener), f"malformed {listener=}"
 
         self.__eventListener = listener
 
@@ -908,8 +880,7 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         self.__backgroundTaskHelper.createTask(self.__startEventLoop())
 
     def submitAction(self, action: AbsTriviaAction):
-        if not isinstance(action, AbsTriviaAction):
-            raise ValueError(f'action argument is malformed: \"{action}\"')
+        assert isinstance(action, AbsTriviaAction), f"malformed {action=}"
 
         try:
             self.__actionQueue.put(action, block = True, timeout = self.__queueTimeoutSeconds)
@@ -917,8 +888,7 @@ class TriviaGameMachine(TriviaGameMachineInterface):
             self.__timber.log('TriviaGameMachine', f'Encountered queue.Full when submitting a new action ({action}) into the action queue (queue size: {self.__actionQueue.qsize()}): {e}', e, traceback.format_exc())
 
     async def __submitEvent(self, event: AbsTriviaEvent):
-        if not isinstance(event, AbsTriviaEvent):
-            raise ValueError(f'event argument is malformed: \"{event}\"')
+        assert isinstance(event, AbsTriviaEvent), f"malformed {event=}"
 
         try:
             self.__eventQueue.put(event, block = True, timeout = self.__queueTimeoutSeconds)

--- a/src/CynanBot/trivia/triviaGameMachine.py
+++ b/src/CynanBot/trivia/triviaGameMachine.py
@@ -123,31 +123,48 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         sleepTimeSeconds: float = 0.5,
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(cutenessRepository, CutenessRepositoryInterface), f"malformed {cutenessRepository=}"
-        assert isinstance(queuedTriviaGameStore, QueuedTriviaGameStoreInterface), f"malformed {queuedTriviaGameStore=}"
-        assert isinstance(shinyTriviaHelper, ShinyTriviaHelper), f"malformed {shinyTriviaHelper=}"
-        assert isinstance(superTriviaCooldownHelper, SuperTriviaCooldownHelperInterface), f"malformed {superTriviaCooldownHelper=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(toxicTriviaHelper, ToxicTriviaHelper), f"malformed {toxicTriviaHelper=}"
-        assert isinstance(triviaAnswerChecker, TriviaAnswerCheckerInterface), f"malformed {triviaAnswerChecker=}"
-        assert isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface), f"malformed {triviaEmoteGenerator=}"
-        assert isinstance(triviaGameStore, TriviaGameStoreInterface), f"malformed {triviaGameStore=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(triviaRepository, TriviaRepositoryInterface), f"malformed {triviaRepository=}"
-        assert isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface), f"malformed {triviaScoreRepository=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        if not utils.isValidNum(queueTimeoutSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(cutenessRepository, CutenessRepositoryInterface):
+            raise ValueError(f'cutenessRepository argument is malformed: \"{cutenessRepository}\"')
+        elif not isinstance(queuedTriviaGameStore, QueuedTriviaGameStoreInterface):
+            raise ValueError(f'queuedTriviaGameStore argument is malformed: \"{queuedTriviaGameStore}\"')
+        elif not isinstance(shinyTriviaHelper, ShinyTriviaHelper):
+            raise ValueError(f'shinyTriviaHelper argument is malformed: \"{shinyTriviaHelper}\"')
+        elif not isinstance(superTriviaCooldownHelper, SuperTriviaCooldownHelperInterface):
+            raise ValueError(f'superTriviaCooldownHelper argument is malformed: \"{superTriviaCooldownHelper}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(toxicTriviaHelper, ToxicTriviaHelper):
+            raise ValueError(f'toxicTriviaHelper argument is malformed: \"{toxicTriviaHelper}\"')
+        elif not isinstance(triviaAnswerChecker, TriviaAnswerCheckerInterface):
+            raise ValueError(f'triviaAnswerChecker argument is malformed: \"{triviaAnswerChecker}\"')
+        elif not isinstance(triviaEmoteGenerator, TriviaEmoteGeneratorInterface):
+            raise ValueError(f'triviaEmoteGenerator argument is malformed: \"{triviaEmoteGenerator}\"')
+        elif not isinstance(triviaGameStore, TriviaGameStoreInterface):
+            raise ValueError(f'triviaGameStore argument is malformed: \"{triviaGameStore}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(triviaRepository, TriviaRepositoryInterface):
+            raise ValueError(f'triviaRepository argument is malformed: \"{triviaRepository}\"')
+        elif not isinstance(triviaScoreRepository, TriviaScoreRepositoryInterface):
+            raise ValueError(f'triviaScoreRepository argument is malformed: \"{triviaScoreRepository}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not utils.isValidNum(queueTimeoutSeconds):
             raise ValueError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
+        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
-        if not utils.isValidNum(sleepTimeSeconds):
+        elif not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        if sleepTimeSeconds < 0.25 or sleepTimeSeconds > 3:
+        elif sleepTimeSeconds < 0.25 or sleepTimeSeconds > 3:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
         self.__cutenessRepository: CutenessRepositoryInterface = cutenessRepository
@@ -179,8 +196,10 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         action: Optional[CheckSuperAnswerTriviaAction],
         state: SuperTriviaGameState
     ) -> Optional[ToxicTriviaPunishmentResult]:
-        assert action is None or isinstance(action, CheckSuperAnswerTriviaAction), f"malformed {action=}"
-        assert isinstance(state, SuperTriviaGameState), f"malformed {state=}"
+        if action is not None and not isinstance(action, CheckSuperAnswerTriviaAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
+        elif not isinstance(state, SuperTriviaGameState):
+            raise ValueError(f'state argument is malformed: \"{state}\"')
 
         if not state.isToxic():
             return None
@@ -256,13 +275,15 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         triviaQuestion: AbsTriviaQuestion,
         extras: Optional[Dict[str, Any]] = None
     ) -> TriviaAnswerCheckResult:
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
 
         return await self.__triviaAnswerChecker.checkAnswer(answer, triviaQuestion, extras)
 
     async def __handleActionCheckAnswer(self, action: CheckAnswerTriviaAction):
-        assert isinstance(action, CheckAnswerTriviaAction), f"malformed {action=}"
-        if action.getTriviaActionType() is not TriviaActionType.CHECK_ANSWER:
+        if not isinstance(action, CheckAnswerTriviaAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
+        elif action.getTriviaActionType() is not TriviaActionType.CHECK_ANSWER:
             raise RuntimeError(f'TriviaActionType is not {TriviaActionType.CHECK_ANSWER}: \"{action.getTriviaActionType()}\"')
 
         state = await self.__triviaGameStore.getNormalGame(
@@ -389,8 +410,9 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         ))
 
     async def __handleActionCheckSuperAnswer(self, action: CheckSuperAnswerTriviaAction):
-        assert isinstance(action, CheckSuperAnswerTriviaAction), f"malformed {action=}"
-        if action.getTriviaActionType() is not TriviaActionType.CHECK_SUPER_ANSWER:
+        if not isinstance(action, CheckSuperAnswerTriviaAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
+        elif action.getTriviaActionType() is not TriviaActionType.CHECK_SUPER_ANSWER:
             raise RuntimeError(f'TriviaActionType is not {TriviaActionType.CHECK_SUPER_ANSWER}: \"{action.getTriviaActionType()}\"')
 
         state = await self.__triviaGameStore.getSuperGame(action.getTwitchChannel())
@@ -498,8 +520,9 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         ))
 
     async def __handleActionClearSuperTriviaQueue(self, action: ClearSuperTriviaQueueTriviaAction):
-        assert isinstance(action, ClearSuperTriviaQueueTriviaAction), f"malformed {action=}"
-        if action.getTriviaActionType() is not TriviaActionType.CLEAR_SUPER_TRIVIA_QUEUE:
+        if not isinstance(action, ClearSuperTriviaQueueTriviaAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
+        elif action.getTriviaActionType() is not TriviaActionType.CLEAR_SUPER_TRIVIA_QUEUE:
             raise RuntimeError(f'TriviaActionType is not {TriviaActionType.CLEAR_SUPER_TRIVIA_QUEUE}: \"{action.getTriviaActionType()}\"')
 
         result = await self.__queuedTriviaGameStore.clearQueuedSuperGames(
@@ -517,8 +540,9 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         ))
 
     async def __handleActionStartNewTriviaGame(self, action: StartNewTriviaGameAction):
-        assert isinstance(action, StartNewTriviaGameAction), f"malformed {action=}"
-        if action.getTriviaActionType() is not TriviaActionType.START_NEW_GAME:
+        if not isinstance(action, StartNewTriviaGameAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
+        elif action.getTriviaActionType() is not TriviaActionType.START_NEW_GAME:
             raise RuntimeError(f'TriviaActionType is not {TriviaActionType.START_NEW_GAME}: \"{action.getTriviaActionType()}\"')
 
         now = datetime.now(self.__timeZone)
@@ -599,8 +623,9 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         ))
 
     async def __handleActionStartNewSuperTriviaGame(self, action: StartNewSuperTriviaGameAction):
-        assert isinstance(action, StartNewSuperTriviaGameAction), f"malformed {action=}"
-        if action.getTriviaActionType() is not TriviaActionType.START_NEW_SUPER_GAME:
+        if not isinstance(action, StartNewSuperTriviaGameAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
+        elif action.getTriviaActionType() is not TriviaActionType.START_NEW_SUPER_GAME:
             raise RuntimeError(f'TriviaActionType is not {TriviaActionType.START_NEW_SUPER_GAME}: \"{action.getTriviaActionType()}\"')
 
         now = datetime.now(self.__timeZone)
@@ -729,7 +754,8 @@ class TriviaGameMachine(TriviaGameMachineInterface):
                 raise UnknownTriviaGameTypeException(f'Unknown TriviaGameType (gameId=\"{state.getGameId()}\") (twitchChannel=\"{state.getTwitchChannel()}\") (actionId=\"{state.getActionId()}\"): \"{state.getTriviaGameType()}\"')
 
     async def __removeDeadNormalTriviaGame(self, state: TriviaGameState):
-        assert isinstance(state, TriviaGameState), f"malformed {state=}"
+        if not isinstance(state, TriviaGameState):
+            raise ValueError(f'state argument is malformed: \"{state}\"')
 
         await self.__removeNormalTriviaGame(
             twitchChannel = state.getTwitchChannel(),
@@ -756,7 +782,8 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         ))
 
     async def __removeDeadSuperTriviaGame(self, state: SuperTriviaGameState):
-        assert isinstance(state, SuperTriviaGameState), f"malformed {state=}"
+        if not isinstance(state, SuperTriviaGameState):
+            raise ValueError(f'state argument is malformed: \"{state}\"')
 
         await self.__removeSuperTriviaGame(state.getTwitchChannel())
         toxicTriviaPunishmentResult: Optional[ToxicTriviaPunishmentResult] = None
@@ -791,7 +818,7 @@ class TriviaGameMachine(TriviaGameMachineInterface):
     async def __removeNormalTriviaGame(self, twitchChannel: str, userId: str):
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         await self.__triviaGameStore.removeNormalGame(
@@ -807,7 +834,8 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         await self.__superTriviaCooldownHelper.update(twitchChannel)
 
     def setEventListener(self, listener: Optional[TriviaEventListener]):
-        assert listener is None or isinstance(listener, TriviaEventListener), f"malformed {listener=}"
+        if listener is not None and not isinstance(listener, TriviaEventListener):
+            raise ValueError(f'listener argument is malformed: \"{listener}\"')
 
         self.__eventListener = listener
 
@@ -880,7 +908,8 @@ class TriviaGameMachine(TriviaGameMachineInterface):
         self.__backgroundTaskHelper.createTask(self.__startEventLoop())
 
     def submitAction(self, action: AbsTriviaAction):
-        assert isinstance(action, AbsTriviaAction), f"malformed {action=}"
+        if not isinstance(action, AbsTriviaAction):
+            raise ValueError(f'action argument is malformed: \"{action}\"')
 
         try:
             self.__actionQueue.put(action, block = True, timeout = self.__queueTimeoutSeconds)
@@ -888,7 +917,8 @@ class TriviaGameMachine(TriviaGameMachineInterface):
             self.__timber.log('TriviaGameMachine', f'Encountered queue.Full when submitting a new action ({action}) into the action queue (queue size: {self.__actionQueue.qsize()}): {e}', e, traceback.format_exc())
 
     async def __submitEvent(self, event: AbsTriviaEvent):
-        assert isinstance(event, AbsTriviaEvent), f"malformed {event=}"
+        if not isinstance(event, AbsTriviaEvent):
+            raise ValueError(f'event argument is malformed: \"{event}\"')
 
         try:
             self.__eventQueue.put(event, block = True, timeout = self.__queueTimeoutSeconds)

--- a/src/CynanBot/trivia/triviaHistoryRepository.py
+++ b/src/CynanBot/trivia/triviaHistoryRepository.py
@@ -27,14 +27,10 @@ class TriviaHistoryRepository(TriviaHistoryRepositoryInterface):
         triviaSettingsRepository: TriviaSettingsRepositoryInterface,
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -54,7 +50,7 @@ class TriviaHistoryRepository(TriviaHistoryRepositoryInterface):
     ) -> Optional[TriviaQuestionReference]:
         if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -127,11 +123,10 @@ class TriviaHistoryRepository(TriviaHistoryRepositoryInterface):
         emote: str,
         twitchChannel: str
     ) -> TriviaContentCode:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         triviaId = question.getTriviaId()

--- a/src/CynanBot/trivia/triviaHistoryRepository.py
+++ b/src/CynanBot/trivia/triviaHistoryRepository.py
@@ -27,10 +27,14 @@ class TriviaHistoryRepository(TriviaHistoryRepositoryInterface):
         triviaSettingsRepository: TriviaSettingsRepositoryInterface,
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -50,7 +54,7 @@ class TriviaHistoryRepository(TriviaHistoryRepositoryInterface):
     ) -> Optional[TriviaQuestionReference]:
         if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -123,10 +127,11 @@ class TriviaHistoryRepository(TriviaHistoryRepositoryInterface):
         emote: str,
         twitchChannel: str
     ) -> TriviaContentCode:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         triviaId = question.getTriviaId()

--- a/src/CynanBot/trivia/triviaIdGenerator.py
+++ b/src/CynanBot/trivia/triviaIdGenerator.py
@@ -30,10 +30,8 @@ class TriviaIdGenerator(TriviaIdGeneratorInterface):
     ) -> str:
         if not utils.isValidStr(question):
             raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif category is not None and not isinstance(category, str):
-            raise ValueError(f'category argument is malformed: \"{category}\"')
-        elif difficulty is not None and not isinstance(difficulty, str):
-            raise ValueError(f'difficulty argument is malformed: \"{difficulty}\"')
+        assert category is None or isinstance(category, str), f"malformed {category=}"
+        assert difficulty is None or isinstance(difficulty, str), f"malformed {difficulty=}"
 
         string = f'{question}'
 

--- a/src/CynanBot/trivia/triviaIdGenerator.py
+++ b/src/CynanBot/trivia/triviaIdGenerator.py
@@ -30,8 +30,10 @@ class TriviaIdGenerator(TriviaIdGeneratorInterface):
     ) -> str:
         if not utils.isValidStr(question):
             raise ValueError(f'question argument is malformed: \"{question}\"')
-        assert category is None or isinstance(category, str), f"malformed {category=}"
-        assert difficulty is None or isinstance(difficulty, str), f"malformed {difficulty=}"
+        elif category is not None and not isinstance(category, str):
+            raise ValueError(f'category argument is malformed: \"{category}\"')
+        elif difficulty is not None and not isinstance(difficulty, str):
+            raise ValueError(f'difficulty argument is malformed: \"{difficulty}\"')
 
         string = f'{question}'
 

--- a/src/CynanBot/trivia/triviaRepositories/absTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/absTriviaQuestionRepository.py
@@ -15,8 +15,7 @@ class AbsTriviaQuestionRepository(TriviaQuestionRepositoryInterface):
         self,
         triviaSettingsRepository: TriviaSettingsRepositoryInterface
     ):
-        if not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
 
         self._triviaSettingsRepository: TriviaSettingsRepositoryInterface = triviaSettingsRepository
 
@@ -27,7 +26,7 @@ class AbsTriviaQuestionRepository(TriviaQuestionRepositoryInterface):
     ) -> List[str]:
         if not utils.hasItems(correctAnswers):
             raise NoTriviaCorrectAnswersException(f'correctAnswers argument is malformed: \"{correctAnswers}\"')
-        elif not utils.hasItems(multipleChoiceResponses):
+        if not utils.hasItems(multipleChoiceResponses):
             raise NoTriviaMultipleChoiceResponsesException(f'multipleChoiceResponses argument is malformed: \"{multipleChoiceResponses}\"')
 
         filteredMultipleChoiceResponses: List[str] = utils.copyList(correctAnswers)
@@ -74,7 +73,7 @@ class AbsTriviaQuestionRepository(TriviaQuestionRepositoryInterface):
     ) -> bool:
         if not utils.hasItems(correctAnswers):
             raise NoTriviaCorrectAnswersException(f'correctAnswers argument is malformed: \"{correctAnswers}\"')
-        elif not utils.hasItems(multipleChoiceResponses):
+        if not utils.hasItems(multipleChoiceResponses):
             raise NoTriviaMultipleChoiceResponsesException(f'multipleChoiceResponses argument is malformed: \"{multipleChoiceResponses}\"')
 
         for correctAnswer in correctAnswers:

--- a/src/CynanBot/trivia/triviaRepositories/absTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/absTriviaQuestionRepository.py
@@ -15,7 +15,8 @@ class AbsTriviaQuestionRepository(TriviaQuestionRepositoryInterface):
         self,
         triviaSettingsRepository: TriviaSettingsRepositoryInterface
     ):
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        if not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise ValueError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
 
         self._triviaSettingsRepository: TriviaSettingsRepositoryInterface = triviaSettingsRepository
 
@@ -26,7 +27,7 @@ class AbsTriviaQuestionRepository(TriviaQuestionRepositoryInterface):
     ) -> List[str]:
         if not utils.hasItems(correctAnswers):
             raise NoTriviaCorrectAnswersException(f'correctAnswers argument is malformed: \"{correctAnswers}\"')
-        if not utils.hasItems(multipleChoiceResponses):
+        elif not utils.hasItems(multipleChoiceResponses):
             raise NoTriviaMultipleChoiceResponsesException(f'multipleChoiceResponses argument is malformed: \"{multipleChoiceResponses}\"')
 
         filteredMultipleChoiceResponses: List[str] = utils.copyList(correctAnswers)
@@ -73,7 +74,7 @@ class AbsTriviaQuestionRepository(TriviaQuestionRepositoryInterface):
     ) -> bool:
         if not utils.hasItems(correctAnswers):
             raise NoTriviaCorrectAnswersException(f'correctAnswers argument is malformed: \"{correctAnswers}\"')
-        if not utils.hasItems(multipleChoiceResponses):
+        elif not utils.hasItems(multipleChoiceResponses):
             raise NoTriviaMultipleChoiceResponsesException(f'multipleChoiceResponses argument is malformed: \"{multipleChoiceResponses}\"')
 
         for correctAnswer in correctAnswers:

--- a/src/CynanBot/trivia/triviaRepositories/bongoTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/bongoTriviaQuestionRepository.py
@@ -39,14 +39,10 @@ class BongoTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__timber: TimberInterface = timber
@@ -54,8 +50,7 @@ class BongoTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__triviaQuestionCompiler: TriviaQuestionCompilerInterface = triviaQuestionCompiler
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('BongoTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/bongoTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/bongoTriviaQuestionRepository.py
@@ -39,10 +39,14 @@ class BongoTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__timber: TimberInterface = timber
@@ -50,7 +54,8 @@ class BongoTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__triviaQuestionCompiler: TriviaQuestionCompilerInterface = triviaQuestionCompiler
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('BongoTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/funtoonTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/funtoonTriviaQuestionRepository.py
@@ -39,16 +39,11 @@ class FuntoonTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
-            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
-        elif not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface):
-            raise ValueError(f'triviaAnswerCompiler argument is malformed: \"{triviaAnswerCompiler}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface), f"malformed {triviaAnswerCompiler=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
@@ -57,8 +52,7 @@ class FuntoonTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__triviaQuestionCompiler: TriviaQuestionCompilerInterface = triviaQuestionCompiler
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('FuntoonTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/funtoonTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/funtoonTriviaQuestionRepository.py
@@ -39,11 +39,16 @@ class FuntoonTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface), f"malformed {triviaAnswerCompiler=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
+            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
+        elif not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface):
+            raise ValueError(f'triviaAnswerCompiler argument is malformed: \"{triviaAnswerCompiler}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
@@ -52,7 +57,8 @@ class FuntoonTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__triviaQuestionCompiler: TriviaQuestionCompilerInterface = triviaQuestionCompiler
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('FuntoonTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/jServiceTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/jServiceTriviaQuestionRepository.py
@@ -42,18 +42,12 @@ class JServiceTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
-            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
-        elif not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface):
-            raise ValueError(f'triviaAnswerCompiler argument is malformed: \"{triviaAnswerCompiler}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface), f"malformed {triviaAnswerCompiler=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
@@ -63,8 +57,7 @@ class JServiceTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__triviaQuestionCompiler: TriviaQuestionCompilerInterface = triviaQuestionCompiler
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('JServiceTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/jServiceTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/jServiceTriviaQuestionRepository.py
@@ -42,12 +42,18 @@ class JServiceTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface), f"malformed {triviaAnswerCompiler=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
+            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
+        elif not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface):
+            raise ValueError(f'triviaAnswerCompiler argument is malformed: \"{triviaAnswerCompiler}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
@@ -57,7 +63,8 @@ class JServiceTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__triviaQuestionCompiler: TriviaQuestionCompilerInterface = triviaQuestionCompiler
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('JServiceTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/lotrTriviaQuestionsRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/lotrTriviaQuestionsRepository.py
@@ -38,15 +38,11 @@ class LotrTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
-            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface):
-            raise ValueError(f'triviaAnswerCompiler argument is malformed: \"{triviaAnswerCompiler}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
-        elif not utils.isValidStr(triviaDatabaseFile):
+        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface), f"malformed {triviaAnswerCompiler=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
@@ -58,8 +54,7 @@ class LotrTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('LotrTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/lotrTriviaQuestionsRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/lotrTriviaQuestionsRepository.py
@@ -38,11 +38,15 @@ class LotrTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface), f"malformed {additionalTriviaAnswersRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface), f"malformed {triviaAnswerCompiler=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
-        if not utils.isValidStr(triviaDatabaseFile):
+        if not isinstance(additionalTriviaAnswersRepository, AdditionalTriviaAnswersRepositoryInterface):
+            raise ValueError(f'additionalTriviaAnswersRepository argument is malformed: \"{additionalTriviaAnswersRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaAnswerCompiler, TriviaAnswerCompilerInterface):
+            raise ValueError(f'triviaAnswerCompiler argument is malformed: \"{triviaAnswerCompiler}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        elif not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__additionalTriviaAnswersRepository: AdditionalTriviaAnswersRepositoryInterface = additionalTriviaAnswersRepository
@@ -54,7 +58,8 @@ class LotrTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('LotrTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/millionaireTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/millionaireTriviaQuestionRepository.py
@@ -32,11 +32,9 @@ class MillionaireTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
-        elif not utils.isValidStr(triviaDatabaseFile):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -46,8 +44,7 @@ class MillionaireTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('MillionaireTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/millionaireTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/millionaireTriviaQuestionRepository.py
@@ -32,9 +32,11 @@ class MillionaireTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
-        if not utils.isValidStr(triviaDatabaseFile):
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        elif not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -44,7 +46,8 @@ class MillionaireTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('MillionaireTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/openTriviaDatabaseTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/openTriviaDatabaseTriviaQuestionRepository.py
@@ -45,16 +45,11 @@ class OpenTriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository, Cl
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
@@ -96,18 +91,17 @@ class OpenTriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository, Cl
         if not utils.hasItems(jsonResponse):
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to null/empty JSON contents: {jsonResponse}')
             raise BadTriviaSessionTokenException(f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to null/empty JSON contents: {jsonResponse}')
-        elif utils.getIntFromDict(jsonResponse, 'response_code', fallback = -1) != 0:
+        if utils.getIntFromDict(jsonResponse, 'response_code', fallback = -1) != 0:
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to bad \"response_code\" value: {jsonResponse}')
             raise BadTriviaSessionTokenException(f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to bad \"response_code\" value: {jsonResponse}')
-        elif not utils.isValidStr(jsonResponse.get('token')):
+        if not utils.isValidStr(jsonResponse.get('token')):
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to bad \"token\" value: {jsonResponse}')
             raise BadTriviaSessionTokenException(f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to bad \"token\" value: {jsonResponse}')
 
         return utils.getStrFromDict(jsonResponse, 'token')
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 
@@ -136,11 +130,11 @@ class OpenTriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository, Cl
         if not utils.hasItems(jsonResponse):
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s JSON data due to null/empty JSON contents: {jsonResponse}')
             raise MalformedTriviaJsonException(f'Rejecting Open Trivia Database\'s JSON data due to null/empty JSON contents: {jsonResponse}')
-        elif utils.getIntFromDict(jsonResponse, 'response_code', fallback = -1) != 0:
+        if utils.getIntFromDict(jsonResponse, 'response_code', fallback = -1) != 0:
             await self.__removeSessionToken(fetchOptions.getTwitchChannel())
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s JSON data due to bad \"response_code\" value: {jsonResponse}')
             raise GenericTriviaNetworkException(self.getTriviaSource())
-        elif not utils.hasItems(jsonResponse.get('results')):
+        if not utils.hasItems(jsonResponse.get('results')):
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s JSON data due to missing/null/empty \"results\" array: {jsonResponse}')
             raise MalformedTriviaJsonException(f'Rejecting Open Trivia Database\'s JSON data due to missing/null/empty \"results\" array: {jsonResponse}')
 
@@ -323,9 +317,8 @@ class OpenTriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository, Cl
         sessionToken: Optional[str],
         twitchChannel: str
     ):
-        if sessionToken is not None and not isinstance(sessionToken, str):
-            raise ValueError(f'sessionToken argument is malformed: \"{sessionToken}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert sessionToken is None or isinstance(sessionToken, str), f"malformed {sessionToken=}"
+        if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()

--- a/src/CynanBot/trivia/triviaRepositories/openTriviaDatabaseTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/openTriviaDatabaseTriviaQuestionRepository.py
@@ -45,11 +45,16 @@ class OpenTriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository, Cl
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
@@ -91,17 +96,18 @@ class OpenTriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository, Cl
         if not utils.hasItems(jsonResponse):
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to null/empty JSON contents: {jsonResponse}')
             raise BadTriviaSessionTokenException(f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to null/empty JSON contents: {jsonResponse}')
-        if utils.getIntFromDict(jsonResponse, 'response_code', fallback = -1) != 0:
+        elif utils.getIntFromDict(jsonResponse, 'response_code', fallback = -1) != 0:
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to bad \"response_code\" value: {jsonResponse}')
             raise BadTriviaSessionTokenException(f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to bad \"response_code\" value: {jsonResponse}')
-        if not utils.isValidStr(jsonResponse.get('token')):
+        elif not utils.isValidStr(jsonResponse.get('token')):
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to bad \"token\" value: {jsonResponse}')
             raise BadTriviaSessionTokenException(f'Rejecting Open Trivia Database\'s session token JSON data for twitchChannel \"{twitchChannel}\" due to bad \"token\" value: {jsonResponse}')
 
         return utils.getStrFromDict(jsonResponse, 'token')
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 
@@ -130,11 +136,11 @@ class OpenTriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository, Cl
         if not utils.hasItems(jsonResponse):
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s JSON data due to null/empty JSON contents: {jsonResponse}')
             raise MalformedTriviaJsonException(f'Rejecting Open Trivia Database\'s JSON data due to null/empty JSON contents: {jsonResponse}')
-        if utils.getIntFromDict(jsonResponse, 'response_code', fallback = -1) != 0:
+        elif utils.getIntFromDict(jsonResponse, 'response_code', fallback = -1) != 0:
             await self.__removeSessionToken(fetchOptions.getTwitchChannel())
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s JSON data due to bad \"response_code\" value: {jsonResponse}')
             raise GenericTriviaNetworkException(self.getTriviaSource())
-        if not utils.hasItems(jsonResponse.get('results')):
+        elif not utils.hasItems(jsonResponse.get('results')):
             self.__timber.log('OpenTriviaDatabaseTriviaQuestionRepository', f'Rejecting Open Trivia Database\'s JSON data due to missing/null/empty \"results\" array: {jsonResponse}')
             raise MalformedTriviaJsonException(f'Rejecting Open Trivia Database\'s JSON data due to missing/null/empty \"results\" array: {jsonResponse}')
 
@@ -317,8 +323,9 @@ class OpenTriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository, Cl
         sessionToken: Optional[str],
         twitchChannel: str
     ):
-        assert sessionToken is None or isinstance(sessionToken, str), f"malformed {sessionToken=}"
-        if not utils.isValidStr(twitchChannel):
+        if sessionToken is not None and not isinstance(sessionToken, str):
+            raise ValueError(f'sessionToken argument is malformed: \"{sessionToken}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()

--- a/src/CynanBot/trivia/triviaRepositories/openTriviaQaTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/openTriviaQaTriviaQuestionRepository.py
@@ -35,11 +35,9 @@ class OpenTriviaQaTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
-        elif not utils.isValidStr(triviaDatabaseFile):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -49,8 +47,7 @@ class OpenTriviaQaTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('OpenTriviaQaTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/openTriviaQaTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/openTriviaQaTriviaQuestionRepository.py
@@ -35,9 +35,11 @@ class OpenTriviaQaTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
-        if not utils.isValidStr(triviaDatabaseFile):
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        elif not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -47,7 +49,8 @@ class OpenTriviaQaTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('OpenTriviaQaTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/pkmnTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/pkmnTriviaQuestionRepository.py
@@ -47,14 +47,10 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(pokepediaRepository, PokepediaRepository):
-            raise ValueError(f'pokepediaRepository argument is malformed: \"{pokepediaRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(maxGeneration, PokepediaGeneration):
-            raise ValueError(f'maxGeneration argument is malformed: \"{maxGeneration}\"')
+        assert isinstance(pokepediaRepository, PokepediaRepository), f"malformed {pokepediaRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(maxGeneration, PokepediaGeneration), f"malformed {maxGeneration=}"
 
         self.__pokepediaRepository: PokepediaRepository = pokepediaRepository
         self.__timber: TimberInterface = timber
@@ -62,8 +58,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__maxGeneration: PokepediaGeneration = maxGeneration
 
     async def __createMoveContestTypeQuestion(self, move: PokepediaMove) -> Optional[Dict[str, Any]]:
-        if not isinstance(move, PokepediaMove):
-            raise ValueError(f'move argument is malformed: \"{move}\"')
+        assert isinstance(move, PokepediaMove), f"malformed {move=}"
 
         if not move.hasContestType():
             return None
@@ -82,8 +77,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         }
 
     async def __createMoveDamageClassQuestion(self, move: PokepediaMove) -> Dict[str, Any]:
-        if not isinstance(move, PokepediaMove):
-            raise ValueError(f'move argument is malformed: \"{move}\"')
+        assert isinstance(move, PokepediaMove), f"malformed {move=}"
 
         damageClassStrs: List[str] = list()
         for damageClass in PokepediaDamageClass:
@@ -97,8 +91,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         }
 
     async def __createMoveIsAvailableAsMachineQuestion(self, move: PokepediaMove) -> Dict[str, Any]:
-        if not isinstance(move, PokepediaMove):
-            raise ValueError(f'move argument is malformed: \"{move}\"')
+        assert isinstance(move, PokepediaMove), f"malformed {move=}"
 
         randomGeneration = await self.__selectRandomGeneration(move.getInitialGeneration())
 
@@ -115,8 +108,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         }
 
     async def __createMoveIsAvailableAsWhichMachineQuestion(self, move: PokepediaMove) -> Optional[Dict[str, Any]]:
-        if not isinstance(move, PokepediaMove):
-            raise ValueError(f'move argument is malformed: \"{move}\"')
+        assert isinstance(move, PokepediaMove), f"malformed {move=}"
 
         if not move.hasMachines():
             return None
@@ -202,11 +194,9 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         berryFlavor: Optional[PokepediaBerryFlavor],
         likeOrDislikeStr: str
     ) -> Dict[str, Any]:
-        if not isinstance(nature, PokepediaNature):
-            raise ValueError(f'nature argument is malformed: \"{nature}\"')
-        elif berryFlavor is not None and not isinstance(berryFlavor, PokepediaBerryFlavor):
-            raise ValueError(f'berryFlavor argument is malformed: \"{berryFlavor}\"')
-        elif not utils.isValidStr(likeOrDislikeStr):
+        assert isinstance(nature, PokepediaNature), f"malformed {nature=}"
+        assert berryFlavor is None or isinstance(berryFlavor, PokepediaBerryFlavor), f"malformed {berryFlavor=}"
+        if not utils.isValidStr(likeOrDislikeStr):
             raise ValueError(f'likeOrDislikeStr argument is malformed: \"{likeOrDislikeStr}\"')
 
         randomFlavors = await self.__selectRandomFalseBerryFlavors(berryFlavor)
@@ -335,8 +325,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         return triviaDict
 
     async def __createStatDecreasingNaturesQuestion(self, stat: PokepediaStat) -> Dict[str, Any]:
-        if not isinstance(stat, PokepediaStat):
-            raise ValueError(f'stat argument is malformed: \"{stat}\"')
+        assert isinstance(stat, PokepediaStat), f"malformed {stat=}"
 
         decreasingNatures = stat.getDecreasingNatures()
         randomNature = random.choice(list(PokepediaNature))
@@ -348,8 +337,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         }
 
     async def __createStatIncreasingNaturesQuestion(self, stat: PokepediaStat) -> Dict[str, Any]:
-        if not isinstance(stat, PokepediaStat):
-            raise ValueError(f'stat argument is malformed: \"{stat}\"')
+        assert isinstance(stat, PokepediaStat), f"malformed {stat=}"
 
         increasingNatures = stat.getIncreasingNatures()
         randomNature = random.choice(list(PokepediaNature))
@@ -361,8 +349,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         }
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('PkmnTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 
@@ -443,8 +430,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self,
         actualFlavor: Optional[PokepediaBerryFlavor]
     ) -> Set[PokepediaBerryFlavor]:
-        if actualFlavor is not None and not isinstance(actualFlavor, PokepediaBerryFlavor):
-            raise ValueError(f'actualFlavor argument is malformed: \"{actualFlavor}\"')
+        assert actualFlavor is None or isinstance(actualFlavor, PokepediaBerryFlavor), f"malformed {actualFlavor=}"
 
         allFlavors: List[PokepediaBerryFlavor] = list(PokepediaBerryFlavor)
         falseFlavors: Set[PokepediaBerryFlavor] = set()
@@ -466,8 +452,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self,
         actualType: PokepediaContestType
     ) -> Set[PokepediaContestType]:
-        if not isinstance(actualType, PokepediaContestType):
-            raise ValueError(f'actualType argument is malformed: \"{actualType}\"')
+        assert isinstance(actualType, PokepediaContestType), f"malformed {actualType=}"
 
         allTypes: List[PokepediaContestType] = list(PokepediaContestType)
         falseTypes: Set[PokepediaContestType] = set()
@@ -515,8 +500,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ) -> Set[int]:
         if not utils.isValidInt(actualMachineNumber):
             raise ValueError(f'actualMachineNumber argument is malformed: \"{actualMachineNumber}\"')
-        elif not isinstance(actualMachineType, PokepediaMachineType):
-            raise ValueError(f'actualMachineType argument is malformed: \"{actualMachineType}\"')
+        assert isinstance(actualMachineType, PokepediaMachineType), f"malformed {actualMachineType=}"
 
         minResponses = await self._triviaSettingsRepository.getMinMultipleChoiceResponses()
         maxResponses = await self._triviaSettingsRepository.getMaxMultipleChoiceResponses()
@@ -537,8 +521,7 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self,
         initialGeneration: PokepediaGeneration
     ) -> PokepediaGeneration:
-        if not isinstance(initialGeneration, PokepediaGeneration):
-            raise ValueError(f'initialGeneration argument is malformed: \"{initialGeneration}\"')
+        assert isinstance(initialGeneration, PokepediaGeneration), f"malformed {initialGeneration=}"
 
         allGenerations: List[PokepediaGeneration] = list(PokepediaGeneration)
         indexOfMax = allGenerations.index(self.__maxGeneration)

--- a/src/CynanBot/trivia/triviaRepositories/pkmnTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/pkmnTriviaQuestionRepository.py
@@ -47,10 +47,14 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(pokepediaRepository, PokepediaRepository), f"malformed {pokepediaRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(maxGeneration, PokepediaGeneration), f"malformed {maxGeneration=}"
+        if not isinstance(pokepediaRepository, PokepediaRepository):
+            raise ValueError(f'pokepediaRepository argument is malformed: \"{pokepediaRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(maxGeneration, PokepediaGeneration):
+            raise ValueError(f'maxGeneration argument is malformed: \"{maxGeneration}\"')
 
         self.__pokepediaRepository: PokepediaRepository = pokepediaRepository
         self.__timber: TimberInterface = timber
@@ -58,7 +62,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__maxGeneration: PokepediaGeneration = maxGeneration
 
     async def __createMoveContestTypeQuestion(self, move: PokepediaMove) -> Optional[Dict[str, Any]]:
-        assert isinstance(move, PokepediaMove), f"malformed {move=}"
+        if not isinstance(move, PokepediaMove):
+            raise ValueError(f'move argument is malformed: \"{move}\"')
 
         if not move.hasContestType():
             return None
@@ -77,7 +82,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         }
 
     async def __createMoveDamageClassQuestion(self, move: PokepediaMove) -> Dict[str, Any]:
-        assert isinstance(move, PokepediaMove), f"malformed {move=}"
+        if not isinstance(move, PokepediaMove):
+            raise ValueError(f'move argument is malformed: \"{move}\"')
 
         damageClassStrs: List[str] = list()
         for damageClass in PokepediaDamageClass:
@@ -91,7 +97,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         }
 
     async def __createMoveIsAvailableAsMachineQuestion(self, move: PokepediaMove) -> Dict[str, Any]:
-        assert isinstance(move, PokepediaMove), f"malformed {move=}"
+        if not isinstance(move, PokepediaMove):
+            raise ValueError(f'move argument is malformed: \"{move}\"')
 
         randomGeneration = await self.__selectRandomGeneration(move.getInitialGeneration())
 
@@ -108,7 +115,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         }
 
     async def __createMoveIsAvailableAsWhichMachineQuestion(self, move: PokepediaMove) -> Optional[Dict[str, Any]]:
-        assert isinstance(move, PokepediaMove), f"malformed {move=}"
+        if not isinstance(move, PokepediaMove):
+            raise ValueError(f'move argument is malformed: \"{move}\"')
 
         if not move.hasMachines():
             return None
@@ -194,9 +202,11 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         berryFlavor: Optional[PokepediaBerryFlavor],
         likeOrDislikeStr: str
     ) -> Dict[str, Any]:
-        assert isinstance(nature, PokepediaNature), f"malformed {nature=}"
-        assert berryFlavor is None or isinstance(berryFlavor, PokepediaBerryFlavor), f"malformed {berryFlavor=}"
-        if not utils.isValidStr(likeOrDislikeStr):
+        if not isinstance(nature, PokepediaNature):
+            raise ValueError(f'nature argument is malformed: \"{nature}\"')
+        elif berryFlavor is not None and not isinstance(berryFlavor, PokepediaBerryFlavor):
+            raise ValueError(f'berryFlavor argument is malformed: \"{berryFlavor}\"')
+        elif not utils.isValidStr(likeOrDislikeStr):
             raise ValueError(f'likeOrDislikeStr argument is malformed: \"{likeOrDislikeStr}\"')
 
         randomFlavors = await self.__selectRandomFalseBerryFlavors(berryFlavor)
@@ -325,7 +335,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         return triviaDict
 
     async def __createStatDecreasingNaturesQuestion(self, stat: PokepediaStat) -> Dict[str, Any]:
-        assert isinstance(stat, PokepediaStat), f"malformed {stat=}"
+        if not isinstance(stat, PokepediaStat):
+            raise ValueError(f'stat argument is malformed: \"{stat}\"')
 
         decreasingNatures = stat.getDecreasingNatures()
         randomNature = random.choice(list(PokepediaNature))
@@ -337,7 +348,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         }
 
     async def __createStatIncreasingNaturesQuestion(self, stat: PokepediaStat) -> Dict[str, Any]:
-        assert isinstance(stat, PokepediaStat), f"malformed {stat=}"
+        if not isinstance(stat, PokepediaStat):
+            raise ValueError(f'stat argument is malformed: \"{stat}\"')
 
         increasingNatures = stat.getIncreasingNatures()
         randomNature = random.choice(list(PokepediaNature))
@@ -349,7 +361,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         }
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('PkmnTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 
@@ -430,7 +443,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self,
         actualFlavor: Optional[PokepediaBerryFlavor]
     ) -> Set[PokepediaBerryFlavor]:
-        assert actualFlavor is None or isinstance(actualFlavor, PokepediaBerryFlavor), f"malformed {actualFlavor=}"
+        if actualFlavor is not None and not isinstance(actualFlavor, PokepediaBerryFlavor):
+            raise ValueError(f'actualFlavor argument is malformed: \"{actualFlavor}\"')
 
         allFlavors: List[PokepediaBerryFlavor] = list(PokepediaBerryFlavor)
         falseFlavors: Set[PokepediaBerryFlavor] = set()
@@ -452,7 +466,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self,
         actualType: PokepediaContestType
     ) -> Set[PokepediaContestType]:
-        assert isinstance(actualType, PokepediaContestType), f"malformed {actualType=}"
+        if not isinstance(actualType, PokepediaContestType):
+            raise ValueError(f'actualType argument is malformed: \"{actualType}\"')
 
         allTypes: List[PokepediaContestType] = list(PokepediaContestType)
         falseTypes: Set[PokepediaContestType] = set()
@@ -500,7 +515,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ) -> Set[int]:
         if not utils.isValidInt(actualMachineNumber):
             raise ValueError(f'actualMachineNumber argument is malformed: \"{actualMachineNumber}\"')
-        assert isinstance(actualMachineType, PokepediaMachineType), f"malformed {actualMachineType=}"
+        elif not isinstance(actualMachineType, PokepediaMachineType):
+            raise ValueError(f'actualMachineType argument is malformed: \"{actualMachineType}\"')
 
         minResponses = await self._triviaSettingsRepository.getMinMultipleChoiceResponses()
         maxResponses = await self._triviaSettingsRepository.getMaxMultipleChoiceResponses()
@@ -521,7 +537,8 @@ class PkmnTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self,
         initialGeneration: PokepediaGeneration
     ) -> PokepediaGeneration:
-        assert isinstance(initialGeneration, PokepediaGeneration), f"malformed {initialGeneration=}"
+        if not isinstance(initialGeneration, PokepediaGeneration):
+            raise ValueError(f'initialGeneration argument is malformed: \"{initialGeneration}\"')
 
         allGenerations: List[PokepediaGeneration] = list(PokepediaGeneration)
         indexOfMax = allGenerations.index(self.__maxGeneration)

--- a/src/CynanBot/trivia/triviaRepositories/quizApiTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/quizApiTriviaQuestionRepository.py
@@ -38,14 +38,11 @@ class QuizApiTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not utils.isValidStr(quizApiKey):
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        if not utils.isValidStr(quizApiKey):
             raise ValueError(f'quizApiKey argument is malformed: \"{quizApiKey}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__quizApiKey: str = quizApiKey
@@ -53,8 +50,7 @@ class QuizApiTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__triviaIdGenerator: TriviaIdGeneratorInterface = triviaIdGenerator
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('QuizApiTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/quizApiTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/quizApiTriviaQuestionRepository.py
@@ -38,11 +38,14 @@ class QuizApiTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        if not utils.isValidStr(quizApiKey):
+        if not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not utils.isValidStr(quizApiKey):
             raise ValueError(f'quizApiKey argument is malformed: \"{quizApiKey}\"')
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__quizApiKey: str = quizApiKey
@@ -50,7 +53,8 @@ class QuizApiTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__triviaIdGenerator: TriviaIdGeneratorInterface = triviaIdGenerator
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('QuizApiTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/triviaDatabaseTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/triviaDatabaseTriviaQuestionRepository.py
@@ -35,11 +35,9 @@ class TriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
-        elif not utils.isValidStr(triviaDatabaseFile):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -49,8 +47,7 @@ class TriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('TriviaDatabaseTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/triviaDatabaseTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/triviaDatabaseTriviaQuestionRepository.py
@@ -35,9 +35,11 @@ class TriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
-        if not utils.isValidStr(triviaDatabaseFile):
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        elif not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -47,7 +49,8 @@ class TriviaDatabaseTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('TriviaDatabaseTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/triviaQuestionCompanyTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/triviaQuestionCompanyTriviaQuestionRepository.py
@@ -33,11 +33,9 @@ class TriviaQuestionCompanyTriviaQuestionRepository(AbsTriviaQuestionRepository)
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
-        elif not utils.isValidStr(triviaDatabaseFile):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -47,8 +45,7 @@ class TriviaQuestionCompanyTriviaQuestionRepository(AbsTriviaQuestionRepository)
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('TriviaQuestionCompanyTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/triviaQuestionCompanyTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/triviaQuestionCompanyTriviaQuestionRepository.py
@@ -33,9 +33,11 @@ class TriviaQuestionCompanyTriviaQuestionRepository(AbsTriviaQuestionRepository)
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
-        if not utils.isValidStr(triviaDatabaseFile):
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        elif not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -45,7 +47,8 @@ class TriviaQuestionCompanyTriviaQuestionRepository(AbsTriviaQuestionRepository)
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('TriviaQuestionCompanyTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/triviaRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/triviaRepository.py
@@ -86,51 +86,32 @@ class TriviaRepository(TriviaRepositoryInterface):
         spoolerLoopSleepTimeSeconds: float = 120,
         triviaRetrySleepTimeSeconds: float = 0.25
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(bongoTriviaQuestionRepository, BongoTriviaQuestionRepository):
-            raise TypeError(f'bongoTriviaQuestionRepository argument is malformed: \"{bongoTriviaQuestionRepository}\"')
-        elif not isinstance(funtoonTriviaQuestionRepository, FuntoonTriviaQuestionRepository):
-            raise TypeError(f'funtoonTriviaQuestionRepository argument is malformed: \"{funtoonTriviaQuestionRepository}\"')
-        elif jServiceTriviaQuestionRepository is not None and not isinstance(jServiceTriviaQuestionRepository, JServiceTriviaQuestionRepository):
-            raise TypeError(f'jServiceTriviaQuestionRepository argument is malformed \"{jServiceTriviaQuestionRepository}\"')
-        elif lotrTriviaQuestionRepository is not None and not isinstance(lotrTriviaQuestionRepository, LotrTriviaQuestionRepository):
-            raise TypeError(f'lotrTriviaQuestionRepository argument is malformed: \"{lotrTriviaQuestionRepository}\"')
-        elif not isinstance(millionaireTriviaQuestionRepository, MillionaireTriviaQuestionRepository):
-            raise TypeError(f'millionaireTriviaQuestionRepository argument is malformed: \"{millionaireTriviaQuestionRepository}\"')
-        elif not isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository):
-            raise TypeError(f'openTriviaDatabaseTriviaQuestionRepository argument is malformed: \"{openTriviaDatabaseTriviaQuestionRepository}\"')
-        elif not isinstance(openTriviaQaTriviaQuestionRepository, OpenTriviaQaTriviaQuestionRepository):
-            raise TypeError(f'openTriviaQaTriviaQuestionRepository argument is malformed: \"{openTriviaQaTriviaQuestionRepository}\"')
-        elif not isinstance(pkmnTriviaQuestionRepository, PkmnTriviaQuestionRepository):
-            raise TypeError(f'pkmnTriviaQuestionRepository argument is malformed: \"{pkmnTriviaQuestionRepository}\"')
-        elif quizApiTriviaQuestionRepository is not None and not isinstance(quizApiTriviaQuestionRepository, QuizApiTriviaQuestionRepository):
-            raise TypeError(f'quizApiTriviaQuestionRepository argument is malformed: \"{quizApiTriviaQuestionRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaDatabaseTriviaQuestionRepository, TriviaDatabaseTriviaQuestionRepository):
-            raise TypeError(f'triviaDatabaseTriviaQuestionRepository argument is malformed: \"{triviaDatabaseTriviaQuestionRepository}\"')
-        elif not isinstance(triviaQuestionCompanyTriviaQuestionRepository, TriviaQuestionCompanyTriviaQuestionRepository):
-            raise TypeError(f'triviaQuestionCompanyTriviaQuestionRepository argument is malformed: \"{triviaQuestionCompanyTriviaQuestionRepository}\"')
-        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
-            raise TypeError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
-        elif not isinstance(triviaSourceInstabilityHelper, TriviaSourceInstabilityHelper):
-            raise TypeError(f'triviaSourceInstabilityHelper argument is malformed: \"{triviaSourceInstabilityHelper}\"')
-        elif not isinstance(triviaVerifier, TriviaVerifierInterface):
-            raise TypeError(f'triviaVerifier argument is malformed: \"{triviaVerifier}\"')
-        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
-            raise TypeError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
-        elif not isinstance(willFryTriviaQuestionRepository, WillFryTriviaQuestionRepository):
-            raise TypeError(f'willFryTriviaQuestionRepository argument is malformed: \"{willFryTriviaQuestionRepository}\"')
-        elif not isinstance(wwtbamTriviaQuestionRepository, WwtbamTriviaQuestionRepository):
-            raise TypeError(f'wwtbamTriviaQuestionRepository argument is malformed: \"{wwtbamTriviaQuestionRepository}\"')
-        elif not utils.isValidNum(spoolerLoopSleepTimeSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(bongoTriviaQuestionRepository, BongoTriviaQuestionRepository), f"malformed {bongoTriviaQuestionRepository=}"
+        assert isinstance(funtoonTriviaQuestionRepository, FuntoonTriviaQuestionRepository), f"malformed {funtoonTriviaQuestionRepository=}"
+        assert jServiceTriviaQuestionRepository is None or isinstance(jServiceTriviaQuestionRepository, JServiceTriviaQuestionRepository), f"malformed {jServiceTriviaQuestionRepository=}"
+        assert lotrTriviaQuestionRepository is None or isinstance(lotrTriviaQuestionRepository, LotrTriviaQuestionRepository), f"malformed {lotrTriviaQuestionRepository=}"
+        assert isinstance(millionaireTriviaQuestionRepository, MillionaireTriviaQuestionRepository), f"malformed {millionaireTriviaQuestionRepository=}"
+        assert isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository), f"malformed {openTriviaDatabaseTriviaQuestionRepository=}"
+        assert isinstance(openTriviaQaTriviaQuestionRepository, OpenTriviaQaTriviaQuestionRepository), f"malformed {openTriviaQaTriviaQuestionRepository=}"
+        assert isinstance(pkmnTriviaQuestionRepository, PkmnTriviaQuestionRepository), f"malformed {pkmnTriviaQuestionRepository=}"
+        assert quizApiTriviaQuestionRepository is None or isinstance(quizApiTriviaQuestionRepository, QuizApiTriviaQuestionRepository), f"malformed {quizApiTriviaQuestionRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaDatabaseTriviaQuestionRepository, TriviaDatabaseTriviaQuestionRepository), f"malformed {triviaDatabaseTriviaQuestionRepository=}"
+        assert isinstance(triviaQuestionCompanyTriviaQuestionRepository, TriviaQuestionCompanyTriviaQuestionRepository), f"malformed {triviaQuestionCompanyTriviaQuestionRepository=}"
+        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
+        assert isinstance(triviaSourceInstabilityHelper, TriviaSourceInstabilityHelper), f"malformed {triviaSourceInstabilityHelper=}"
+        assert isinstance(triviaVerifier, TriviaVerifierInterface), f"malformed {triviaVerifier=}"
+        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
+        assert isinstance(willFryTriviaQuestionRepository, WillFryTriviaQuestionRepository), f"malformed {willFryTriviaQuestionRepository=}"
+        assert isinstance(wwtbamTriviaQuestionRepository, WwtbamTriviaQuestionRepository), f"malformed {wwtbamTriviaQuestionRepository=}"
+        if not utils.isValidNum(spoolerLoopSleepTimeSeconds):
             raise TypeError(f'spoolerLoopSleepTimeSeconds argument is malformed: \"{spoolerLoopSleepTimeSeconds}\"')
-        elif spoolerLoopSleepTimeSeconds < 15 or spoolerLoopSleepTimeSeconds > 300:
+        if spoolerLoopSleepTimeSeconds < 15 or spoolerLoopSleepTimeSeconds > 300:
             raise ValueError(f'spoolerLoopSleepTimeSeconds argument is out of bounds: {spoolerLoopSleepTimeSeconds}')
-        elif not utils.isValidNum(triviaRetrySleepTimeSeconds):
+        if not utils.isValidNum(triviaRetrySleepTimeSeconds):
             raise TypeError(f'triviaRetrySleepTimeSeconds argument is malformed: \"{triviaRetrySleepTimeSeconds}\"')
-        elif triviaRetrySleepTimeSeconds < 0.25 or triviaRetrySleepTimeSeconds > 3:
+        if triviaRetrySleepTimeSeconds < 0.25 or triviaRetrySleepTimeSeconds > 3:
             raise ValueError(f'triviaRetrySleepTimeSeconds argument is out of bounds: {triviaRetrySleepTimeSeconds}')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -161,8 +142,7 @@ class TriviaRepository(TriviaRepositoryInterface):
         self.__triviaQuestionSpool: SimpleQueue[AbsTriviaQuestion] = SimpleQueue()
 
     async def __chooseRandomTriviaSource(self, triviaFetchOptions: TriviaFetchOptions) -> TriviaQuestionRepositoryInterface:
-        if not isinstance(triviaFetchOptions, TriviaFetchOptions):
-            raise TypeError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
+        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
 
         triviaSourcesAndWeights: Dict[TriviaSource, int] = await self.__triviaSettingsRepository.getAvailableTriviaSourcesAndWeights()
         triviaSourcesToRemove: Set[TriviaSource] = await self.__getCurrentlyInvalidTriviaSources(triviaFetchOptions)
@@ -228,8 +208,7 @@ class TriviaRepository(TriviaRepositoryInterface):
     ) -> Optional[AbsTriviaQuestion]:
         if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
-            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
+        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
 
         question: Optional[AbsTriviaQuestion] = None
         retryCount: int = 0
@@ -275,8 +254,7 @@ class TriviaRepository(TriviaRepositoryInterface):
         raise TooManyTriviaFetchAttemptsException(f'Unable to fetch trivia from {attemptedTriviaSources} after {retryCount} attempts (max attempts is {maxRetryCount})')
 
     async def __getCurrentlyInvalidTriviaSources(self, triviaFetchOptions: TriviaFetchOptions) -> Set[TriviaSource]:
-        if not isinstance(triviaFetchOptions, TriviaFetchOptions):
-            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
+        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
 
         availableTriviaSourcesMap: Dict[TriviaSource, TriviaQuestionRepositoryInterface] = dict()
         for triviaSource, triviaQuestionRepository in self.__triviaSourceToRepositoryMap.items():
@@ -332,8 +310,7 @@ class TriviaRepository(TriviaRepositoryInterface):
         self,
         triviaFetchOptions: TriviaFetchOptions
     ) -> Optional[AbsTriviaQuestion]:
-        if not isinstance(triviaFetchOptions, TriviaFetchOptions):
-            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
+        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
 
         if triviaFetchOptions.requireQuestionAnswerTriviaQuestion():
             if not self.__superTriviaQuestionSpool.empty():
@@ -469,10 +446,8 @@ class TriviaRepository(TriviaRepositoryInterface):
         question: Optional[AbsTriviaQuestion],
         triviaFetchOptions: TriviaFetchOptions
     ) -> bool:
-        if question is not None and not isinstance(question, AbsTriviaQuestion):
-            raise TypeError(f'question argument is malformed: \"{question}\"')
-        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
-            raise TypeError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
+        assert question is None or isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
 
         triviaContentCode = await self.__triviaVerifier.checkContent(
             question = question,
@@ -491,12 +466,10 @@ class TriviaRepository(TriviaRepositoryInterface):
         emote: str,
         triviaFetchOptions: TriviaFetchOptions
     ) -> bool:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise TypeError(f'question argument is malformed: \"{question}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not utils.isValidStr(emote):
             raise TypeError(f'emote argument is malformed: \"{emote}\"')
-        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
-            raise TypeError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
+        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
 
         triviaContentCode = await self.__triviaVerifier.checkHistory(
             question = question, 

--- a/src/CynanBot/trivia/triviaRepositories/triviaRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/triviaRepository.py
@@ -86,32 +86,51 @@ class TriviaRepository(TriviaRepositoryInterface):
         spoolerLoopSleepTimeSeconds: float = 120,
         triviaRetrySleepTimeSeconds: float = 0.25
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(bongoTriviaQuestionRepository, BongoTriviaQuestionRepository), f"malformed {bongoTriviaQuestionRepository=}"
-        assert isinstance(funtoonTriviaQuestionRepository, FuntoonTriviaQuestionRepository), f"malformed {funtoonTriviaQuestionRepository=}"
-        assert jServiceTriviaQuestionRepository is None or isinstance(jServiceTriviaQuestionRepository, JServiceTriviaQuestionRepository), f"malformed {jServiceTriviaQuestionRepository=}"
-        assert lotrTriviaQuestionRepository is None or isinstance(lotrTriviaQuestionRepository, LotrTriviaQuestionRepository), f"malformed {lotrTriviaQuestionRepository=}"
-        assert isinstance(millionaireTriviaQuestionRepository, MillionaireTriviaQuestionRepository), f"malformed {millionaireTriviaQuestionRepository=}"
-        assert isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository), f"malformed {openTriviaDatabaseTriviaQuestionRepository=}"
-        assert isinstance(openTriviaQaTriviaQuestionRepository, OpenTriviaQaTriviaQuestionRepository), f"malformed {openTriviaQaTriviaQuestionRepository=}"
-        assert isinstance(pkmnTriviaQuestionRepository, PkmnTriviaQuestionRepository), f"malformed {pkmnTriviaQuestionRepository=}"
-        assert quizApiTriviaQuestionRepository is None or isinstance(quizApiTriviaQuestionRepository, QuizApiTriviaQuestionRepository), f"malformed {quizApiTriviaQuestionRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaDatabaseTriviaQuestionRepository, TriviaDatabaseTriviaQuestionRepository), f"malformed {triviaDatabaseTriviaQuestionRepository=}"
-        assert isinstance(triviaQuestionCompanyTriviaQuestionRepository, TriviaQuestionCompanyTriviaQuestionRepository), f"malformed {triviaQuestionCompanyTriviaQuestionRepository=}"
-        assert isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface), f"malformed {triviaSettingsRepository=}"
-        assert isinstance(triviaSourceInstabilityHelper, TriviaSourceInstabilityHelper), f"malformed {triviaSourceInstabilityHelper=}"
-        assert isinstance(triviaVerifier, TriviaVerifierInterface), f"malformed {triviaVerifier=}"
-        assert isinstance(twitchHandleProvider, TwitchHandleProviderInterface), f"malformed {twitchHandleProvider=}"
-        assert isinstance(willFryTriviaQuestionRepository, WillFryTriviaQuestionRepository), f"malformed {willFryTriviaQuestionRepository=}"
-        assert isinstance(wwtbamTriviaQuestionRepository, WwtbamTriviaQuestionRepository), f"malformed {wwtbamTriviaQuestionRepository=}"
-        if not utils.isValidNum(spoolerLoopSleepTimeSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(bongoTriviaQuestionRepository, BongoTriviaQuestionRepository):
+            raise TypeError(f'bongoTriviaQuestionRepository argument is malformed: \"{bongoTriviaQuestionRepository}\"')
+        elif not isinstance(funtoonTriviaQuestionRepository, FuntoonTriviaQuestionRepository):
+            raise TypeError(f'funtoonTriviaQuestionRepository argument is malformed: \"{funtoonTriviaQuestionRepository}\"')
+        elif jServiceTriviaQuestionRepository is not None and not isinstance(jServiceTriviaQuestionRepository, JServiceTriviaQuestionRepository):
+            raise TypeError(f'jServiceTriviaQuestionRepository argument is malformed \"{jServiceTriviaQuestionRepository}\"')
+        elif lotrTriviaQuestionRepository is not None and not isinstance(lotrTriviaQuestionRepository, LotrTriviaQuestionRepository):
+            raise TypeError(f'lotrTriviaQuestionRepository argument is malformed: \"{lotrTriviaQuestionRepository}\"')
+        elif not isinstance(millionaireTriviaQuestionRepository, MillionaireTriviaQuestionRepository):
+            raise TypeError(f'millionaireTriviaQuestionRepository argument is malformed: \"{millionaireTriviaQuestionRepository}\"')
+        elif not isinstance(openTriviaDatabaseTriviaQuestionRepository, OpenTriviaDatabaseTriviaQuestionRepository):
+            raise TypeError(f'openTriviaDatabaseTriviaQuestionRepository argument is malformed: \"{openTriviaDatabaseTriviaQuestionRepository}\"')
+        elif not isinstance(openTriviaQaTriviaQuestionRepository, OpenTriviaQaTriviaQuestionRepository):
+            raise TypeError(f'openTriviaQaTriviaQuestionRepository argument is malformed: \"{openTriviaQaTriviaQuestionRepository}\"')
+        elif not isinstance(pkmnTriviaQuestionRepository, PkmnTriviaQuestionRepository):
+            raise TypeError(f'pkmnTriviaQuestionRepository argument is malformed: \"{pkmnTriviaQuestionRepository}\"')
+        elif quizApiTriviaQuestionRepository is not None and not isinstance(quizApiTriviaQuestionRepository, QuizApiTriviaQuestionRepository):
+            raise TypeError(f'quizApiTriviaQuestionRepository argument is malformed: \"{quizApiTriviaQuestionRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaDatabaseTriviaQuestionRepository, TriviaDatabaseTriviaQuestionRepository):
+            raise TypeError(f'triviaDatabaseTriviaQuestionRepository argument is malformed: \"{triviaDatabaseTriviaQuestionRepository}\"')
+        elif not isinstance(triviaQuestionCompanyTriviaQuestionRepository, TriviaQuestionCompanyTriviaQuestionRepository):
+            raise TypeError(f'triviaQuestionCompanyTriviaQuestionRepository argument is malformed: \"{triviaQuestionCompanyTriviaQuestionRepository}\"')
+        elif not isinstance(triviaSettingsRepository, TriviaSettingsRepositoryInterface):
+            raise TypeError(f'triviaSettingsRepository argument is malformed: \"{triviaSettingsRepository}\"')
+        elif not isinstance(triviaSourceInstabilityHelper, TriviaSourceInstabilityHelper):
+            raise TypeError(f'triviaSourceInstabilityHelper argument is malformed: \"{triviaSourceInstabilityHelper}\"')
+        elif not isinstance(triviaVerifier, TriviaVerifierInterface):
+            raise TypeError(f'triviaVerifier argument is malformed: \"{triviaVerifier}\"')
+        elif not isinstance(twitchHandleProvider, TwitchHandleProviderInterface):
+            raise TypeError(f'twitchHandleProvider argument is malformed: \"{twitchHandleProvider}\"')
+        elif not isinstance(willFryTriviaQuestionRepository, WillFryTriviaQuestionRepository):
+            raise TypeError(f'willFryTriviaQuestionRepository argument is malformed: \"{willFryTriviaQuestionRepository}\"')
+        elif not isinstance(wwtbamTriviaQuestionRepository, WwtbamTriviaQuestionRepository):
+            raise TypeError(f'wwtbamTriviaQuestionRepository argument is malformed: \"{wwtbamTriviaQuestionRepository}\"')
+        elif not utils.isValidNum(spoolerLoopSleepTimeSeconds):
             raise TypeError(f'spoolerLoopSleepTimeSeconds argument is malformed: \"{spoolerLoopSleepTimeSeconds}\"')
-        if spoolerLoopSleepTimeSeconds < 15 or spoolerLoopSleepTimeSeconds > 300:
+        elif spoolerLoopSleepTimeSeconds < 15 or spoolerLoopSleepTimeSeconds > 300:
             raise ValueError(f'spoolerLoopSleepTimeSeconds argument is out of bounds: {spoolerLoopSleepTimeSeconds}')
-        if not utils.isValidNum(triviaRetrySleepTimeSeconds):
+        elif not utils.isValidNum(triviaRetrySleepTimeSeconds):
             raise TypeError(f'triviaRetrySleepTimeSeconds argument is malformed: \"{triviaRetrySleepTimeSeconds}\"')
-        if triviaRetrySleepTimeSeconds < 0.25 or triviaRetrySleepTimeSeconds > 3:
+        elif triviaRetrySleepTimeSeconds < 0.25 or triviaRetrySleepTimeSeconds > 3:
             raise ValueError(f'triviaRetrySleepTimeSeconds argument is out of bounds: {triviaRetrySleepTimeSeconds}')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -142,7 +161,8 @@ class TriviaRepository(TriviaRepositoryInterface):
         self.__triviaQuestionSpool: SimpleQueue[AbsTriviaQuestion] = SimpleQueue()
 
     async def __chooseRandomTriviaSource(self, triviaFetchOptions: TriviaFetchOptions) -> TriviaQuestionRepositoryInterface:
-        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
+        if not isinstance(triviaFetchOptions, TriviaFetchOptions):
+            raise TypeError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
 
         triviaSourcesAndWeights: Dict[TriviaSource, int] = await self.__triviaSettingsRepository.getAvailableTriviaSourcesAndWeights()
         triviaSourcesToRemove: Set[TriviaSource] = await self.__getCurrentlyInvalidTriviaSources(triviaFetchOptions)
@@ -208,7 +228,8 @@ class TriviaRepository(TriviaRepositoryInterface):
     ) -> Optional[AbsTriviaQuestion]:
         if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
+        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
+            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
 
         question: Optional[AbsTriviaQuestion] = None
         retryCount: int = 0
@@ -254,7 +275,8 @@ class TriviaRepository(TriviaRepositoryInterface):
         raise TooManyTriviaFetchAttemptsException(f'Unable to fetch trivia from {attemptedTriviaSources} after {retryCount} attempts (max attempts is {maxRetryCount})')
 
     async def __getCurrentlyInvalidTriviaSources(self, triviaFetchOptions: TriviaFetchOptions) -> Set[TriviaSource]:
-        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
+        if not isinstance(triviaFetchOptions, TriviaFetchOptions):
+            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
 
         availableTriviaSourcesMap: Dict[TriviaSource, TriviaQuestionRepositoryInterface] = dict()
         for triviaSource, triviaQuestionRepository in self.__triviaSourceToRepositoryMap.items():
@@ -310,7 +332,8 @@ class TriviaRepository(TriviaRepositoryInterface):
         self,
         triviaFetchOptions: TriviaFetchOptions
     ) -> Optional[AbsTriviaQuestion]:
-        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
+        if not isinstance(triviaFetchOptions, TriviaFetchOptions):
+            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
 
         if triviaFetchOptions.requireQuestionAnswerTriviaQuestion():
             if not self.__superTriviaQuestionSpool.empty():
@@ -446,8 +469,10 @@ class TriviaRepository(TriviaRepositoryInterface):
         question: Optional[AbsTriviaQuestion],
         triviaFetchOptions: TriviaFetchOptions
     ) -> bool:
-        assert question is None or isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
+        if question is not None and not isinstance(question, AbsTriviaQuestion):
+            raise TypeError(f'question argument is malformed: \"{question}\"')
+        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
+            raise TypeError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
 
         triviaContentCode = await self.__triviaVerifier.checkContent(
             question = question,
@@ -466,10 +491,12 @@ class TriviaRepository(TriviaRepositoryInterface):
         emote: str,
         triviaFetchOptions: TriviaFetchOptions
     ) -> bool:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(question, AbsTriviaQuestion):
+            raise TypeError(f'question argument is malformed: \"{question}\"')
+        elif not utils.isValidStr(emote):
             raise TypeError(f'emote argument is malformed: \"{emote}\"')
-        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
+        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
+            raise TypeError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
 
         triviaContentCode = await self.__triviaVerifier.checkHistory(
             question = question, 

--- a/src/CynanBot/trivia/triviaRepositories/willFryTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/willFryTriviaQuestionRepository.py
@@ -39,14 +39,10 @@ class WillFryTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
-            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__timber: TimberInterface = timber
@@ -54,8 +50,7 @@ class WillFryTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__triviaQuestionCompiler: TriviaQuestionCompilerInterface = triviaQuestionCompiler
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('WillFryTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/willFryTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/willFryTriviaQuestionRepository.py
@@ -39,10 +39,14 @@ class WillFryTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaIdGenerator, TriviaIdGeneratorInterface), f"malformed {triviaIdGenerator=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaIdGenerator, TriviaIdGeneratorInterface):
+            raise ValueError(f'triviaIdGenerator argument is malformed: \"{triviaIdGenerator}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__timber: TimberInterface = timber
@@ -50,7 +54,8 @@ class WillFryTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__triviaQuestionCompiler: TriviaQuestionCompilerInterface = triviaQuestionCompiler
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('WillFryTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/wwtbamTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/wwtbamTriviaQuestionRepository.py
@@ -32,11 +32,9 @@ class WwtbamTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
-            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
-        elif not utils.isValidStr(triviaDatabaseFile):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
+        if not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -46,8 +44,7 @@ class WwtbamTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        if not isinstance(fetchOptions, TriviaFetchOptions):
-            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
+        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
 
         self.__timber.log('WwtbamTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaRepositories/wwtbamTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/wwtbamTriviaQuestionRepository.py
@@ -32,9 +32,11 @@ class WwtbamTriviaQuestionRepository(AbsTriviaQuestionRepository):
     ):
         super().__init__(triviaSettingsRepository)
 
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface), f"malformed {triviaQuestionCompiler=}"
-        if not utils.isValidStr(triviaDatabaseFile):
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaQuestionCompiler, TriviaQuestionCompilerInterface):
+            raise ValueError(f'triviaQuestionCompiler argument is malformed: \"{triviaQuestionCompiler}\"')
+        elif not utils.isValidStr(triviaDatabaseFile):
             raise ValueError(f'triviaDatabaseFile argument is malformed: \"{triviaDatabaseFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -44,7 +46,8 @@ class WwtbamTriviaQuestionRepository(AbsTriviaQuestionRepository):
         self.__hasQuestionSetAvailable: Optional[bool] = None
 
     async def fetchTriviaQuestion(self, fetchOptions: TriviaFetchOptions) -> AbsTriviaQuestion:
-        assert isinstance(fetchOptions, TriviaFetchOptions), f"malformed {fetchOptions=}"
+        if not isinstance(fetchOptions, TriviaFetchOptions):
+            raise ValueError(f'fetchOptions argument is malformed: \"{fetchOptions}\"')
 
         self.__timber.log('WwtbamTriviaQuestionRepository', f'Fetching trivia question... (fetchOptions={fetchOptions})')
 

--- a/src/CynanBot/trivia/triviaSettingsRepository.py
+++ b/src/CynanBot/trivia/triviaSettingsRepository.py
@@ -10,8 +10,7 @@ from CynanBot.trivia.triviaSettingsRepositoryInterface import \
 class TriviaSettingsRepository(TriviaSettingsRepositoryInterface):
 
     def __init__(self, settingsJsonReader: JsonReaderInterface):
-        if not isinstance(settingsJsonReader, JsonReaderInterface):
-            raise TypeError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
+        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
 
@@ -82,7 +81,7 @@ class TriviaSettingsRepository(TriviaSettingsRepositoryInterface):
 
         if minMultipleChoiceResponses < 2 or minMultipleChoiceResponses > utils.getIntMaxSafeSize():
             raise ValueError(f'\"min_multiple_choice_responses\" is out of bounds: {minMultipleChoiceResponses}')
-        elif maxMultipleChoiceResponses < minMultipleChoiceResponses:
+        if maxMultipleChoiceResponses < minMultipleChoiceResponses:
             raise ValueError(f'\"min_multiple_choice_responses\" ({minMultipleChoiceResponses}) is less than \"max_multiple_choice_responses\" ({maxMultipleChoiceResponses})')
 
         return maxMultipleChoiceResponses
@@ -136,7 +135,7 @@ class TriviaSettingsRepository(TriviaSettingsRepositoryInterface):
 
         if minMultipleChoiceResponses < 2 or minMultipleChoiceResponses > utils.getIntMaxSafeSize():
             raise ValueError(f'\"min_multiple_choice_responses\" is out of bounds: {minMultipleChoiceResponses}')
-        elif maxMultipleChoiceResponses < minMultipleChoiceResponses:
+        if maxMultipleChoiceResponses < minMultipleChoiceResponses:
             raise ValueError(f'\"min_multiple_choice_responses\" ({minMultipleChoiceResponses}) is less than \"max_multiple_choice_responses\" ({maxMultipleChoiceResponses})')
 
         return minMultipleChoiceResponses

--- a/src/CynanBot/trivia/triviaSettingsRepository.py
+++ b/src/CynanBot/trivia/triviaSettingsRepository.py
@@ -10,7 +10,8 @@ from CynanBot.trivia.triviaSettingsRepositoryInterface import \
 class TriviaSettingsRepository(TriviaSettingsRepositoryInterface):
 
     def __init__(self, settingsJsonReader: JsonReaderInterface):
-        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
+        if not isinstance(settingsJsonReader, JsonReaderInterface):
+            raise TypeError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
 
@@ -81,7 +82,7 @@ class TriviaSettingsRepository(TriviaSettingsRepositoryInterface):
 
         if minMultipleChoiceResponses < 2 or minMultipleChoiceResponses > utils.getIntMaxSafeSize():
             raise ValueError(f'\"min_multiple_choice_responses\" is out of bounds: {minMultipleChoiceResponses}')
-        if maxMultipleChoiceResponses < minMultipleChoiceResponses:
+        elif maxMultipleChoiceResponses < minMultipleChoiceResponses:
             raise ValueError(f'\"min_multiple_choice_responses\" ({minMultipleChoiceResponses}) is less than \"max_multiple_choice_responses\" ({maxMultipleChoiceResponses})')
 
         return maxMultipleChoiceResponses
@@ -135,7 +136,7 @@ class TriviaSettingsRepository(TriviaSettingsRepositoryInterface):
 
         if minMultipleChoiceResponses < 2 or minMultipleChoiceResponses > utils.getIntMaxSafeSize():
             raise ValueError(f'\"min_multiple_choice_responses\" is out of bounds: {minMultipleChoiceResponses}')
-        if maxMultipleChoiceResponses < minMultipleChoiceResponses:
+        elif maxMultipleChoiceResponses < minMultipleChoiceResponses:
             raise ValueError(f'\"min_multiple_choice_responses\" ({minMultipleChoiceResponses}) is less than \"max_multiple_choice_responses\" ({maxMultipleChoiceResponses})')
 
         return minMultipleChoiceResponses

--- a/src/CynanBot/trivia/triviaSourceInstabilityHelper.py
+++ b/src/CynanBot/trivia/triviaSourceInstabilityHelper.py
@@ -14,12 +14,9 @@ class TriviaSourceInstabilityHelper():
         fallOffTimeDelta: timedelta = timedelta(minutes = 20),
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(fallOffTimeDelta, timedelta):
-            raise ValueError(f'fallOffTimeDelta argument is malformed: \"{fallOffTimeDelta}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(fallOffTimeDelta, timedelta), f"malformed {fallOffTimeDelta=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__timber: TimberInterface = timber
         self.__fallOffTimeDelta: timedelta = fallOffTimeDelta
@@ -29,8 +26,7 @@ class TriviaSourceInstabilityHelper():
         self.__values: Dict[TriviaSource, int] = defaultdict(lambda: 0)
 
     def __getitem__(self, key: TriviaSource) -> int:
-        if not isinstance(key, TriviaSource):
-            raise ValueError(f'key argument is malformed: \"{key}\"')
+        assert isinstance(key, TriviaSource), f"malformed {key=}"
 
         now = datetime.now(self.__timeZone)
         lastErrorTime = self.__times.get(key, None)
@@ -42,8 +38,7 @@ class TriviaSourceInstabilityHelper():
         return 0
 
     def incrementErrorCount(self, key: TriviaSource) -> int:
-        if not isinstance(key, TriviaSource):
-            raise ValueError(f'key argument is malformed: \"{key}\"')
+        assert isinstance(key, TriviaSource), f"malformed {key=}"
 
         now = datetime.now(self.__timeZone)
         lastErrorTime = self.__times.get(key, None)

--- a/src/CynanBot/trivia/triviaSourceInstabilityHelper.py
+++ b/src/CynanBot/trivia/triviaSourceInstabilityHelper.py
@@ -14,9 +14,12 @@ class TriviaSourceInstabilityHelper():
         fallOffTimeDelta: timedelta = timedelta(minutes = 20),
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(fallOffTimeDelta, timedelta), f"malformed {fallOffTimeDelta=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(fallOffTimeDelta, timedelta):
+            raise ValueError(f'fallOffTimeDelta argument is malformed: \"{fallOffTimeDelta}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__timber: TimberInterface = timber
         self.__fallOffTimeDelta: timedelta = fallOffTimeDelta
@@ -26,7 +29,8 @@ class TriviaSourceInstabilityHelper():
         self.__values: Dict[TriviaSource, int] = defaultdict(lambda: 0)
 
     def __getitem__(self, key: TriviaSource) -> int:
-        assert isinstance(key, TriviaSource), f"malformed {key=}"
+        if not isinstance(key, TriviaSource):
+            raise ValueError(f'key argument is malformed: \"{key}\"')
 
         now = datetime.now(self.__timeZone)
         lastErrorTime = self.__times.get(key, None)
@@ -38,7 +42,8 @@ class TriviaSourceInstabilityHelper():
         return 0
 
     def incrementErrorCount(self, key: TriviaSource) -> int:
-        assert isinstance(key, TriviaSource), f"malformed {key=}"
+        if not isinstance(key, TriviaSource):
+            raise ValueError(f'key argument is malformed: \"{key}\"')
 
         now = datetime.now(self.__timeZone)
         lastErrorTime = self.__times.get(key, None)

--- a/src/CynanBot/trivia/triviaUtils.py
+++ b/src/CynanBot/trivia/triviaUtils.py
@@ -52,22 +52,14 @@ class TriviaUtils(TriviaUtilsInterface):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface):
-            raise ValueError(f'bannedTriviaGameControllersRepository argument is malformed: \"{bannedTriviaGameControllersRepository}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface):
-            raise ValueError(f'triviaGameControllersRepository argument is malformed: \"{triviaGameControllersRepository}\"')
-        elif not isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface):
-            raise ValueError(f'triviaGameGlobalControllersRepository argument is malformed: \"{triviaGameGlobalControllersRepository}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface), f"malformed {bannedTriviaGameControllersRepository=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface), f"malformed {triviaGameControllersRepository=}"
+        assert isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface), f"malformed {triviaGameGlobalControllersRepository=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__bannedTriviaGameControllersRepository: BannedTriviaGameControllersRepositoryInterface = bannedTriviaGameControllersRepository
@@ -81,7 +73,7 @@ class TriviaUtils(TriviaUtilsInterface):
     async def getClearedSuperTriviaQueueMessage(self, numberOfGamesRemoved: int) -> str:
         if not utils.isValidInt(numberOfGamesRemoved):
             raise ValueError(f'numberOfGamesRemoved argument is malformed: \"{numberOfGamesRemoved}\"')
-        elif numberOfGamesRemoved < 0 or numberOfGamesRemoved > utils.getIntMaxSafeSize():
+        if numberOfGamesRemoved < 0 or numberOfGamesRemoved > utils.getIntMaxSafeSize():
             raise ValueError(f'numberOfGamesRemoved argument is out of bounds: {numberOfGamesRemoved}')
 
         numberOfGamesRemovedStr = locale.format_string("%d", numberOfGamesRemoved, grouping = True)
@@ -97,20 +89,15 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = '; '
     ) -> str:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif not isinstance(newCuteness, CutenessResult):
-            raise ValueError(f'newCuteness argument is malformed: \"{newCuteness}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        assert isinstance(newCuteness, CutenessResult), f"malformed {newCuteness=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(userNameThatRedeemed):
+        if not utils.isValidStr(userNameThatRedeemed):
             raise ValueError(f'userNameThatRedeemed argument is malformed: \"{userNameThatRedeemed}\"')
-        elif not isinstance(twitchUser, UserInterface):
-            raise ValueError(f'twitchUser argument is malformed: \"{twitchUser}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -140,16 +127,13 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = '; '
     ) -> str:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(userNameThatRedeemed):
+        if not utils.isValidStr(userNameThatRedeemed):
             raise ValueError(f'userNameThatRedeemed argument is malformed: \"{userNameThatRedeemed}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -173,14 +157,12 @@ class TriviaUtils(TriviaUtilsInterface):
         userNameThatRedeemed: str,
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None
     ) -> str:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(userNameThatRedeemed):
+        if not utils.isValidStr(userNameThatRedeemed):
             raise ValueError(f'userNameThatRedeemed argument is malformed: \"{userNameThatRedeemed}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -209,12 +191,9 @@ class TriviaUtils(TriviaUtilsInterface):
     ) -> str:
         if not utils.isValidStr(emotePrompt):
             raise ValueError(f'emotePrompt argument is malformed: \"{emotePrompt}\"')
-        elif not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
-            raise ValueError(f'toxicTriviaPunishmentResult argument is malformed: \"{toxicTriviaPunishmentResult}\"')
-        elif not isinstance(bucketDelimiter, str):
-            raise ValueError(f'bucketDelimiter argument is malformed: \"{bucketDelimiter}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult), f"malformed {toxicTriviaPunishmentResult=}"
+        assert isinstance(bucketDelimiter, str), f"malformed {bucketDelimiter=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         punishmentAmountToUserNames: Dict[int, List[str]] = defaultdict(lambda: list())
 
@@ -246,16 +225,13 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = '; '
     ) -> str:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(userNameThatRedeemed):
+        if not utils.isValidStr(userNameThatRedeemed):
             raise ValueError(f'userNameThatRedeemed argument is malformed: \"{userNameThatRedeemed}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -280,10 +256,8 @@ class TriviaUtils(TriviaUtilsInterface):
     ) -> str:
         if not utils.isValidStr(emotePrompt):
             raise ValueError(f'emotePrompt argument is malformed: \"{emotePrompt}\"')
-        elif not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
-            raise ValueError(f'toxicTriviaPunishmentResult argument is malformed: \"{toxicTriviaPunishmentResult}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult), f"malformed {toxicTriviaPunishmentResult=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         punishmentAmountToUserNames: Dict[int, List[str]] = defaultdict(lambda: list())
 
@@ -318,22 +292,17 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = '; '
     ) -> str:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif not isinstance(newCuteness, CutenessResult):
-            raise ValueError(f'newCuteness argument is malformed: \"{newCuteness}\"')
-        elif not utils.isValidInt(points):
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        assert isinstance(newCuteness, CutenessResult), f"malformed {newCuteness=}"
+        if not utils.isValidInt(points):
             raise ValueError(f'points argument is malformed: \"{points}\"')
-        elif not utils.isValidStr(emote):
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif not isinstance(twitchUser, UserInterface):
-            raise ValueError(f'twitchUser argument is malformed: \"{twitchUser}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -375,14 +344,11 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = '; '
     ) -> str:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -409,24 +375,20 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = ' '
     ) -> str:
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif not utils.isValidInt(delaySeconds):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        if not utils.isValidInt(delaySeconds):
             raise ValueError(f'delaySeconds argument is malformed: \"{delaySeconds}\"')
-        elif delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
+        if delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
             raise ValueError(f'delaySeconds argument is out of bounds: {delaySeconds}')
-        elif not utils.isValidInt(points):
+        if not utils.isValidInt(points):
             raise ValueError(f'points argument is malformed: \"{points}\"')
-        elif points < 1 or points > utils.getIntMaxSafeSize():
+        if points < 1 or points > utils.getIntMaxSafeSize():
             raise ValueError(f'points argument is out of bounds: {points}')
-        elif not utils.isValidStr(emote):
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not isinstance(twitchUser, UserInterface):
-            raise ValueError(f'twitchUser argument is malformed: \"{twitchUser}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -457,16 +419,12 @@ class TriviaUtils(TriviaUtilsInterface):
         bucketDelimiter: str = '; ',
         delimiter: str = ', '
     ) -> Optional[str]:
-        if toxicTriviaPunishmentResult is not None and not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
-            raise ValueError(f'toxicTriviaPunishmentResult argument is malformed: \"{toxicTriviaPunishmentResult}\"')
-        elif not utils.isValidStr(emote):
+        assert toxicTriviaPunishmentResult is None or isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult), f"malformed {toxicTriviaPunishmentResult=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not isinstance(twitchUser, UserInterface):
-            raise ValueError(f'twitchUser argument is malformed: \"{twitchUser}\"')
-        elif not isinstance(bucketDelimiter, str):
-            raise ValueError(f'bucketDelimiter argument is malformed: \"{bucketDelimiter}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
+        assert isinstance(bucketDelimiter, str), f"malformed {bucketDelimiter=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         if not twitchUser.isCutenessEnabled() or toxicTriviaPunishmentResult is None:
             return None
@@ -492,8 +450,7 @@ class TriviaUtils(TriviaUtilsInterface):
         bannedControllers: Optional[List[BannedTriviaGameController]],
         delimiter: str = ', '
     ) -> str:
-        if not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         if not utils.hasItems(bannedControllers):
             return f'ⓘ There are no banned trivia game controllers.'
@@ -510,8 +467,7 @@ class TriviaUtils(TriviaUtilsInterface):
         gameControllers: Optional[List[TriviaGameController]],
         delimiter: str = ', '
     ) -> str:
-        if not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         if not utils.hasItems(gameControllers):
             return f'ⓘ Your channel has no trivia game controllers.'
@@ -528,8 +484,7 @@ class TriviaUtils(TriviaUtilsInterface):
         gameControllers: Optional[List[TriviaGameGlobalController]],
         delimiter: str = ', '
     ) -> str:
-        if not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         if not utils.hasItems(gameControllers):
             return f'ⓘ There are no global trivia game controllers.'
@@ -552,26 +507,22 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = ' '
     ) -> str:
-        if not isinstance(triviaQuestion, AbsTriviaQuestion):
-            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
-        elif not utils.isValidInt(delaySeconds):
+        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
+        if not utils.isValidInt(delaySeconds):
             raise ValueError(f'delaySeconds argument is malformed: \"{delaySeconds}\"')
-        elif delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
+        if delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
             raise ValueError(f'delaySeconds argument is out of bounds: {delaySeconds}')
-        elif not utils.isValidInt(points):
+        if not utils.isValidInt(points):
             raise ValueError(f'points argument is malformed: \"{points}\"')
-        elif points < 1 or points > utils.getIntMaxSafeSize():
+        if points < 1 or points > utils.getIntMaxSafeSize():
             raise ValueError(f'points argument is out of bounds: {points}')
-        elif not utils.isValidStr(emote):
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not utils.isValidStr(userNameThatRedeemed):
+        if not utils.isValidStr(userNameThatRedeemed):
             raise ValueError(f'userNameThatRedeemed argument is malformed: \"{userNameThatRedeemed}\"')
-        elif not isinstance(twitchUser, UserInterface):
-            raise ValueError(f'twitchUser argument is malformed: \"{twitchUser}\"')
-        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
-            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
-        elif not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
+        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -601,14 +552,11 @@ class TriviaUtils(TriviaUtilsInterface):
         toxicResult: ToxicTriviaResult,
         triviaResult: TriviaScoreResult
     ) -> str:
-        if not isinstance(shinyResult, ShinyTriviaResult):
-            raise ValueError(f'shinyResult argument is malformed: \"{shinyResult}\"')
-        elif not utils.isValidStr(userName):
+        assert isinstance(shinyResult, ShinyTriviaResult), f"malformed {shinyResult=}"
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif not isinstance(toxicResult, ToxicTriviaResult):
-            raise ValueError(f'toxicResult argument is malformed: \"{toxicResult}\"')
-        elif not isinstance(triviaResult, TriviaScoreResult):
-            raise ValueError(f'triviaResult argument is malformed: \"{triviaResult}\"')
+        assert isinstance(toxicResult, ToxicTriviaResult), f"malformed {toxicResult=}"
+        assert isinstance(triviaResult, TriviaScoreResult), f"malformed {triviaResult=}"
 
         triviaStr = ''
         if triviaResult.getTotal() >= 1:
@@ -653,7 +601,7 @@ class TriviaUtils(TriviaUtilsInterface):
     async def isPrivilegedTriviaUser(self, twitchChannel: str, userId: str) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         twitchUser: Optional[UserInterface] = None

--- a/src/CynanBot/trivia/triviaUtils.py
+++ b/src/CynanBot/trivia/triviaUtils.py
@@ -52,14 +52,22 @@ class TriviaUtils(TriviaUtilsInterface):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface), f"malformed {bannedTriviaGameControllersRepository=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface), f"malformed {triviaGameControllersRepository=}"
-        assert isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface), f"malformed {triviaGameGlobalControllersRepository=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise ValueError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(bannedTriviaGameControllersRepository, BannedTriviaGameControllersRepositoryInterface):
+            raise ValueError(f'bannedTriviaGameControllersRepository argument is malformed: \"{bannedTriviaGameControllersRepository}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaGameControllersRepository, TriviaGameControllersRepositoryInterface):
+            raise ValueError(f'triviaGameControllersRepository argument is malformed: \"{triviaGameControllersRepository}\"')
+        elif not isinstance(triviaGameGlobalControllersRepository, TriviaGameGlobalControllersRepositoryInterface):
+            raise ValueError(f'triviaGameGlobalControllersRepository argument is malformed: \"{triviaGameGlobalControllersRepository}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__bannedTriviaGameControllersRepository: BannedTriviaGameControllersRepositoryInterface = bannedTriviaGameControllersRepository
@@ -73,7 +81,7 @@ class TriviaUtils(TriviaUtilsInterface):
     async def getClearedSuperTriviaQueueMessage(self, numberOfGamesRemoved: int) -> str:
         if not utils.isValidInt(numberOfGamesRemoved):
             raise ValueError(f'numberOfGamesRemoved argument is malformed: \"{numberOfGamesRemoved}\"')
-        if numberOfGamesRemoved < 0 or numberOfGamesRemoved > utils.getIntMaxSafeSize():
+        elif numberOfGamesRemoved < 0 or numberOfGamesRemoved > utils.getIntMaxSafeSize():
             raise ValueError(f'numberOfGamesRemoved argument is out of bounds: {numberOfGamesRemoved}')
 
         numberOfGamesRemovedStr = locale.format_string("%d", numberOfGamesRemoved, grouping = True)
@@ -89,15 +97,20 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = '; '
     ) -> str:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        assert isinstance(newCuteness, CutenessResult), f"malformed {newCuteness=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
+        elif not isinstance(newCuteness, CutenessResult):
+            raise ValueError(f'newCuteness argument is malformed: \"{newCuteness}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(userNameThatRedeemed):
+        elif not utils.isValidStr(userNameThatRedeemed):
             raise ValueError(f'userNameThatRedeemed argument is malformed: \"{userNameThatRedeemed}\"')
-        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif not isinstance(twitchUser, UserInterface):
+            raise ValueError(f'twitchUser argument is malformed: \"{twitchUser}\"')
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -127,13 +140,16 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = '; '
     ) -> str:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(userNameThatRedeemed):
+        elif not utils.isValidStr(userNameThatRedeemed):
             raise ValueError(f'userNameThatRedeemed argument is malformed: \"{userNameThatRedeemed}\"')
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -157,12 +173,14 @@ class TriviaUtils(TriviaUtilsInterface):
         userNameThatRedeemed: str,
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None
     ) -> str:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(userNameThatRedeemed):
+        elif not utils.isValidStr(userNameThatRedeemed):
             raise ValueError(f'userNameThatRedeemed argument is malformed: \"{userNameThatRedeemed}\"')
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -191,9 +209,12 @@ class TriviaUtils(TriviaUtilsInterface):
     ) -> str:
         if not utils.isValidStr(emotePrompt):
             raise ValueError(f'emotePrompt argument is malformed: \"{emotePrompt}\"')
-        assert isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult), f"malformed {toxicTriviaPunishmentResult=}"
-        assert isinstance(bucketDelimiter, str), f"malformed {bucketDelimiter=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
+            raise ValueError(f'toxicTriviaPunishmentResult argument is malformed: \"{toxicTriviaPunishmentResult}\"')
+        elif not isinstance(bucketDelimiter, str):
+            raise ValueError(f'bucketDelimiter argument is malformed: \"{bucketDelimiter}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         punishmentAmountToUserNames: Dict[int, List[str]] = defaultdict(lambda: list())
 
@@ -225,13 +246,16 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = '; '
     ) -> str:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(userNameThatRedeemed):
+        elif not utils.isValidStr(userNameThatRedeemed):
             raise ValueError(f'userNameThatRedeemed argument is malformed: \"{userNameThatRedeemed}\"')
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -256,8 +280,10 @@ class TriviaUtils(TriviaUtilsInterface):
     ) -> str:
         if not utils.isValidStr(emotePrompt):
             raise ValueError(f'emotePrompt argument is malformed: \"{emotePrompt}\"')
-        assert isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult), f"malformed {toxicTriviaPunishmentResult=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
+            raise ValueError(f'toxicTriviaPunishmentResult argument is malformed: \"{toxicTriviaPunishmentResult}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         punishmentAmountToUserNames: Dict[int, List[str]] = defaultdict(lambda: list())
 
@@ -292,17 +318,22 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = '; '
     ) -> str:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        assert isinstance(newCuteness, CutenessResult), f"malformed {newCuteness=}"
-        if not utils.isValidInt(points):
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
+        elif not isinstance(newCuteness, CutenessResult):
+            raise ValueError(f'newCuteness argument is malformed: \"{newCuteness}\"')
+        elif not utils.isValidInt(points):
             raise ValueError(f'points argument is malformed: \"{points}\"')
-        if not utils.isValidStr(emote):
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif not isinstance(twitchUser, UserInterface):
+            raise ValueError(f'twitchUser argument is malformed: \"{twitchUser}\"')
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -344,11 +375,14 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = '; '
     ) -> str:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -375,20 +409,24 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = ' '
     ) -> str:
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        if not utils.isValidInt(delaySeconds):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif not utils.isValidInt(delaySeconds):
             raise ValueError(f'delaySeconds argument is malformed: \"{delaySeconds}\"')
-        if delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
+        elif delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
             raise ValueError(f'delaySeconds argument is out of bounds: {delaySeconds}')
-        if not utils.isValidInt(points):
+        elif not utils.isValidInt(points):
             raise ValueError(f'points argument is malformed: \"{points}\"')
-        if points < 1 or points > utils.getIntMaxSafeSize():
+        elif points < 1 or points > utils.getIntMaxSafeSize():
             raise ValueError(f'points argument is out of bounds: {points}')
-        if not utils.isValidStr(emote):
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif not isinstance(twitchUser, UserInterface):
+            raise ValueError(f'twitchUser argument is malformed: \"{twitchUser}\"')
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -419,12 +457,16 @@ class TriviaUtils(TriviaUtilsInterface):
         bucketDelimiter: str = '; ',
         delimiter: str = ', '
     ) -> Optional[str]:
-        assert toxicTriviaPunishmentResult is None or isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult), f"malformed {toxicTriviaPunishmentResult=}"
-        if not utils.isValidStr(emote):
+        if toxicTriviaPunishmentResult is not None and not isinstance(toxicTriviaPunishmentResult, ToxicTriviaPunishmentResult):
+            raise ValueError(f'toxicTriviaPunishmentResult argument is malformed: \"{toxicTriviaPunishmentResult}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
-        assert isinstance(bucketDelimiter, str), f"malformed {bucketDelimiter=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif not isinstance(twitchUser, UserInterface):
+            raise ValueError(f'twitchUser argument is malformed: \"{twitchUser}\"')
+        elif not isinstance(bucketDelimiter, str):
+            raise ValueError(f'bucketDelimiter argument is malformed: \"{bucketDelimiter}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         if not twitchUser.isCutenessEnabled() or toxicTriviaPunishmentResult is None:
             return None
@@ -450,7 +492,8 @@ class TriviaUtils(TriviaUtilsInterface):
         bannedControllers: Optional[List[BannedTriviaGameController]],
         delimiter: str = ', '
     ) -> str:
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         if not utils.hasItems(bannedControllers):
             return f'ⓘ There are no banned trivia game controllers.'
@@ -467,7 +510,8 @@ class TriviaUtils(TriviaUtilsInterface):
         gameControllers: Optional[List[TriviaGameController]],
         delimiter: str = ', '
     ) -> str:
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         if not utils.hasItems(gameControllers):
             return f'ⓘ Your channel has no trivia game controllers.'
@@ -484,7 +528,8 @@ class TriviaUtils(TriviaUtilsInterface):
         gameControllers: Optional[List[TriviaGameGlobalController]],
         delimiter: str = ', '
     ) -> str:
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         if not utils.hasItems(gameControllers):
             return f'ⓘ There are no global trivia game controllers.'
@@ -507,22 +552,26 @@ class TriviaUtils(TriviaUtilsInterface):
         specialTriviaStatus: Optional[SpecialTriviaStatus] = None,
         delimiter: str = ' '
     ) -> str:
-        assert isinstance(triviaQuestion, AbsTriviaQuestion), f"malformed {triviaQuestion=}"
-        if not utils.isValidInt(delaySeconds):
+        if not isinstance(triviaQuestion, AbsTriviaQuestion):
+            raise ValueError(f'triviaQuestion argument is malformed: \"{triviaQuestion}\"')
+        elif not utils.isValidInt(delaySeconds):
             raise ValueError(f'delaySeconds argument is malformed: \"{delaySeconds}\"')
-        if delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
+        elif delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
             raise ValueError(f'delaySeconds argument is out of bounds: {delaySeconds}')
-        if not utils.isValidInt(points):
+        elif not utils.isValidInt(points):
             raise ValueError(f'points argument is malformed: \"{points}\"')
-        if points < 1 or points > utils.getIntMaxSafeSize():
+        elif points < 1 or points > utils.getIntMaxSafeSize():
             raise ValueError(f'points argument is out of bounds: {points}')
-        if not utils.isValidStr(emote):
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        if not utils.isValidStr(userNameThatRedeemed):
+        elif not utils.isValidStr(userNameThatRedeemed):
             raise ValueError(f'userNameThatRedeemed argument is malformed: \"{userNameThatRedeemed}\"')
-        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
-        assert specialTriviaStatus is None or isinstance(specialTriviaStatus, SpecialTriviaStatus), f"malformed {specialTriviaStatus=}"
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        elif not isinstance(twitchUser, UserInterface):
+            raise ValueError(f'twitchUser argument is malformed: \"{twitchUser}\"')
+        elif specialTriviaStatus is not None and not isinstance(specialTriviaStatus, SpecialTriviaStatus):
+            raise ValueError(f'specialTriviaStatus argument is malformed: \"{specialTriviaStatus}\"')
+        elif not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         emotePrompt = emote
         if specialTriviaStatus is SpecialTriviaStatus.SHINY:
@@ -552,11 +601,14 @@ class TriviaUtils(TriviaUtilsInterface):
         toxicResult: ToxicTriviaResult,
         triviaResult: TriviaScoreResult
     ) -> str:
-        assert isinstance(shinyResult, ShinyTriviaResult), f"malformed {shinyResult=}"
-        if not utils.isValidStr(userName):
+        if not isinstance(shinyResult, ShinyTriviaResult):
+            raise ValueError(f'shinyResult argument is malformed: \"{shinyResult}\"')
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert isinstance(toxicResult, ToxicTriviaResult), f"malformed {toxicResult=}"
-        assert isinstance(triviaResult, TriviaScoreResult), f"malformed {triviaResult=}"
+        elif not isinstance(toxicResult, ToxicTriviaResult):
+            raise ValueError(f'toxicResult argument is malformed: \"{toxicResult}\"')
+        elif not isinstance(triviaResult, TriviaScoreResult):
+            raise ValueError(f'triviaResult argument is malformed: \"{triviaResult}\"')
 
         triviaStr = ''
         if triviaResult.getTotal() >= 1:
@@ -601,7 +653,7 @@ class TriviaUtils(TriviaUtilsInterface):
     async def isPrivilegedTriviaUser(self, twitchChannel: str, userId: str) -> bool:
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         twitchUser: Optional[UserInterface] = None

--- a/src/CynanBot/trivia/triviaVerifier.py
+++ b/src/CynanBot/trivia/triviaVerifier.py
@@ -24,14 +24,10 @@ class TriviaVerifier(TriviaVerifierInterface):
         triviaContentScanner: TriviaContentScannerInterface,
         triviaHistoryRepository: TriviaHistoryRepositoryInterface
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(triviaBanHelper, TriviaBanHelperInterface):
-            raise ValueError(f'triviaBanHelper argument is malformed: \"{triviaBanHelper}\"')
-        elif not isinstance(triviaContentScanner, TriviaContentScannerInterface):
-            raise ValueError(f'triviaContentScanner argument is malformed: \"{triviaContentScanner}\"')
-        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
-            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(triviaBanHelper, TriviaBanHelperInterface), f"malformed {triviaBanHelper=}"
+        assert isinstance(triviaContentScanner, TriviaContentScannerInterface), f"malformed {triviaContentScanner=}"
+        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
 
         self.__timber: TimberInterface = timber
         self.__triviaBanHelper: TriviaBanHelperInterface = triviaBanHelper
@@ -46,10 +42,8 @@ class TriviaVerifier(TriviaVerifierInterface):
         if question is None:
             return TriviaContentCode.IS_NONE
 
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
-            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
 
         if not triviaFetchOptions.areQuestionAnswerTriviaQuestionsEnabled() and question.getTriviaType() is TriviaQuestionType.QUESTION_ANSWER:
             self.__timber.log('TriviaVerifier', f'The given TriviaType is illegal: {question.getTriviaType()} (triviaFetchOptions: {triviaFetchOptions})')
@@ -76,12 +70,10 @@ class TriviaVerifier(TriviaVerifierInterface):
         emote: str,
         triviaFetchOptions: TriviaFetchOptions
     ) -> TriviaContentCode:
-        if not isinstance(question, AbsTriviaQuestion):
-            raise ValueError(f'question argument is malformed: \"{question}\"')
-        elif not utils.isValidStr(emote):
+        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
+        if not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
-            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
+        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
 
         contentCode = await self.__triviaHistoryRepository.verify(
             question = question, 

--- a/src/CynanBot/trivia/triviaVerifier.py
+++ b/src/CynanBot/trivia/triviaVerifier.py
@@ -24,10 +24,14 @@ class TriviaVerifier(TriviaVerifierInterface):
         triviaContentScanner: TriviaContentScannerInterface,
         triviaHistoryRepository: TriviaHistoryRepositoryInterface
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(triviaBanHelper, TriviaBanHelperInterface), f"malformed {triviaBanHelper=}"
-        assert isinstance(triviaContentScanner, TriviaContentScannerInterface), f"malformed {triviaContentScanner=}"
-        assert isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface), f"malformed {triviaHistoryRepository=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(triviaBanHelper, TriviaBanHelperInterface):
+            raise ValueError(f'triviaBanHelper argument is malformed: \"{triviaBanHelper}\"')
+        elif not isinstance(triviaContentScanner, TriviaContentScannerInterface):
+            raise ValueError(f'triviaContentScanner argument is malformed: \"{triviaContentScanner}\"')
+        elif not isinstance(triviaHistoryRepository, TriviaHistoryRepositoryInterface):
+            raise ValueError(f'triviaHistoryRepository argument is malformed: \"{triviaHistoryRepository}\"')
 
         self.__timber: TimberInterface = timber
         self.__triviaBanHelper: TriviaBanHelperInterface = triviaBanHelper
@@ -42,8 +46,10 @@ class TriviaVerifier(TriviaVerifierInterface):
         if question is None:
             return TriviaContentCode.IS_NONE
 
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
+        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
+            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
 
         if not triviaFetchOptions.areQuestionAnswerTriviaQuestionsEnabled() and question.getTriviaType() is TriviaQuestionType.QUESTION_ANSWER:
             self.__timber.log('TriviaVerifier', f'The given TriviaType is illegal: {question.getTriviaType()} (triviaFetchOptions: {triviaFetchOptions})')
@@ -70,10 +76,12 @@ class TriviaVerifier(TriviaVerifierInterface):
         emote: str,
         triviaFetchOptions: TriviaFetchOptions
     ) -> TriviaContentCode:
-        assert isinstance(question, AbsTriviaQuestion), f"malformed {question=}"
-        if not utils.isValidStr(emote):
+        if not isinstance(question, AbsTriviaQuestion):
+            raise ValueError(f'question argument is malformed: \"{question}\"')
+        elif not utils.isValidStr(emote):
             raise ValueError(f'emote argument is malformed: \"{emote}\"')
-        assert isinstance(triviaFetchOptions, TriviaFetchOptions), f"malformed {triviaFetchOptions=}"
+        elif not isinstance(triviaFetchOptions, TriviaFetchOptions):
+            raise ValueError(f'triviaFetchOptions argument is malformed: \"{triviaFetchOptions}\"')
 
         contentCode = await self.__triviaHistoryRepository.verify(
             question = question, 

--- a/src/CynanBot/tts/decTalk/decTalkCommandBuilder.py
+++ b/src/CynanBot/tts/decTalk/decTalkCommandBuilder.py
@@ -28,14 +28,10 @@ class DecTalkCommandBuilder(TtsCommandBuilderInterface):
         timber: TimberInterface,
         ttsSettingsRepository: TtsSettingsRepositoryInterface
     ):
-        if not isinstance(contentScanner, ContentScannerInterface):
-            raise TypeError(f'contentScanner argument is malformed: \"{contentScanner}\"')
-        elif not isinstance(emojiHelper, EmojiHelperInterface):
-            raise TypeError(f'emojiHelper argument is malformed: \"{emojiHelper}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface):
-            raise TypeError(f'ttsSettingsRepository argument is malformed: \"{ttsSettingsRepository}\"')
+        assert isinstance(contentScanner, ContentScannerInterface), f"malformed {contentScanner=}"
+        assert isinstance(emojiHelper, EmojiHelperInterface), f"malformed {emojiHelper=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface), f"malformed {ttsSettingsRepository=}"
 
         self.__contentScanner: ContentScannerInterface = contentScanner
         self.__emojiHelper: EmojiHelperInterface = emojiHelper
@@ -48,8 +44,7 @@ class DecTalkCommandBuilder(TtsCommandBuilderInterface):
         self.__whiteSpaceRegEx: Pattern = re.compile(r'\s{2,}', re.IGNORECASE)
 
     async def buildAndCleanEvent(self, event: Optional[TtsEvent]) -> Optional[str]:
-        if event is not None and not isinstance(event, TtsEvent):
-            raise TypeError(f'event argument is malformed: \"{event}\"')
+        assert event is None or isinstance(event, TtsEvent), f"malformed {event=}"
 
         if event is None:
             return None
@@ -214,18 +209,15 @@ class DecTalkCommandBuilder(TtsCommandBuilderInterface):
         event: TtsEvent,
         donation: TtsCheerDonation
     ) -> Optional[str]:
-        if not isinstance(event, TtsEvent):
-            raise TypeError(f'event argument is malformed: \"{event}\"')
-        elif not isinstance(donation, TtsCheerDonation):
-            raise TypeError(f'donation argument is malformed: \"{donation}\"')
-        elif donation.getType() is not TtsDonationType.CHEER:
+        assert isinstance(event, TtsEvent), f"malformed {event=}"
+        assert isinstance(donation, TtsCheerDonation), f"malformed {donation=}"
+        if donation.getType() is not TtsDonationType.CHEER:
             raise TypeError(f'TtsDonationType is not {TtsDonationType.CHEER}: \"{donation.getType()}\" ({donation=})')
 
         return f'{event.getUserName()} cheered {donation.getBits()}!'
 
     async def __processDonationPrefix(self, event: TtsEvent) -> Optional[str]:
-        if not isinstance(event, TtsEvent):
-            raise TypeError(f'event argument is malformed: \"{event}\"')
+        assert isinstance(event, TtsEvent), f"malformed {event=}"
 
         donation: Optional[TtsDonation] = event.getDonation()
 
@@ -252,11 +244,9 @@ class DecTalkCommandBuilder(TtsCommandBuilderInterface):
         event: TtsEvent,
         donation: TtsSubscriptionDonation
     ) -> str:
-        if not isinstance(event, TtsEvent):
-            raise TypeError(f'event argument is malformed: \"{event}\"')
-        elif not isinstance(donation, TtsSubscriptionDonation):
-            raise TypeError(f'donation argument is malformed: \"{donation}\"')
-        elif donation.getType() is not TtsDonationType.SUBSCRIPTION:
+        assert isinstance(event, TtsEvent), f"malformed {event=}"
+        assert isinstance(donation, TtsSubscriptionDonation), f"malformed {donation=}"
+        if donation.getType() is not TtsDonationType.SUBSCRIPTION:
             raise TypeError(f'TtsDonationType is not {TtsDonationType.SUBSCRIPTION}: \"{donation.getType()}\" ({donation=})')
 
         # I don't think it makes sense for a subscription to be anonymous, and also not a gift?

--- a/src/CynanBot/tts/decTalk/decTalkCommandBuilder.py
+++ b/src/CynanBot/tts/decTalk/decTalkCommandBuilder.py
@@ -28,10 +28,14 @@ class DecTalkCommandBuilder(TtsCommandBuilderInterface):
         timber: TimberInterface,
         ttsSettingsRepository: TtsSettingsRepositoryInterface
     ):
-        assert isinstance(contentScanner, ContentScannerInterface), f"malformed {contentScanner=}"
-        assert isinstance(emojiHelper, EmojiHelperInterface), f"malformed {emojiHelper=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface), f"malformed {ttsSettingsRepository=}"
+        if not isinstance(contentScanner, ContentScannerInterface):
+            raise TypeError(f'contentScanner argument is malformed: \"{contentScanner}\"')
+        elif not isinstance(emojiHelper, EmojiHelperInterface):
+            raise TypeError(f'emojiHelper argument is malformed: \"{emojiHelper}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface):
+            raise TypeError(f'ttsSettingsRepository argument is malformed: \"{ttsSettingsRepository}\"')
 
         self.__contentScanner: ContentScannerInterface = contentScanner
         self.__emojiHelper: EmojiHelperInterface = emojiHelper
@@ -44,7 +48,8 @@ class DecTalkCommandBuilder(TtsCommandBuilderInterface):
         self.__whiteSpaceRegEx: Pattern = re.compile(r'\s{2,}', re.IGNORECASE)
 
     async def buildAndCleanEvent(self, event: Optional[TtsEvent]) -> Optional[str]:
-        assert event is None or isinstance(event, TtsEvent), f"malformed {event=}"
+        if event is not None and not isinstance(event, TtsEvent):
+            raise TypeError(f'event argument is malformed: \"{event}\"')
 
         if event is None:
             return None
@@ -209,15 +214,18 @@ class DecTalkCommandBuilder(TtsCommandBuilderInterface):
         event: TtsEvent,
         donation: TtsCheerDonation
     ) -> Optional[str]:
-        assert isinstance(event, TtsEvent), f"malformed {event=}"
-        assert isinstance(donation, TtsCheerDonation), f"malformed {donation=}"
-        if donation.getType() is not TtsDonationType.CHEER:
+        if not isinstance(event, TtsEvent):
+            raise TypeError(f'event argument is malformed: \"{event}\"')
+        elif not isinstance(donation, TtsCheerDonation):
+            raise TypeError(f'donation argument is malformed: \"{donation}\"')
+        elif donation.getType() is not TtsDonationType.CHEER:
             raise TypeError(f'TtsDonationType is not {TtsDonationType.CHEER}: \"{donation.getType()}\" ({donation=})')
 
         return f'{event.getUserName()} cheered {donation.getBits()}!'
 
     async def __processDonationPrefix(self, event: TtsEvent) -> Optional[str]:
-        assert isinstance(event, TtsEvent), f"malformed {event=}"
+        if not isinstance(event, TtsEvent):
+            raise TypeError(f'event argument is malformed: \"{event}\"')
 
         donation: Optional[TtsDonation] = event.getDonation()
 
@@ -244,9 +252,11 @@ class DecTalkCommandBuilder(TtsCommandBuilderInterface):
         event: TtsEvent,
         donation: TtsSubscriptionDonation
     ) -> str:
-        assert isinstance(event, TtsEvent), f"malformed {event=}"
-        assert isinstance(donation, TtsSubscriptionDonation), f"malformed {donation=}"
-        if donation.getType() is not TtsDonationType.SUBSCRIPTION:
+        if not isinstance(event, TtsEvent):
+            raise TypeError(f'event argument is malformed: \"{event}\"')
+        elif not isinstance(donation, TtsSubscriptionDonation):
+            raise TypeError(f'donation argument is malformed: \"{donation}\"')
+        elif donation.getType() is not TtsDonationType.SUBSCRIPTION:
             raise TypeError(f'TtsDonationType is not {TtsDonationType.SUBSCRIPTION}: \"{donation.getType()}\" ({donation=})')
 
         # I don't think it makes sense for a subscription to be anonymous, and also not a gift?

--- a/src/CynanBot/tts/decTalk/decTalkFileManager.py
+++ b/src/CynanBot/tts/decTalk/decTalkFileManager.py
@@ -23,11 +23,9 @@ class DecTalkFileManager(DecTalkFileManagerInterface):
         timber: TimberInterface,
         directory: str = 'temp'
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidStr(directory):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidStr(directory):
             raise ValueError(f'directory argument is malformed: \"{directory}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper

--- a/src/CynanBot/tts/decTalk/decTalkFileManager.py
+++ b/src/CynanBot/tts/decTalk/decTalkFileManager.py
@@ -23,9 +23,11 @@ class DecTalkFileManager(DecTalkFileManagerInterface):
         timber: TimberInterface,
         directory: str = 'temp'
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidStr(directory):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidStr(directory):
             raise ValueError(f'directory argument is malformed: \"{directory}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper

--- a/src/CynanBot/tts/decTalk/decTalkManager.py
+++ b/src/CynanBot/tts/decTalk/decTalkManager.py
@@ -27,14 +27,10 @@ class DecTalkManager(TtsManagerInterface):
         timber: TimberInterface,
         ttsSettingsRepository: TtsSettingsRepositoryInterface
     ):
-        if not isinstance(decTalkCommandBuilder, DecTalkCommandBuilder):
-            raise TypeError(f'decTalkCommandBuilder argument is malformed: \"{decTalkCommandBuilder}\"')
-        elif not isinstance(decTalkFileManager, DecTalkFileManagerInterface):
-            raise TypeError(f'decTalkFileManager argument is malformed: \"{decTalkFileManager}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface):
-            raise TypeError(f'ttsSettingsRepository argument is malformed: \"{ttsSettingsRepository}\"')
+        assert isinstance(decTalkCommandBuilder, DecTalkCommandBuilder), f"malformed {decTalkCommandBuilder=}"
+        assert isinstance(decTalkFileManager, DecTalkFileManagerInterface), f"malformed {decTalkFileManager=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface), f"malformed {ttsSettingsRepository=}"
 
         self.__decTalkFileManager: DecTalkFileManagerInterface = decTalkFileManager
         self.__timber: TimberInterface = timber
@@ -88,9 +84,8 @@ class DecTalkManager(TtsManagerInterface):
         if process is None:
             self.__timber.log('DecTalkManager', f'Went to kill the Dec Talk process, but the process is None: \"{process}\"')
             return
-        elif not isinstance(process, Process):
-            raise TypeError(f'process argument is malformed: \"{process}\"')
-        elif process.returncode is not None:
+        elassert isinstance(process, Process), f"malformed {process=}"
+        if process.returncode is not None:
             self.__timber.log('DecTalkManager', f'Went to kill the Dec Talk process, but the process (\"{process}\") has a return code: \"{process.returncode}\"')
             return
 
@@ -109,8 +104,7 @@ class DecTalkManager(TtsManagerInterface):
         return self.__isPlaying
 
     async def playTtsEvent(self, event: TtsEvent) -> bool:
-        if not isinstance(event, TtsEvent):
-            raise TypeError(f'event argument is malformed: \"{event}\"')
+        assert isinstance(event, TtsEvent), f"malformed {event=}"
 
         if not await self.__ttsSettingsRepository.isEnabled():
             return False

--- a/src/CynanBot/tts/decTalk/decTalkManager.py
+++ b/src/CynanBot/tts/decTalk/decTalkManager.py
@@ -27,10 +27,14 @@ class DecTalkManager(TtsManagerInterface):
         timber: TimberInterface,
         ttsSettingsRepository: TtsSettingsRepositoryInterface
     ):
-        assert isinstance(decTalkCommandBuilder, DecTalkCommandBuilder), f"malformed {decTalkCommandBuilder=}"
-        assert isinstance(decTalkFileManager, DecTalkFileManagerInterface), f"malformed {decTalkFileManager=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface), f"malformed {ttsSettingsRepository=}"
+        if not isinstance(decTalkCommandBuilder, DecTalkCommandBuilder):
+            raise TypeError(f'decTalkCommandBuilder argument is malformed: \"{decTalkCommandBuilder}\"')
+        elif not isinstance(decTalkFileManager, DecTalkFileManagerInterface):
+            raise TypeError(f'decTalkFileManager argument is malformed: \"{decTalkFileManager}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(ttsSettingsRepository, TtsSettingsRepositoryInterface):
+            raise TypeError(f'ttsSettingsRepository argument is malformed: \"{ttsSettingsRepository}\"')
 
         self.__decTalkFileManager: DecTalkFileManagerInterface = decTalkFileManager
         self.__timber: TimberInterface = timber
@@ -84,8 +88,9 @@ class DecTalkManager(TtsManagerInterface):
         if process is None:
             self.__timber.log('DecTalkManager', f'Went to kill the Dec Talk process, but the process is None: \"{process}\"')
             return
-        elassert isinstance(process, Process), f"malformed {process=}"
-        if process.returncode is not None:
+        elif not isinstance(process, Process):
+            raise TypeError(f'process argument is malformed: \"{process}\"')
+        elif process.returncode is not None:
             self.__timber.log('DecTalkManager', f'Went to kill the Dec Talk process, but the process (\"{process}\") has a return code: \"{process.returncode}\"')
             return
 
@@ -104,7 +109,8 @@ class DecTalkManager(TtsManagerInterface):
         return self.__isPlaying
 
     async def playTtsEvent(self, event: TtsEvent) -> bool:
-        assert isinstance(event, TtsEvent), f"malformed {event=}"
+        if not isinstance(event, TtsEvent):
+            raise TypeError(f'event argument is malformed: \"{event}\"')
 
         if not await self.__ttsSettingsRepository.isEnabled():
             return False

--- a/src/CynanBot/tts/ttsEvent.py
+++ b/src/CynanBot/tts/ttsEvent.py
@@ -18,20 +18,16 @@ class TtsEvent():
         provider: TtsProvider,
         raidInfo: Optional[TtsRaidInfo]
     ):
-        if message is not None and not isinstance(message, str):
-            raise TypeError(f'message argument is malformed: \"{message}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert message is None or isinstance(message, str), f"malformed {message=}"
+        if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
-        elif donation is not None and not isinstance(donation, TtsDonation):
-            raise TypeError(f'donation argument is malformed: \"{donation}\"')
-        elif not isinstance(provider, TtsProvider):
-            raise TypeError(f'provider argument is malformed: \"{provider}\"')
-        elif raidInfo is not None and not isinstance(raidInfo, TtsRaidInfo):
-            raise TypeError(f'raidInfo argument is malformed: \"{raidInfo}\"')
+        assert donation is None or isinstance(donation, TtsDonation), f"malformed {donation=}"
+        assert isinstance(provider, TtsProvider), f"malformed {provider=}"
+        assert raidInfo is None or isinstance(raidInfo, TtsRaidInfo), f"malformed {raidInfo=}"
 
         self.__message: Optional[str] = message
         self.__twitchChannel: str = twitchChannel

--- a/src/CynanBot/tts/ttsEvent.py
+++ b/src/CynanBot/tts/ttsEvent.py
@@ -18,16 +18,20 @@ class TtsEvent():
         provider: TtsProvider,
         raidInfo: Optional[TtsRaidInfo]
     ):
-        assert message is None or isinstance(message, str), f"malformed {message=}"
-        if not utils.isValidStr(twitchChannel):
+        if message is not None and not isinstance(message, str):
+            raise TypeError(f'message argument is malformed: \"{message}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
-        assert donation is None or isinstance(donation, TtsDonation), f"malformed {donation=}"
-        assert isinstance(provider, TtsProvider), f"malformed {provider=}"
-        assert raidInfo is None or isinstance(raidInfo, TtsRaidInfo), f"malformed {raidInfo=}"
+        elif donation is not None and not isinstance(donation, TtsDonation):
+            raise TypeError(f'donation argument is malformed: \"{donation}\"')
+        elif not isinstance(provider, TtsProvider):
+            raise TypeError(f'provider argument is malformed: \"{provider}\"')
+        elif raidInfo is not None and not isinstance(raidInfo, TtsRaidInfo):
+            raise TypeError(f'raidInfo argument is malformed: \"{raidInfo}\"')
 
         self.__message: Optional[str] = message
         self.__twitchChannel: str = twitchChannel

--- a/src/CynanBot/tts/ttsSettingsRepository.py
+++ b/src/CynanBot/tts/ttsSettingsRepository.py
@@ -9,8 +9,7 @@ from CynanBot.tts.ttsSettingsRepositoryInterface import \
 class TtsSettingsRepository(TtsSettingsRepositoryInterface):
 
     def __init__(self, settingsJsonReader: JsonReaderInterface):
-        if not isinstance(settingsJsonReader, JsonReaderInterface):
-            raise ValueError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
+        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
 

--- a/src/CynanBot/tts/ttsSettingsRepository.py
+++ b/src/CynanBot/tts/ttsSettingsRepository.py
@@ -9,7 +9,8 @@ from CynanBot.tts.ttsSettingsRepositoryInterface import \
 class TtsSettingsRepository(TtsSettingsRepositoryInterface):
 
     def __init__(self, settingsJsonReader: JsonReaderInterface):
-        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
+        if not isinstance(settingsJsonReader, JsonReaderInterface):
+            raise ValueError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
 
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
 

--- a/src/CynanBot/tts/ttsSubscriptionDonation.py
+++ b/src/CynanBot/tts/ttsSubscriptionDonation.py
@@ -18,10 +18,8 @@ class TtsSubscriptionDonation(TtsDonation):
     ):
         if not utils.isValidBool(isAnonymous):
             raise TypeError(f'isAnonymous argument is malformed: \"{isAnonymous}\"')
-        elif giftType is not None and not isinstance(giftType, TtsSubscriptionDonationGiftType):
-            raise TypeError(f'giftType argument is malformed: \"{giftType}\"')
-        elif not isinstance(tier, TwitchSubscriberTier):
-            raise TypeError(f'tier argument is malformed: \"{tier}\"')
+        assert giftType is None or isinstance(giftType, TtsSubscriptionDonationGiftType), f"malformed {giftType=}"
+        assert isinstance(tier, TwitchSubscriberTier), f"malformed {tier=}"
 
         self.__isAnonymous: bool = isAnonymous
         self.__giftType: Optional[TtsSubscriptionDonationGiftType] = giftType

--- a/src/CynanBot/tts/ttsSubscriptionDonation.py
+++ b/src/CynanBot/tts/ttsSubscriptionDonation.py
@@ -18,8 +18,10 @@ class TtsSubscriptionDonation(TtsDonation):
     ):
         if not utils.isValidBool(isAnonymous):
             raise TypeError(f'isAnonymous argument is malformed: \"{isAnonymous}\"')
-        assert giftType is None or isinstance(giftType, TtsSubscriptionDonationGiftType), f"malformed {giftType=}"
-        assert isinstance(tier, TwitchSubscriberTier), f"malformed {tier=}"
+        elif giftType is not None and not isinstance(giftType, TtsSubscriptionDonationGiftType):
+            raise TypeError(f'giftType argument is malformed: \"{giftType}\"')
+        elif not isinstance(tier, TwitchSubscriberTier):
+            raise TypeError(f'tier argument is malformed: \"{tier}\"')
 
         self.__isAnonymous: bool = isAnonymous
         self.__giftType: Optional[TtsSubscriptionDonationGiftType] = giftType

--- a/src/CynanBot/twitch/api/twitchApiService.py
+++ b/src/CynanBot/twitch/api/twitchApiService.py
@@ -69,16 +69,11 @@ class TwitchApiService(TwitchApiServiceInterface):
         twitchWebsocketJsonMapper: TwitchWebsocketJsonMapperInterface,
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchCredentialsProvider, TwitchCredentialsProviderInterface):
-            raise ValueError(f'twitchCredentialsProvider argument is malformed: \"{twitchCredentialsProvider}\"')
-        elif not isinstance(twitchWebsocketJsonMapper, TwitchWebsocketJsonMapperInterface):
-            raise ValueError(f'twitchWebsocketJsonMapper argument is malformed: \"{twitchWebsocketJsonMapper}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchCredentialsProvider, TwitchCredentialsProviderInterface), f"malformed {twitchCredentialsProvider=}"
+        assert isinstance(twitchWebsocketJsonMapper, TwitchWebsocketJsonMapperInterface), f"malformed {twitchWebsocketJsonMapper=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__timber: TimberInterface = timber
@@ -94,9 +89,9 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> bool:
         if not utils.isValidStr(broadcasterId):
             raise ValueError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        elif not utils.isValidStr(twitchAccessToken):
+        if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__timber.log('TwitchApiService', f'Adding moderator... ({broadcasterId=}) ({twitchAccessToken=}) ({userId=})')
@@ -135,8 +130,7 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> TwitchBanResponse:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not isinstance(banRequest, TwitchBanRequest):
-            raise ValueError(f'banRequest argument is malformed: \"{banRequest}\"')
+        assert isinstance(banRequest, TwitchBanRequest), f"malformed {banRequest=}"
 
         self.__timber.log('TwitchApiService', f'Banning user... ({twitchAccessToken=}) ({banRequest=})')
         clientSession = await self.__networkClientProvider.get()
@@ -166,7 +160,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when banning user ({banRequest=}) ({responseStatusCode=}) ({jsonResponse=})')
             raise GenericNetworkException(f'Encountered non-200 HTTP status code when banning user ({banRequest=}) ({responseStatusCode=}) ({jsonResponse=})')
-        elif not utils.hasItems(jsonResponse):
+        if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when banning user ({banRequest=}) ({jsonResponse=})')
             raise TwitchJsonException(f'Recieved a null/empty JSON response when banning user ({banRequest=}) ({jsonResponse=})')
 
@@ -205,8 +199,7 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> TwitchEventSubResponse:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not isinstance(eventSubRequest, TwitchEventSubRequest):
-            raise ValueError(f'eventSubRequest argument is malformed: \"{eventSubRequest}\"')
+        assert isinstance(eventSubRequest, TwitchEventSubRequest), f"malformed {eventSubRequest=}"
 
         self.__timber.log('TwitchApiService', f'Creating EventSub subscription... ({twitchAccessToken=}) ({eventSubRequest=})')
         twitchClientId = await self.__twitchCredentialsProvider.getTwitchClientId()
@@ -232,7 +225,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when creating EventSub subscription ({twitchAccessToken=}) ({eventSubRequest=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when creating EventSub subscription ({twitchAccessToken=}) ({eventSubRequest=}): {jsonResponse}')
-        elif responseStatusCode != 202:
+        if responseStatusCode != 202:
             self.__timber.log('TwitchApiService', f'Encountered non-202 HTTP status code ({responseStatusCode}) when creating EventSub subscription ({twitchAccessToken=}) ({eventSubRequest=}): {jsonResponse}')
             raise TwitchStatusCodeException(f'TwitchApiService encountered non-202 HTTP status code ({responseStatusCode}) when creating EventSub subscription ({twitchAccessToken=}) ({eventSubRequest=}): {jsonResponse}')
 
@@ -292,8 +285,7 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> TwitchBannedUsersResponse:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not isinstance(bannedUserRequest, TwitchBannedUserRequest):
-            raise ValueError(f'bannedUserRequest argument is malformed: \"{bannedUserRequest}\"')
+        assert isinstance(bannedUserRequest, TwitchBannedUserRequest), f"malformed {bannedUserRequest=}"
 
         self.__timber.log('TwitchApiService', f'Fetching banned users... {bannedUserRequest=}')
         twitchClientId = await self.__twitchCredentialsProvider.getTwitchClientId()
@@ -345,16 +337,13 @@ class TwitchApiService(TwitchApiServiceInterface):
         bannedUserRequest: TwitchBannedUserRequest,
         currentPagination: Optional[TwitchPaginationResponse]
     ) -> TwitchBannedUsersPageResponse:
-        if not isinstance(clientSession, NetworkHandle):
-            raise ValueError(f'clientSession argument is malformed: \"{clientSession}\"')
-        elif not utils.isValidStr(twitchAccessToken):
+        assert isinstance(clientSession, NetworkHandle), f"malformed {clientSession=}"
+        if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.isValidStr(twitchClientId):
+        if not utils.isValidStr(twitchClientId):
             raise ValueError(f'twitchClientId argument is malformed: \"{twitchClientId}\"')
-        elif not isinstance(bannedUserRequest, TwitchBannedUserRequest):
-            raise ValueError(f'bannedUserRequest argument is malformed: \"{bannedUserRequest}\"')
-        elif currentPagination is not None and not isinstance(currentPagination, TwitchPaginationResponse):
-            raise ValueError(f'currentPagination argument is malformed: \"{currentPagination}\"')
+        assert isinstance(bannedUserRequest, TwitchBannedUserRequest), f"malformed {bannedUserRequest=}"
+        assert currentPagination is None or isinstance(currentPagination, TwitchPaginationResponse), f"malformed {currentPagination=}"
 
         url = f'https://api.twitch.tv/helix/moderation/banned?broadcaster_id={bannedUserRequest.getBroadcasterId()}&first=100'
 
@@ -383,10 +372,10 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {jsonResponse}')
-        elif responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
+        if responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
             self.__timber.log('TwitchApiService', f'Received an error ({responseStatusCode}) when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {jsonResponse}')
             raise TwitchTokenIsExpiredException(f'TwitchApiService received an error ({responseStatusCode}) when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {jsonResponse}')
-        elif responseStatusCode != 200:
+        if responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {responseStatusCode}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {responseStatusCode}')
 
@@ -468,10 +457,10 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching emote details (broadcasterId=\"{broadcasterId}\"): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching emote details (broadcasterId=\"{broadcasterId}\"): {jsonResponse}')
-        elif responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
+        if responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
             self.__timber.log('TwitchApiService', f'Received an error ({responseStatusCode}) when fetching emote details (broadcasterId=\"{broadcasterId}\"): {jsonResponse}')
             raise TwitchTokenIsExpiredException(f'TwitchApiService received an error ({responseStatusCode}) when fetching emote details (broadcasterId=\"{broadcasterId}\"): {jsonResponse}')
-        elif responseStatusCode != 200:
+        if responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when fetching emote details (broadcasterId=\"{broadcasterId}\"): {responseStatusCode}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when fetching emote details (broadcasterId=\"{broadcasterId}\"): {responseStatusCode}')
 
@@ -515,9 +504,9 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> Optional[TwitchFollower]:
         if not utils.isValidStr(broadcasterId):
             raise TypeError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        elif not utils.isValidStr(twitchAccessToken):
+        if not utils.isValidStr(twitchAccessToken):
             raise TypeError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         self.__timber.log('TwitchApiService', f'Fetching follower... ({broadcasterId=}) ({twitchAccessToken=}) ({userId=})')
@@ -543,10 +532,10 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {jsonResponse}')
-        elif responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
+        if responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
             self.__timber.log('TwitchApiService', f'Received an error ({responseStatusCode}) when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {jsonResponse}')
             raise TwitchTokenIsExpiredException(f'TwitchApiService received an error ({responseStatusCode}) when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {jsonResponse}')
-        elif responseStatusCode != 200:
+        if responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {responseStatusCode}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {responseStatusCode}')
 
@@ -575,9 +564,9 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> List[TwitchLiveUserDetails]:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.areValidStrs(userNames):
+        if not utils.areValidStrs(userNames):
             raise ValueError(f'userNames argument is malformed: \"{userNames}\"')
-        elif len(userNames) > 100:
+        if len(userNames) > 100:
             raise ValueError(f'userNames argument has too many values (len is {len(userNames)}, max is 100): \"{userNames}\"')
 
         userNames.sort(key = lambda userName: userName.lower())
@@ -606,10 +595,10 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching live user details (userNames=\"{userNames}\"): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching live user details (userNames=\"{userNames}\"): {jsonResponse}')
-        elif responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
+        if responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
             self.__timber.log('TwitchApiService', f'Received an error ({responseStatusCode}) when fetching live user details (userNames=\"{userNames}\"): {jsonResponse}')
             raise TwitchTokenIsExpiredException(f'TwitchApiService received an error ({responseStatusCode}) when fetching live user details (userNames=\"{userNames}\"): {jsonResponse}')
-        elif responseStatusCode != 200:
+        if responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when fetching live user details (userNames=\"{userNames}\"): {responseStatusCode}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when fetching live user details (userNames=\"{userNames}\"): {responseStatusCode}')
 
@@ -646,9 +635,9 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> Optional[TwitchModUser]:
         if not utils.isValidStr(broadcasterId):
             raise ValueError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        elif not utils.isValidStr(twitchAccessToken):
+        if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         twitchClientId = await self.__twitchCredentialsProvider.getTwitchClientId()
@@ -673,10 +662,10 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching moderator ({broadcasterId=}) ({userId=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching moderator ({broadcasterId=}) ({userId=}): {jsonResponse}')
-        elif responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
+        if responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
             self.__timber.log('TwitchApiService', f'Received an error ({responseStatusCode}) when fetching moderator ({broadcasterId=}) ({userId=}): {jsonResponse}')
             raise TwitchTokenIsExpiredException(f'TwitchApiService received an error ({responseStatusCode}) when fetching moderator ({broadcasterId=}) ({userId=}): {jsonResponse}')
-        elif responseStatusCode != 200:
+        if responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when fetching moderator ({broadcasterId=}) ({userId=}): {responseStatusCode}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when fetching moderator ({broadcasterId=}) ({userId=}): {responseStatusCode}')
 
@@ -718,7 +707,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching tokens (code=\"{code}\"): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching tokens (code=\"{code}\"): {jsonResponse}')
-        elif 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
+        if 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
             self.__timber.log('TwitchApiService', f'Received an error of some kind when fetching tokens (code=\"{code}\"): {jsonResponse}')
             raise TwitchErrorException(f'TwitchApiService received an error of some kind when fetching tokens (code=\"{code}\"): {jsonResponse}')
 
@@ -749,7 +738,7 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> Optional[TwitchUserDetails]:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__timber.log('TwitchApiService', f'Fetching user details... ({userId=})')
@@ -779,7 +768,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching user details ({userId=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching user details ({userId=}): {jsonResponse}')
-        elif 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
+        if 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
             self.__timber.log('TwitchApiService', f'Received an error of some kind when fetching user details ({userId=}): {jsonResponse}')
             raise TwitchErrorException(f'TwitchApiService received an error of some kind when fetching user details ({userId=}): {jsonResponse}')
 
@@ -815,7 +804,7 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> Optional[TwitchUserDetails]:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         userName = userName.lower()
@@ -846,7 +835,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching user details (userName=\"{userName}\"): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching user details (userName=\"{userName}\"): {jsonResponse}')
-        elif 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
+        if 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
             self.__timber.log('TwitchApiService', f'Received an error of some kind when fetching user details (userName=\"{userName}\"): {jsonResponse}')
             raise TwitchErrorException(f'TwitchApiService received an error of some kind when fetching user details (userName=\"{userName}\"): {jsonResponse}')
 
@@ -883,9 +872,9 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> Optional[TwitchUserSubscriptionDetails]:
         if not utils.isValidStr(broadcasterId):
             raise ValueError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        elif not utils.isValidStr(twitchAccessToken):
+        if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__timber.log('TwitchApiService', f'Fetching user subscription details... (broadcasterId=\"{broadcasterId}\") (userId=\"{userId}\")')
@@ -915,7 +904,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching user subscription details (broadcasterId=\"{broadcasterId}\") (userId=\"{userId}\"): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching user subscription details (broadcasterId=\"{broadcasterId}\") (userId=\"{userId}\"): {jsonResponse}')
-        elif 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
+        if 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
             self.__timber.log('TwitchApiService', f'Received an error of some kind when fetching user subscription details (broadcasterId=\"{broadcasterId}\") (userId=\"{userId}\"): {jsonResponse}')
             raise TwitchErrorException(f'TwitchApiService received an error of some kind when fetching user subscription details (broadcasterId=\"{broadcasterId}\") (userId=\"{userId}\"): {jsonResponse}')
 
@@ -970,7 +959,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if response.getStatusCode() == 400:
             self.__timber.log('TwitchApiService', f'Encountered HTTP 400 status code when refreshing tokens ({twitchRefreshToken=}): {response.getStatusCode()}')
             raise TwitchPasswordChangedException(f'Encountered HTTP 400 status code when refreshing tokens ({twitchRefreshToken=}): {response.getStatusCode()}')
-        elif response.getStatusCode() != 200:
+        if response.getStatusCode() != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when refreshing tokens ({twitchRefreshToken=}): {response.getStatusCode()}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when refreshing tokens ({twitchRefreshToken=}): {response.getStatusCode()}')
 
@@ -980,7 +969,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when refreshing tokens ({twitchRefreshToken=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when refreshing tokens ({twitchRefreshToken=}): {jsonResponse}')
-        elif 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
+        if 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
             self.__timber.log('TwitchApiService', f'Received an error of some kind when refreshing tokens ({twitchRefreshToken=}): {jsonResponse}')
             raise TwitchErrorException(f'TwitchApiService received an error of some kind when refreshing tokens ({twitchRefreshToken=}): {jsonResponse}')
 
@@ -1011,8 +1000,7 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> bool:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not isinstance(unbanRequest, TwitchUnbanRequest):
-            raise ValueError(f'unbanRequest argument is malformed: \"{unbanRequest}\"')
+        assert isinstance(unbanRequest, TwitchUnbanRequest), f"malformed {unbanRequest=}"
 
         self.__timber.log('TwitchApiService', f'Unbanning user... ({twitchAccessToken=}) ({unbanRequest=})')
 

--- a/src/CynanBot/twitch/api/twitchApiService.py
+++ b/src/CynanBot/twitch/api/twitchApiService.py
@@ -69,11 +69,16 @@ class TwitchApiService(TwitchApiServiceInterface):
         twitchWebsocketJsonMapper: TwitchWebsocketJsonMapperInterface,
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchCredentialsProvider, TwitchCredentialsProviderInterface), f"malformed {twitchCredentialsProvider=}"
-        assert isinstance(twitchWebsocketJsonMapper, TwitchWebsocketJsonMapperInterface), f"malformed {twitchWebsocketJsonMapper=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        if not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchCredentialsProvider, TwitchCredentialsProviderInterface):
+            raise ValueError(f'twitchCredentialsProvider argument is malformed: \"{twitchCredentialsProvider}\"')
+        elif not isinstance(twitchWebsocketJsonMapper, TwitchWebsocketJsonMapperInterface):
+            raise ValueError(f'twitchWebsocketJsonMapper argument is malformed: \"{twitchWebsocketJsonMapper}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__timber: TimberInterface = timber
@@ -89,9 +94,9 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> bool:
         if not utils.isValidStr(broadcasterId):
             raise ValueError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        if not utils.isValidStr(twitchAccessToken):
+        elif not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__timber.log('TwitchApiService', f'Adding moderator... ({broadcasterId=}) ({twitchAccessToken=}) ({userId=})')
@@ -130,7 +135,8 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> TwitchBanResponse:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        assert isinstance(banRequest, TwitchBanRequest), f"malformed {banRequest=}"
+        elif not isinstance(banRequest, TwitchBanRequest):
+            raise ValueError(f'banRequest argument is malformed: \"{banRequest}\"')
 
         self.__timber.log('TwitchApiService', f'Banning user... ({twitchAccessToken=}) ({banRequest=})')
         clientSession = await self.__networkClientProvider.get()
@@ -160,7 +166,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when banning user ({banRequest=}) ({responseStatusCode=}) ({jsonResponse=})')
             raise GenericNetworkException(f'Encountered non-200 HTTP status code when banning user ({banRequest=}) ({responseStatusCode=}) ({jsonResponse=})')
-        if not utils.hasItems(jsonResponse):
+        elif not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when banning user ({banRequest=}) ({jsonResponse=})')
             raise TwitchJsonException(f'Recieved a null/empty JSON response when banning user ({banRequest=}) ({jsonResponse=})')
 
@@ -199,7 +205,8 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> TwitchEventSubResponse:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        assert isinstance(eventSubRequest, TwitchEventSubRequest), f"malformed {eventSubRequest=}"
+        elif not isinstance(eventSubRequest, TwitchEventSubRequest):
+            raise ValueError(f'eventSubRequest argument is malformed: \"{eventSubRequest}\"')
 
         self.__timber.log('TwitchApiService', f'Creating EventSub subscription... ({twitchAccessToken=}) ({eventSubRequest=})')
         twitchClientId = await self.__twitchCredentialsProvider.getTwitchClientId()
@@ -225,7 +232,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when creating EventSub subscription ({twitchAccessToken=}) ({eventSubRequest=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when creating EventSub subscription ({twitchAccessToken=}) ({eventSubRequest=}): {jsonResponse}')
-        if responseStatusCode != 202:
+        elif responseStatusCode != 202:
             self.__timber.log('TwitchApiService', f'Encountered non-202 HTTP status code ({responseStatusCode}) when creating EventSub subscription ({twitchAccessToken=}) ({eventSubRequest=}): {jsonResponse}')
             raise TwitchStatusCodeException(f'TwitchApiService encountered non-202 HTTP status code ({responseStatusCode}) when creating EventSub subscription ({twitchAccessToken=}) ({eventSubRequest=}): {jsonResponse}')
 
@@ -285,7 +292,8 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> TwitchBannedUsersResponse:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        assert isinstance(bannedUserRequest, TwitchBannedUserRequest), f"malformed {bannedUserRequest=}"
+        elif not isinstance(bannedUserRequest, TwitchBannedUserRequest):
+            raise ValueError(f'bannedUserRequest argument is malformed: \"{bannedUserRequest}\"')
 
         self.__timber.log('TwitchApiService', f'Fetching banned users... {bannedUserRequest=}')
         twitchClientId = await self.__twitchCredentialsProvider.getTwitchClientId()
@@ -337,13 +345,16 @@ class TwitchApiService(TwitchApiServiceInterface):
         bannedUserRequest: TwitchBannedUserRequest,
         currentPagination: Optional[TwitchPaginationResponse]
     ) -> TwitchBannedUsersPageResponse:
-        assert isinstance(clientSession, NetworkHandle), f"malformed {clientSession=}"
-        if not utils.isValidStr(twitchAccessToken):
+        if not isinstance(clientSession, NetworkHandle):
+            raise ValueError(f'clientSession argument is malformed: \"{clientSession}\"')
+        elif not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.isValidStr(twitchClientId):
+        elif not utils.isValidStr(twitchClientId):
             raise ValueError(f'twitchClientId argument is malformed: \"{twitchClientId}\"')
-        assert isinstance(bannedUserRequest, TwitchBannedUserRequest), f"malformed {bannedUserRequest=}"
-        assert currentPagination is None or isinstance(currentPagination, TwitchPaginationResponse), f"malformed {currentPagination=}"
+        elif not isinstance(bannedUserRequest, TwitchBannedUserRequest):
+            raise ValueError(f'bannedUserRequest argument is malformed: \"{bannedUserRequest}\"')
+        elif currentPagination is not None and not isinstance(currentPagination, TwitchPaginationResponse):
+            raise ValueError(f'currentPagination argument is malformed: \"{currentPagination}\"')
 
         url = f'https://api.twitch.tv/helix/moderation/banned?broadcaster_id={bannedUserRequest.getBroadcasterId()}&first=100'
 
@@ -372,10 +383,10 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {jsonResponse}')
-        if responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
+        elif responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
             self.__timber.log('TwitchApiService', f'Received an error ({responseStatusCode}) when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {jsonResponse}')
             raise TwitchTokenIsExpiredException(f'TwitchApiService received an error ({responseStatusCode}) when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {jsonResponse}')
-        if responseStatusCode != 200:
+        elif responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {responseStatusCode}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when fetching banned users ({twitchAccessToken=}) ({bannedUserRequest=}): {responseStatusCode}')
 
@@ -457,10 +468,10 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching emote details (broadcasterId=\"{broadcasterId}\"): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching emote details (broadcasterId=\"{broadcasterId}\"): {jsonResponse}')
-        if responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
+        elif responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
             self.__timber.log('TwitchApiService', f'Received an error ({responseStatusCode}) when fetching emote details (broadcasterId=\"{broadcasterId}\"): {jsonResponse}')
             raise TwitchTokenIsExpiredException(f'TwitchApiService received an error ({responseStatusCode}) when fetching emote details (broadcasterId=\"{broadcasterId}\"): {jsonResponse}')
-        if responseStatusCode != 200:
+        elif responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when fetching emote details (broadcasterId=\"{broadcasterId}\"): {responseStatusCode}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when fetching emote details (broadcasterId=\"{broadcasterId}\"): {responseStatusCode}')
 
@@ -504,9 +515,9 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> Optional[TwitchFollower]:
         if not utils.isValidStr(broadcasterId):
             raise TypeError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        if not utils.isValidStr(twitchAccessToken):
+        elif not utils.isValidStr(twitchAccessToken):
             raise TypeError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         self.__timber.log('TwitchApiService', f'Fetching follower... ({broadcasterId=}) ({twitchAccessToken=}) ({userId=})')
@@ -532,10 +543,10 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {jsonResponse}')
-        if responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
+        elif responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
             self.__timber.log('TwitchApiService', f'Received an error ({responseStatusCode}) when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {jsonResponse}')
             raise TwitchTokenIsExpiredException(f'TwitchApiService received an error ({responseStatusCode}) when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {jsonResponse}')
-        if responseStatusCode != 200:
+        elif responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {responseStatusCode}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when fetching follower ({broadcasterId=}) ({twitchAccessToken=}) ({userId=}): {responseStatusCode}')
 
@@ -564,9 +575,9 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> List[TwitchLiveUserDetails]:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.areValidStrs(userNames):
+        elif not utils.areValidStrs(userNames):
             raise ValueError(f'userNames argument is malformed: \"{userNames}\"')
-        if len(userNames) > 100:
+        elif len(userNames) > 100:
             raise ValueError(f'userNames argument has too many values (len is {len(userNames)}, max is 100): \"{userNames}\"')
 
         userNames.sort(key = lambda userName: userName.lower())
@@ -595,10 +606,10 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching live user details (userNames=\"{userNames}\"): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching live user details (userNames=\"{userNames}\"): {jsonResponse}')
-        if responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
+        elif responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
             self.__timber.log('TwitchApiService', f'Received an error ({responseStatusCode}) when fetching live user details (userNames=\"{userNames}\"): {jsonResponse}')
             raise TwitchTokenIsExpiredException(f'TwitchApiService received an error ({responseStatusCode}) when fetching live user details (userNames=\"{userNames}\"): {jsonResponse}')
-        if responseStatusCode != 200:
+        elif responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when fetching live user details (userNames=\"{userNames}\"): {responseStatusCode}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when fetching live user details (userNames=\"{userNames}\"): {responseStatusCode}')
 
@@ -635,9 +646,9 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> Optional[TwitchModUser]:
         if not utils.isValidStr(broadcasterId):
             raise ValueError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        if not utils.isValidStr(twitchAccessToken):
+        elif not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         twitchClientId = await self.__twitchCredentialsProvider.getTwitchClientId()
@@ -662,10 +673,10 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching moderator ({broadcasterId=}) ({userId=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching moderator ({broadcasterId=}) ({userId=}): {jsonResponse}')
-        if responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
+        elif responseStatusCode == 401 or ('error' in jsonResponse and len(jsonResponse['error']) >= 1):
             self.__timber.log('TwitchApiService', f'Received an error ({responseStatusCode}) when fetching moderator ({broadcasterId=}) ({userId=}): {jsonResponse}')
             raise TwitchTokenIsExpiredException(f'TwitchApiService received an error ({responseStatusCode}) when fetching moderator ({broadcasterId=}) ({userId=}): {jsonResponse}')
-        if responseStatusCode != 200:
+        elif responseStatusCode != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when fetching moderator ({broadcasterId=}) ({userId=}): {responseStatusCode}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when fetching moderator ({broadcasterId=}) ({userId=}): {responseStatusCode}')
 
@@ -707,7 +718,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching tokens (code=\"{code}\"): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching tokens (code=\"{code}\"): {jsonResponse}')
-        if 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
+        elif 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
             self.__timber.log('TwitchApiService', f'Received an error of some kind when fetching tokens (code=\"{code}\"): {jsonResponse}')
             raise TwitchErrorException(f'TwitchApiService received an error of some kind when fetching tokens (code=\"{code}\"): {jsonResponse}')
 
@@ -738,7 +749,7 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> Optional[TwitchUserDetails]:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__timber.log('TwitchApiService', f'Fetching user details... ({userId=})')
@@ -768,7 +779,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching user details ({userId=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching user details ({userId=}): {jsonResponse}')
-        if 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
+        elif 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
             self.__timber.log('TwitchApiService', f'Received an error of some kind when fetching user details ({userId=}): {jsonResponse}')
             raise TwitchErrorException(f'TwitchApiService received an error of some kind when fetching user details ({userId=}): {jsonResponse}')
 
@@ -804,7 +815,7 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> Optional[TwitchUserDetails]:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         userName = userName.lower()
@@ -835,7 +846,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching user details (userName=\"{userName}\"): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching user details (userName=\"{userName}\"): {jsonResponse}')
-        if 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
+        elif 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
             self.__timber.log('TwitchApiService', f'Received an error of some kind when fetching user details (userName=\"{userName}\"): {jsonResponse}')
             raise TwitchErrorException(f'TwitchApiService received an error of some kind when fetching user details (userName=\"{userName}\"): {jsonResponse}')
 
@@ -872,9 +883,9 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> Optional[TwitchUserSubscriptionDetails]:
         if not utils.isValidStr(broadcasterId):
             raise ValueError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        if not utils.isValidStr(twitchAccessToken):
+        elif not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
 
         self.__timber.log('TwitchApiService', f'Fetching user subscription details... (broadcasterId=\"{broadcasterId}\") (userId=\"{userId}\")')
@@ -904,7 +915,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when fetching user subscription details (broadcasterId=\"{broadcasterId}\") (userId=\"{userId}\"): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when fetching user subscription details (broadcasterId=\"{broadcasterId}\") (userId=\"{userId}\"): {jsonResponse}')
-        if 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
+        elif 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
             self.__timber.log('TwitchApiService', f'Received an error of some kind when fetching user subscription details (broadcasterId=\"{broadcasterId}\") (userId=\"{userId}\"): {jsonResponse}')
             raise TwitchErrorException(f'TwitchApiService received an error of some kind when fetching user subscription details (broadcasterId=\"{broadcasterId}\") (userId=\"{userId}\"): {jsonResponse}')
 
@@ -959,7 +970,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if response.getStatusCode() == 400:
             self.__timber.log('TwitchApiService', f'Encountered HTTP 400 status code when refreshing tokens ({twitchRefreshToken=}): {response.getStatusCode()}')
             raise TwitchPasswordChangedException(f'Encountered HTTP 400 status code when refreshing tokens ({twitchRefreshToken=}): {response.getStatusCode()}')
-        if response.getStatusCode() != 200:
+        elif response.getStatusCode() != 200:
             self.__timber.log('TwitchApiService', f'Encountered non-200 HTTP status code when refreshing tokens ({twitchRefreshToken=}): {response.getStatusCode()}')
             raise GenericNetworkException(f'TwitchApiService encountered non-200 HTTP status code when refreshing tokens ({twitchRefreshToken=}): {response.getStatusCode()}')
 
@@ -969,7 +980,7 @@ class TwitchApiService(TwitchApiServiceInterface):
         if not utils.hasItems(jsonResponse):
             self.__timber.log('TwitchApiService', f'Received a null/empty JSON response when refreshing tokens ({twitchRefreshToken=}): {jsonResponse}')
             raise TwitchJsonException(f'TwitchApiService received a null/empty JSON response when refreshing tokens ({twitchRefreshToken=}): {jsonResponse}')
-        if 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
+        elif 'error' in jsonResponse and len(jsonResponse['error']) >= 1:
             self.__timber.log('TwitchApiService', f'Received an error of some kind when refreshing tokens ({twitchRefreshToken=}): {jsonResponse}')
             raise TwitchErrorException(f'TwitchApiService received an error of some kind when refreshing tokens ({twitchRefreshToken=}): {jsonResponse}')
 
@@ -1000,7 +1011,8 @@ class TwitchApiService(TwitchApiServiceInterface):
     ) -> bool:
         if not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        assert isinstance(unbanRequest, TwitchUnbanRequest), f"malformed {unbanRequest=}"
+        elif not isinstance(unbanRequest, TwitchUnbanRequest):
+            raise ValueError(f'unbanRequest argument is malformed: \"{unbanRequest}\"')
 
         self.__timber.log('TwitchApiService', f'Unbanning user... ({twitchAccessToken=}) ({unbanRequest=})')
 

--- a/src/CynanBot/twitch/api/twitchBanRequest.py
+++ b/src/CynanBot/twitch/api/twitchBanRequest.py
@@ -18,17 +18,16 @@ class TwitchBanRequest():
     ):
         if duration is not None and not utils.isValidInt(duration):
             raise TypeError(f'duration argument is malformed: \"{duration}\"')
-        elif duration is not None and duration < 1:
+        if duration is not None and duration < 1:
             raise ValueError(f'duration argument is out of bounds: {duration}')
-        elif duration is not None and duration > 1209600:
+        if duration is not None and duration > 1209600:
             raise TimeoutDurationSecondsTooLongException(f'duration argument is out of bounds: {duration}')
-        elif not utils.isValidStr(broadcasterUserId):
+        if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif not utils.isValidStr(moderatorUserId):
+        if not utils.isValidStr(moderatorUserId):
             raise TypeError(f'moderatorUserId argument is malformed: \"{moderatorUserId}\"')
-        elif reason is not None and not isinstance(reason, str):
-            raise TypeError(f'reason argument is malformed: \"{reason}\"')
-        elif not utils.isValidStr(userIdToBan):
+        assert reason is None or isinstance(reason, str), f"malformed {reason=}"
+        if not utils.isValidStr(userIdToBan):
             raise TypeError(f'userIdToBan argument is malformed: \"{userIdToBan}\"')
 
         self.__duration: Optional[int] = duration

--- a/src/CynanBot/twitch/api/twitchBanRequest.py
+++ b/src/CynanBot/twitch/api/twitchBanRequest.py
@@ -18,16 +18,17 @@ class TwitchBanRequest():
     ):
         if duration is not None and not utils.isValidInt(duration):
             raise TypeError(f'duration argument is malformed: \"{duration}\"')
-        if duration is not None and duration < 1:
+        elif duration is not None and duration < 1:
             raise ValueError(f'duration argument is out of bounds: {duration}')
-        if duration is not None and duration > 1209600:
+        elif duration is not None and duration > 1209600:
             raise TimeoutDurationSecondsTooLongException(f'duration argument is out of bounds: {duration}')
-        if not utils.isValidStr(broadcasterUserId):
+        elif not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        if not utils.isValidStr(moderatorUserId):
+        elif not utils.isValidStr(moderatorUserId):
             raise TypeError(f'moderatorUserId argument is malformed: \"{moderatorUserId}\"')
-        assert reason is None or isinstance(reason, str), f"malformed {reason=}"
-        if not utils.isValidStr(userIdToBan):
+        elif reason is not None and not isinstance(reason, str):
+            raise TypeError(f'reason argument is malformed: \"{reason}\"')
+        elif not utils.isValidStr(userIdToBan):
             raise TypeError(f'userIdToBan argument is malformed: \"{userIdToBan}\"')
 
         self.__duration: Optional[int] = duration

--- a/src/CynanBot/twitch/api/twitchBanResponse.py
+++ b/src/CynanBot/twitch/api/twitchBanResponse.py
@@ -16,15 +16,13 @@ class TwitchBanResponse():
         moderatorUserId: str,
         userId: str
     ):
-        if not isinstance(createdAt, SimpleDateTime):
-            raise TypeError(f'createdAt argument is malformed: \"{createdAt}\"')
-        elif endTime is not None and not isinstance(endTime, SimpleDateTime):
-            raise TypeError(f'endTime argument is malformed: \"{endTime}\"')
-        elif not utils.isValidStr(broadcasterUserId):
+        assert isinstance(createdAt, SimpleDateTime), f"malformed {createdAt=}"
+        assert endTime is None or isinstance(endTime, SimpleDateTime), f"malformed {endTime=}"
+        if not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif not utils.isValidStr(moderatorUserId):
+        if not utils.isValidStr(moderatorUserId):
             raise TypeError(f'moderatorUserId argument is malformed: \"{moderatorUserId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         self.__createdAt: SimpleDateTime = createdAt

--- a/src/CynanBot/twitch/api/twitchBanResponse.py
+++ b/src/CynanBot/twitch/api/twitchBanResponse.py
@@ -16,13 +16,15 @@ class TwitchBanResponse():
         moderatorUserId: str,
         userId: str
     ):
-        assert isinstance(createdAt, SimpleDateTime), f"malformed {createdAt=}"
-        assert endTime is None or isinstance(endTime, SimpleDateTime), f"malformed {endTime=}"
-        if not utils.isValidStr(broadcasterUserId):
+        if not isinstance(createdAt, SimpleDateTime):
+            raise TypeError(f'createdAt argument is malformed: \"{createdAt}\"')
+        elif endTime is not None and not isinstance(endTime, SimpleDateTime):
+            raise TypeError(f'endTime argument is malformed: \"{endTime}\"')
+        elif not utils.isValidStr(broadcasterUserId):
             raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        if not utils.isValidStr(moderatorUserId):
+        elif not utils.isValidStr(moderatorUserId):
             raise TypeError(f'moderatorUserId argument is malformed: \"{moderatorUserId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         self.__createdAt: SimpleDateTime = createdAt

--- a/src/CynanBot/twitch/api/twitchBannedUser.py
+++ b/src/CynanBot/twitch/api/twitchBannedUser.py
@@ -18,23 +18,20 @@ class TwitchBannedUser():
         userLogin: str,
         userName: str
     ):
-        if not isinstance(createdAt, SimpleDateTime):
-            raise TypeError(f'createdAt argument is malformed: \"{createdAt}\"')
-        elif expiresAt is not None and not isinstance(expiresAt, SimpleDateTime):
-            raise TypeError(f'expiresAt argument is malformed: \"{expiresAt}\"')
-        elif not utils.isValidStr(moderatorId):
+        assert isinstance(createdAt, SimpleDateTime), f"malformed {createdAt=}"
+        assert expiresAt is None or isinstance(expiresAt, SimpleDateTime), f"malformed {expiresAt=}"
+        if not utils.isValidStr(moderatorId):
             raise TypeError(f'moderatorId argument is malformed: \"{moderatorId}\"')
-        elif not utils.isValidStr(moderatorLogin):
+        if not utils.isValidStr(moderatorLogin):
             raise TypeError(f'moderatorLogin argument is malformed: \"{moderatorLogin}\"')
-        elif not utils.isValidStr(moderatorName):
+        if not utils.isValidStr(moderatorName):
             raise TypeError(f'moderatorName argument is malformed: \"{moderatorName}\"')
-        elif reason is not None and not isinstance(reason, str):
-            raise TypeError(f'reason argument is malformed: \"{reason}\"')
-        elif not utils.isValidStr(userId):
+        assert reason is None or isinstance(reason, str), f"malformed {reason=}"
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userLogin):
+        if not utils.isValidStr(userLogin):
             raise TypeError(f'userLogin argument is malformed: \"{userLogin}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         self.__createdAt: SimpleDateTime = createdAt

--- a/src/CynanBot/twitch/api/twitchBannedUser.py
+++ b/src/CynanBot/twitch/api/twitchBannedUser.py
@@ -18,20 +18,23 @@ class TwitchBannedUser():
         userLogin: str,
         userName: str
     ):
-        assert isinstance(createdAt, SimpleDateTime), f"malformed {createdAt=}"
-        assert expiresAt is None or isinstance(expiresAt, SimpleDateTime), f"malformed {expiresAt=}"
-        if not utils.isValidStr(moderatorId):
+        if not isinstance(createdAt, SimpleDateTime):
+            raise TypeError(f'createdAt argument is malformed: \"{createdAt}\"')
+        elif expiresAt is not None and not isinstance(expiresAt, SimpleDateTime):
+            raise TypeError(f'expiresAt argument is malformed: \"{expiresAt}\"')
+        elif not utils.isValidStr(moderatorId):
             raise TypeError(f'moderatorId argument is malformed: \"{moderatorId}\"')
-        if not utils.isValidStr(moderatorLogin):
+        elif not utils.isValidStr(moderatorLogin):
             raise TypeError(f'moderatorLogin argument is malformed: \"{moderatorLogin}\"')
-        if not utils.isValidStr(moderatorName):
+        elif not utils.isValidStr(moderatorName):
             raise TypeError(f'moderatorName argument is malformed: \"{moderatorName}\"')
-        assert reason is None or isinstance(reason, str), f"malformed {reason=}"
-        if not utils.isValidStr(userId):
+        elif reason is not None and not isinstance(reason, str):
+            raise TypeError(f'reason argument is malformed: \"{reason}\"')
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userLogin):
+        elif not utils.isValidStr(userLogin):
             raise TypeError(f'userLogin argument is malformed: \"{userLogin}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         self.__createdAt: SimpleDateTime = createdAt

--- a/src/CynanBot/twitch/api/twitchBannedUserRequest.py
+++ b/src/CynanBot/twitch/api/twitchBannedUserRequest.py
@@ -12,8 +12,7 @@ class TwitchBannedUserRequest():
     ):
         if not utils.isValidStr(broadcasterId):
             raise TypeError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        elif requestedUserId is not None and not isinstance(requestedUserId, str):
-            raise TypeError(f'requestedUserId argument is malformed: \"{requestedUserId}\"')
+        assert requestedUserId is None or isinstance(requestedUserId, str), f"malformed {requestedUserId=}"
 
         self.__broadcasterId: str = broadcasterId
         self.__requestedUserId: Optional[str] = requestedUserId

--- a/src/CynanBot/twitch/api/twitchBannedUserRequest.py
+++ b/src/CynanBot/twitch/api/twitchBannedUserRequest.py
@@ -12,7 +12,8 @@ class TwitchBannedUserRequest():
     ):
         if not utils.isValidStr(broadcasterId):
             raise TypeError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        assert requestedUserId is None or isinstance(requestedUserId, str), f"malformed {requestedUserId=}"
+        elif requestedUserId is not None and not isinstance(requestedUserId, str):
+            raise TypeError(f'requestedUserId argument is malformed: \"{requestedUserId}\"')
 
         self.__broadcasterId: str = broadcasterId
         self.__requestedUserId: Optional[str] = requestedUserId

--- a/src/CynanBot/twitch/api/twitchBannedUsersPageResponse.py
+++ b/src/CynanBot/twitch/api/twitchBannedUsersPageResponse.py
@@ -11,10 +11,8 @@ class TwitchBannedUsersPageResponse():
         users: Optional[List[TwitchBannedUser]],
         pagination: Optional[TwitchPaginationResponse]
     ):
-        if users is not None and not isinstance(users, List):
-            raise TypeError(f'users argument is malformed: \"{users}\"')
-        elif pagination is not None and not isinstance(pagination, TwitchPaginationResponse):
-            raise TypeError(f'pagination argument is malformed: \"{pagination}\"')
+        assert users is None or isinstance(users, List), f"malformed {users=}"
+        assert pagination is None or isinstance(pagination, TwitchPaginationResponse), f"malformed {pagination=}"
 
         self.__users: Optional[List[TwitchBannedUser]] = users
         self.__pagination: Optional[TwitchPaginationResponse] = pagination

--- a/src/CynanBot/twitch/api/twitchBannedUsersPageResponse.py
+++ b/src/CynanBot/twitch/api/twitchBannedUsersPageResponse.py
@@ -11,8 +11,10 @@ class TwitchBannedUsersPageResponse():
         users: Optional[List[TwitchBannedUser]],
         pagination: Optional[TwitchPaginationResponse]
     ):
-        assert users is None or isinstance(users, List), f"malformed {users=}"
-        assert pagination is None or isinstance(pagination, TwitchPaginationResponse), f"malformed {pagination=}"
+        if users is not None and not isinstance(users, List):
+            raise TypeError(f'users argument is malformed: \"{users}\"')
+        elif pagination is not None and not isinstance(pagination, TwitchPaginationResponse):
+            raise TypeError(f'pagination argument is malformed: \"{pagination}\"')
 
         self.__users: Optional[List[TwitchBannedUser]] = users
         self.__pagination: Optional[TwitchPaginationResponse] = pagination

--- a/src/CynanBot/twitch/api/twitchBannedUsersResponse.py
+++ b/src/CynanBot/twitch/api/twitchBannedUsersResponse.py
@@ -12,12 +12,10 @@ class TwitchBannedUsersResponse():
         broadcasterId: str,
         requestedUserId: Optional[str]
     ):
-        if users is not None and not isinstance(users, List):
-            raise TypeError(f'users argument is malformed: \"{users}\"')
-        elif not utils.isValidStr(broadcasterId):
+        assert users is None or isinstance(users, List), f"malformed {users=}"
+        if not utils.isValidStr(broadcasterId):
             raise TypeError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        elif requestedUserId is not None and not isinstance(requestedUserId, str):
-            raise TypeError(f'requestedUserId argument is malformed: \"{requestedUserId}\"')
+        assert requestedUserId is None or isinstance(requestedUserId, str), f"malformed {requestedUserId=}"
 
         self.__users: Optional[List[TwitchBannedUser]] = users
         self.__broadcasterId: str = broadcasterId

--- a/src/CynanBot/twitch/api/twitchBannedUsersResponse.py
+++ b/src/CynanBot/twitch/api/twitchBannedUsersResponse.py
@@ -12,10 +12,12 @@ class TwitchBannedUsersResponse():
         broadcasterId: str,
         requestedUserId: Optional[str]
     ):
-        assert users is None or isinstance(users, List), f"malformed {users=}"
-        if not utils.isValidStr(broadcasterId):
+        if users is not None and not isinstance(users, List):
+            raise TypeError(f'users argument is malformed: \"{users}\"')
+        elif not utils.isValidStr(broadcasterId):
             raise TypeError(f'broadcasterId argument is malformed: \"{broadcasterId}\"')
-        assert requestedUserId is None or isinstance(requestedUserId, str), f"malformed {requestedUserId=}"
+        elif requestedUserId is not None and not isinstance(requestedUserId, str):
+            raise TypeError(f'requestedUserId argument is malformed: \"{requestedUserId}\"')
 
         self.__users: Optional[List[TwitchBannedUser]] = users
         self.__broadcasterId: str = broadcasterId

--- a/src/CynanBot/twitch/api/twitchCommunitySubGift.py
+++ b/src/CynanBot/twitch/api/twitchCommunitySubGift.py
@@ -15,12 +15,11 @@ class TwitchCommunitySubGift():
     ):
         if cumulativeTotal is not None and not utils.isValidInt(cumulativeTotal):
             raise TypeError(f'cumulativeTotal argument is malformed: \"{cumulativeTotal}\"')
-        elif not utils.isValidInt(total):
+        if not utils.isValidInt(total):
             raise TypeError(f'total argument is malformed: \"{total}\"')
-        elif not utils.isValidStr(communitySubGiftId):
+        if not utils.isValidStr(communitySubGiftId):
             raise TypeError(f'communitySubGiftId argument is malformed: \"{communitySubGiftId}\"')
-        elif not isinstance(subTier, TwitchSubscriberTier):
-            raise TypeError(f'subTier argument is malformed: \"{subTier}\"')
+        assert isinstance(subTier, TwitchSubscriberTier), f"malformed {subTier=}"
 
         self.__cumulativeTotal: Optional[int] = cumulativeTotal
         self.__total: int = total

--- a/src/CynanBot/twitch/api/twitchCommunitySubGift.py
+++ b/src/CynanBot/twitch/api/twitchCommunitySubGift.py
@@ -15,11 +15,12 @@ class TwitchCommunitySubGift():
     ):
         if cumulativeTotal is not None and not utils.isValidInt(cumulativeTotal):
             raise TypeError(f'cumulativeTotal argument is malformed: \"{cumulativeTotal}\"')
-        if not utils.isValidInt(total):
+        elif not utils.isValidInt(total):
             raise TypeError(f'total argument is malformed: \"{total}\"')
-        if not utils.isValidStr(communitySubGiftId):
+        elif not utils.isValidStr(communitySubGiftId):
             raise TypeError(f'communitySubGiftId argument is malformed: \"{communitySubGiftId}\"')
-        assert isinstance(subTier, TwitchSubscriberTier), f"malformed {subTier=}"
+        elif not isinstance(subTier, TwitchSubscriberTier):
+            raise TypeError(f'subTier argument is malformed: \"{subTier}\"')
 
         self.__cumulativeTotal: Optional[int] = cumulativeTotal
         self.__total: int = total

--- a/src/CynanBot/twitch/api/twitchEmoteDetails.py
+++ b/src/CynanBot/twitch/api/twitchEmoteDetails.py
@@ -19,14 +19,12 @@ class TwitchEmoteDetails():
     ):
         if not utils.hasItems(emoteImages):
             raise ValueError(f'emoteImages argument is malformed: \"{emoteImages}\"')
-        elif not utils.isValidStr(emoteId):
+        if not utils.isValidStr(emoteId):
             raise ValueError(f'emoteId argument is malformed: \"{emoteId}\"')
-        elif not utils.isValidStr(emoteName):
+        if not utils.isValidStr(emoteName):
             raise ValueError(f'emoteName argument is malformed: \"{emoteName}\"')
-        elif not isinstance(emoteType, TwitchEmoteType):
-            raise ValueError(f'emoteType argument is malformed: \"{emoteType}\"')
-        elif not isinstance(subscriberTier, TwitchSubscriberTier):
-            raise ValueError(f'subscriberTier argument is malformed: \"{subscriberTier}\"')
+        assert isinstance(emoteType, TwitchEmoteType), f"malformed {emoteType=}"
+        assert isinstance(subscriberTier, TwitchSubscriberTier), f"malformed {subscriberTier=}"
 
         self.__emoteImages: List[TwitchEmoteImage] = emoteImages
         self.__emoteId: str = emoteId
@@ -35,8 +33,7 @@ class TwitchEmoteDetails():
         self.__subscriberTier: TwitchSubscriberTier = subscriberTier
 
     def getEmote(self, imageScale: TwitchEmoteImageScale) -> Optional[TwitchEmoteImage]:
-        if not isinstance(imageScale, TwitchEmoteImageScale):
-            raise ValueError(f'imageScale argument is malformed: \"{imageScale}\"')
+        assert isinstance(imageScale, TwitchEmoteImageScale), f"malformed {imageScale=}"
 
         for emoteImage in self.__emoteImages:
             if emoteImage.getImageScale() is imageScale:

--- a/src/CynanBot/twitch/api/twitchEmoteDetails.py
+++ b/src/CynanBot/twitch/api/twitchEmoteDetails.py
@@ -19,12 +19,14 @@ class TwitchEmoteDetails():
     ):
         if not utils.hasItems(emoteImages):
             raise ValueError(f'emoteImages argument is malformed: \"{emoteImages}\"')
-        if not utils.isValidStr(emoteId):
+        elif not utils.isValidStr(emoteId):
             raise ValueError(f'emoteId argument is malformed: \"{emoteId}\"')
-        if not utils.isValidStr(emoteName):
+        elif not utils.isValidStr(emoteName):
             raise ValueError(f'emoteName argument is malformed: \"{emoteName}\"')
-        assert isinstance(emoteType, TwitchEmoteType), f"malformed {emoteType=}"
-        assert isinstance(subscriberTier, TwitchSubscriberTier), f"malformed {subscriberTier=}"
+        elif not isinstance(emoteType, TwitchEmoteType):
+            raise ValueError(f'emoteType argument is malformed: \"{emoteType}\"')
+        elif not isinstance(subscriberTier, TwitchSubscriberTier):
+            raise ValueError(f'subscriberTier argument is malformed: \"{subscriberTier}\"')
 
         self.__emoteImages: List[TwitchEmoteImage] = emoteImages
         self.__emoteId: str = emoteId
@@ -33,7 +35,8 @@ class TwitchEmoteDetails():
         self.__subscriberTier: TwitchSubscriberTier = subscriberTier
 
     def getEmote(self, imageScale: TwitchEmoteImageScale) -> Optional[TwitchEmoteImage]:
-        assert isinstance(imageScale, TwitchEmoteImageScale), f"malformed {imageScale=}"
+        if not isinstance(imageScale, TwitchEmoteImageScale):
+            raise ValueError(f'imageScale argument is malformed: \"{imageScale}\"')
 
         for emoteImage in self.__emoteImages:
             if emoteImage.getImageScale() is imageScale:

--- a/src/CynanBot/twitch/api/twitchEmoteImage.py
+++ b/src/CynanBot/twitch/api/twitchEmoteImage.py
@@ -7,8 +7,7 @@ class TwitchEmoteImage():
     def __init__(self, url: str, imageScale: TwitchEmoteImageScale):
         if not utils.isValidUrl(url):
             raise ValueError(f'url argument is malformed: \"{url}\"')
-        elif not isinstance(imageScale, TwitchEmoteImageScale):
-            raise ValueError(f'imageScale argument is malformed: \"{imageScale}\"')
+        assert isinstance(imageScale, TwitchEmoteImageScale), f"malformed {imageScale=}"
 
         self.__url: str = url
         self.__imageScale: TwitchEmoteImageScale = imageScale

--- a/src/CynanBot/twitch/api/twitchEmoteImage.py
+++ b/src/CynanBot/twitch/api/twitchEmoteImage.py
@@ -7,7 +7,8 @@ class TwitchEmoteImage():
     def __init__(self, url: str, imageScale: TwitchEmoteImageScale):
         if not utils.isValidUrl(url):
             raise ValueError(f'url argument is malformed: \"{url}\"')
-        assert isinstance(imageScale, TwitchEmoteImageScale), f"malformed {imageScale=}"
+        elif not isinstance(imageScale, TwitchEmoteImageScale):
+            raise ValueError(f'imageScale argument is malformed: \"{imageScale}\"')
 
         self.__url: str = url
         self.__imageScale: TwitchEmoteImageScale = imageScale

--- a/src/CynanBot/twitch/api/twitchEventSubRequest.py
+++ b/src/CynanBot/twitch/api/twitchEventSubRequest.py
@@ -19,12 +19,9 @@ class TwitchEventSubRequest():
         subscriptionType: TwitchWebsocketSubscriptionType,
         transport: TwitchWebsocketTransport
     ):
-        if not isinstance(condition, TwitchWebsocketCondition):
-            raise ValueError(f'condition argument is malformed: \"{condition}\"')
-        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise ValueError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
-        elif not isinstance(transport, TwitchWebsocketTransport):
-            raise ValueError(f'transport argument is malformed: \"{transport}\"')
+        assert isinstance(condition, TwitchWebsocketCondition), f"malformed {condition=}"
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        assert isinstance(transport, TwitchWebsocketTransport), f"malformed {transport=}"
 
         self.__condition: TwitchWebsocketCondition = condition
         self.__subscriptionType: TwitchWebsocketSubscriptionType = subscriptionType

--- a/src/CynanBot/twitch/api/twitchEventSubRequest.py
+++ b/src/CynanBot/twitch/api/twitchEventSubRequest.py
@@ -19,9 +19,12 @@ class TwitchEventSubRequest():
         subscriptionType: TwitchWebsocketSubscriptionType,
         transport: TwitchWebsocketTransport
     ):
-        assert isinstance(condition, TwitchWebsocketCondition), f"malformed {condition=}"
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
-        assert isinstance(transport, TwitchWebsocketTransport), f"malformed {transport=}"
+        if not isinstance(condition, TwitchWebsocketCondition):
+            raise ValueError(f'condition argument is malformed: \"{condition}\"')
+        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise ValueError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        elif not isinstance(transport, TwitchWebsocketTransport):
+            raise ValueError(f'transport argument is malformed: \"{transport}\"')
 
         self.__condition: TwitchWebsocketCondition = condition
         self.__subscriptionType: TwitchWebsocketSubscriptionType = subscriptionType

--- a/src/CynanBot/twitch/api/twitchEventSubResponse.py
+++ b/src/CynanBot/twitch/api/twitchEventSubResponse.py
@@ -28,26 +28,21 @@ class TwitchEventSubResponse():
     ):
         if not utils.isValidInt(cost):
             raise ValueError(f'cost argument is malformed: \"{cost}\"')
-        elif not utils.isValidInt(maxTotalCost):
+        if not utils.isValidInt(maxTotalCost):
             raise ValueError(f'maxTotalCost argument is malformed: \"{maxTotalCost}\"')
-        elif not utils.isValidInt(total):
+        if not utils.isValidInt(total):
             raise ValueError(f'total argument is malformed: \"{total}\"')
-        elif not utils.isValidInt(totalCost):
+        if not utils.isValidInt(totalCost):
             raise ValueError(f'totalCost argument is malformed: \"{totalCost}\"')
-        elif not isinstance(createdAt, SimpleDateTime):
-            raise ValueError(f'createdAt argument is malformed: \"{createdAt}\"')
-        elif not utils.isValidStr(subscriptionId):
+        assert isinstance(createdAt, SimpleDateTime), f"malformed {createdAt=}"
+        if not utils.isValidStr(subscriptionId):
             raise ValueError(f'subscriptionId argument is malformed: \"{subscriptionId}\"')
-        elif not utils.isValidStr(version):
+        if not utils.isValidStr(version):
             raise ValueError(f'version argument is malformed: \"{version}\"')
-        elif not isinstance(condition, TwitchWebsocketCondition):
-            raise ValueError(f'condition argument is malformed: \"{condition}\"')
-        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise ValueError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
-        elif not isinstance(status, TwitchWebsocketConnectionStatus):
-            raise ValueError(f'status argument is malformed: \"{status}\"')
-        elif not isinstance(transport, TwitchWebsocketTransport):
-            raise ValueError(f'transport argument is malformed: \"{transport}\"')
+        assert isinstance(condition, TwitchWebsocketCondition), f"malformed {condition=}"
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        assert isinstance(status, TwitchWebsocketConnectionStatus), f"malformed {status=}"
+        assert isinstance(transport, TwitchWebsocketTransport), f"malformed {transport=}"
 
         self.__cost: int = cost
         self.__maxTotalCost: int = maxTotalCost

--- a/src/CynanBot/twitch/api/twitchEventSubResponse.py
+++ b/src/CynanBot/twitch/api/twitchEventSubResponse.py
@@ -28,21 +28,26 @@ class TwitchEventSubResponse():
     ):
         if not utils.isValidInt(cost):
             raise ValueError(f'cost argument is malformed: \"{cost}\"')
-        if not utils.isValidInt(maxTotalCost):
+        elif not utils.isValidInt(maxTotalCost):
             raise ValueError(f'maxTotalCost argument is malformed: \"{maxTotalCost}\"')
-        if not utils.isValidInt(total):
+        elif not utils.isValidInt(total):
             raise ValueError(f'total argument is malformed: \"{total}\"')
-        if not utils.isValidInt(totalCost):
+        elif not utils.isValidInt(totalCost):
             raise ValueError(f'totalCost argument is malformed: \"{totalCost}\"')
-        assert isinstance(createdAt, SimpleDateTime), f"malformed {createdAt=}"
-        if not utils.isValidStr(subscriptionId):
+        elif not isinstance(createdAt, SimpleDateTime):
+            raise ValueError(f'createdAt argument is malformed: \"{createdAt}\"')
+        elif not utils.isValidStr(subscriptionId):
             raise ValueError(f'subscriptionId argument is malformed: \"{subscriptionId}\"')
-        if not utils.isValidStr(version):
+        elif not utils.isValidStr(version):
             raise ValueError(f'version argument is malformed: \"{version}\"')
-        assert isinstance(condition, TwitchWebsocketCondition), f"malformed {condition=}"
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
-        assert isinstance(status, TwitchWebsocketConnectionStatus), f"malformed {status=}"
-        assert isinstance(transport, TwitchWebsocketTransport), f"malformed {transport=}"
+        elif not isinstance(condition, TwitchWebsocketCondition):
+            raise ValueError(f'condition argument is malformed: \"{condition}\"')
+        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise ValueError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        elif not isinstance(status, TwitchWebsocketConnectionStatus):
+            raise ValueError(f'status argument is malformed: \"{status}\"')
+        elif not isinstance(transport, TwitchWebsocketTransport):
+            raise ValueError(f'transport argument is malformed: \"{transport}\"')
 
         self.__cost: int = cost
         self.__maxTotalCost: int = maxTotalCost

--- a/src/CynanBot/twitch/api/twitchFollower.py
+++ b/src/CynanBot/twitch/api/twitchFollower.py
@@ -13,13 +13,12 @@ class TwitchFollower():
         userLogin: str,
         userName: str
     ):
-        if not isinstance(followedAt, SimpleDateTime):
-            raise TypeError(f'followedAt argument is malformed: \"{followedAt}\"')
-        elif not utils.isValidStr(userId):
+        assert isinstance(followedAt, SimpleDateTime), f"malformed {followedAt=}"
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userLogin):
+        if not utils.isValidStr(userLogin):
             raise TypeError(f'userLogin argument is malformed: \"{userLogin}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         self.__followedAt: SimpleDateTime = followedAt

--- a/src/CynanBot/twitch/api/twitchFollower.py
+++ b/src/CynanBot/twitch/api/twitchFollower.py
@@ -13,12 +13,13 @@ class TwitchFollower():
         userLogin: str,
         userName: str
     ):
-        assert isinstance(followedAt, SimpleDateTime), f"malformed {followedAt=}"
-        if not utils.isValidStr(userId):
+        if not isinstance(followedAt, SimpleDateTime):
+            raise TypeError(f'followedAt argument is malformed: \"{followedAt}\"')
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userLogin):
+        elif not utils.isValidStr(userLogin):
             raise TypeError(f'userLogin argument is malformed: \"{userLogin}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         self.__followedAt: SimpleDateTime = followedAt

--- a/src/CynanBot/twitch/api/twitchLiveUserDetails.py
+++ b/src/CynanBot/twitch/api/twitchLiveUserDetails.py
@@ -24,30 +24,24 @@ class TwitchLiveUserDetails():
     ):
         if not utils.isValidBool(isMature):
             raise ValueError(f'isMature argument is malformed: \"{isMature}\"')
-        elif not utils.isValidInt(viewerCount):
+        if not utils.isValidInt(viewerCount):
             raise ValueError(f'viewerCount argument is malformed: \"{viewerCount}\"')
-        elif viewerCount < 0 or viewerCount > utils.getIntMaxSafeSize():
+        if viewerCount < 0 or viewerCount > utils.getIntMaxSafeSize():
             raise ValueError(f'viewerCount argument is out of bounds: {viewerCount}')
-        elif not utils.isValidStr(streamId):
+        if not utils.isValidStr(streamId):
             raise ValueError(f'streamId argument is malformed: \"{streamId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userLogin):
+        if not utils.isValidStr(userLogin):
             raise ValueError(f'userLogin argument is malformed: \"{userLogin}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif gameId is not None and not isinstance(gameId, str):
-            raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
-        elif gameName is not None and not isinstance(gameName, str):
-            raise ValueError(f'gameName argument is malformed: \"{gameName}\"')
-        elif language is not None and not isinstance(language, str):
-            raise ValueError(f'language argument is malformed: \"{language}\"')
-        elif thumbnailUrl is not None and not isinstance(thumbnailUrl, str):
-            raise ValueError(f'thumbnailUrl argument is malformed: \"{thumbnailUrl}\"')
-        elif title is not None and not isinstance(title, str):
-            raise ValueError(f'title argument is malformed: \"{title}\"')
-        elif not isinstance(streamType, TwitchStreamType):
-            raise ValueError(f'streamType argument is malformed: \"{streamType}\"')
+        assert gameId is None or isinstance(gameId, str), f"malformed {gameId=}"
+        assert gameName is None or isinstance(gameName, str), f"malformed {gameName=}"
+        assert language is None or isinstance(language, str), f"malformed {language=}"
+        assert thumbnailUrl is None or isinstance(thumbnailUrl, str), f"malformed {thumbnailUrl=}"
+        assert title is None or isinstance(title, str), f"malformed {title=}"
+        assert isinstance(streamType, TwitchStreamType), f"malformed {streamType=}"
 
         self.__isMature: bool = isMature
         self.__viewerCount: int = viewerCount

--- a/src/CynanBot/twitch/api/twitchLiveUserDetails.py
+++ b/src/CynanBot/twitch/api/twitchLiveUserDetails.py
@@ -24,24 +24,30 @@ class TwitchLiveUserDetails():
     ):
         if not utils.isValidBool(isMature):
             raise ValueError(f'isMature argument is malformed: \"{isMature}\"')
-        if not utils.isValidInt(viewerCount):
+        elif not utils.isValidInt(viewerCount):
             raise ValueError(f'viewerCount argument is malformed: \"{viewerCount}\"')
-        if viewerCount < 0 or viewerCount > utils.getIntMaxSafeSize():
+        elif viewerCount < 0 or viewerCount > utils.getIntMaxSafeSize():
             raise ValueError(f'viewerCount argument is out of bounds: {viewerCount}')
-        if not utils.isValidStr(streamId):
+        elif not utils.isValidStr(streamId):
             raise ValueError(f'streamId argument is malformed: \"{streamId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userLogin):
+        elif not utils.isValidStr(userLogin):
             raise ValueError(f'userLogin argument is malformed: \"{userLogin}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert gameId is None or isinstance(gameId, str), f"malformed {gameId=}"
-        assert gameName is None or isinstance(gameName, str), f"malformed {gameName=}"
-        assert language is None or isinstance(language, str), f"malformed {language=}"
-        assert thumbnailUrl is None or isinstance(thumbnailUrl, str), f"malformed {thumbnailUrl=}"
-        assert title is None or isinstance(title, str), f"malformed {title=}"
-        assert isinstance(streamType, TwitchStreamType), f"malformed {streamType=}"
+        elif gameId is not None and not isinstance(gameId, str):
+            raise ValueError(f'gameId argument is malformed: \"{gameId}\"')
+        elif gameName is not None and not isinstance(gameName, str):
+            raise ValueError(f'gameName argument is malformed: \"{gameName}\"')
+        elif language is not None and not isinstance(language, str):
+            raise ValueError(f'language argument is malformed: \"{language}\"')
+        elif thumbnailUrl is not None and not isinstance(thumbnailUrl, str):
+            raise ValueError(f'thumbnailUrl argument is malformed: \"{thumbnailUrl}\"')
+        elif title is not None and not isinstance(title, str):
+            raise ValueError(f'title argument is malformed: \"{title}\"')
+        elif not isinstance(streamType, TwitchStreamType):
+            raise ValueError(f'streamType argument is malformed: \"{streamType}\"')
 
         self.__isMature: bool = isMature
         self.__viewerCount: int = viewerCount

--- a/src/CynanBot/twitch/api/twitchOutcome.py
+++ b/src/CynanBot/twitch/api/twitchOutcome.py
@@ -18,20 +18,18 @@ class TwitchOutcome():
     ):
         if not utils.isValidInt(channelPoints):
             raise TypeError(f'channelPoints argument is malformed: \"{channelPoints}\"')
-        elif channelPoints < 0 or channelPoints > utils.getLongMaxSafeSize():
+        if channelPoints < 0 or channelPoints > utils.getLongMaxSafeSize():
             raise ValueError(f'channelPoints argument is out of bounds: {channelPoints}')
-        elif not utils.isValidInt(users):
+        if not utils.isValidInt(users):
             raise TypeError(f'users argument is malformed: \"{users}\"')
-        elif users < 0 or users > utils.getIntMaxSafeSize():
+        if users < 0 or users > utils.getIntMaxSafeSize():
             raise ValueError(f'users argument is out of bounds: {users}')
-        elif not utils.isValidStr(outcomeId):
+        if not utils.isValidStr(outcomeId):
             raise TypeError(f'outcomeId argument is malformed: \"{outcomeId}\"')
-        elif not utils.isValidStr(title):
+        if not utils.isValidStr(title):
             raise TypeError(f'title argument is malformed: \"{title}\"')
-        elif not isinstance(color, TwitchOutcomeColor):
-            raise TypeError(f'color argument is malformed: \"{color}\"')
-        elif topPredictors is not None and not isinstance(topPredictors, List):
-            raise TypeError(f'topPredictors argument is malformed: \"{topPredictors}\"')
+        assert isinstance(color, TwitchOutcomeColor), f"malformed {color=}"
+        assert topPredictors is None or isinstance(topPredictors, List), f"malformed {topPredictors=}"
 
         self.__channelPoints: int = channelPoints
         self.__users: int = users

--- a/src/CynanBot/twitch/api/twitchOutcome.py
+++ b/src/CynanBot/twitch/api/twitchOutcome.py
@@ -18,18 +18,20 @@ class TwitchOutcome():
     ):
         if not utils.isValidInt(channelPoints):
             raise TypeError(f'channelPoints argument is malformed: \"{channelPoints}\"')
-        if channelPoints < 0 or channelPoints > utils.getLongMaxSafeSize():
+        elif channelPoints < 0 or channelPoints > utils.getLongMaxSafeSize():
             raise ValueError(f'channelPoints argument is out of bounds: {channelPoints}')
-        if not utils.isValidInt(users):
+        elif not utils.isValidInt(users):
             raise TypeError(f'users argument is malformed: \"{users}\"')
-        if users < 0 or users > utils.getIntMaxSafeSize():
+        elif users < 0 or users > utils.getIntMaxSafeSize():
             raise ValueError(f'users argument is out of bounds: {users}')
-        if not utils.isValidStr(outcomeId):
+        elif not utils.isValidStr(outcomeId):
             raise TypeError(f'outcomeId argument is malformed: \"{outcomeId}\"')
-        if not utils.isValidStr(title):
+        elif not utils.isValidStr(title):
             raise TypeError(f'title argument is malformed: \"{title}\"')
-        assert isinstance(color, TwitchOutcomeColor), f"malformed {color=}"
-        assert topPredictors is None or isinstance(topPredictors, List), f"malformed {topPredictors=}"
+        elif not isinstance(color, TwitchOutcomeColor):
+            raise TypeError(f'color argument is malformed: \"{color}\"')
+        elif topPredictors is not None and not isinstance(topPredictors, List):
+            raise TypeError(f'topPredictors argument is malformed: \"{topPredictors}\"')
 
         self.__channelPoints: int = channelPoints
         self.__users: int = users

--- a/src/CynanBot/twitch/api/twitchReward.py
+++ b/src/CynanBot/twitch/api/twitchReward.py
@@ -14,11 +14,10 @@ class TwitchReward():
     ):
         if not utils.isValidInt(cost):
             raise TypeError(f'cost argument is malformed: \"{cost}\"')
-        elif prompt is not None and not isinstance(prompt, str):
-            raise TypeError(f'prompt argument is malformed: \"{prompt}\"')
-        elif not utils.isValidStr(rewardId):
+        assert prompt is None or isinstance(prompt, str), f"malformed {prompt=}"
+        if not utils.isValidStr(rewardId):
             raise TypeError(f'rewardId argument is malformed: \"{rewardId}\"')
-        elif not utils.isValidStr(title):
+        if not utils.isValidStr(title):
             raise TypeError(f'title argument is malformed: \"{title}\"')
 
         self.__cost: int = cost

--- a/src/CynanBot/twitch/api/twitchReward.py
+++ b/src/CynanBot/twitch/api/twitchReward.py
@@ -14,10 +14,11 @@ class TwitchReward():
     ):
         if not utils.isValidInt(cost):
             raise TypeError(f'cost argument is malformed: \"{cost}\"')
-        assert prompt is None or isinstance(prompt, str), f"malformed {prompt=}"
-        if not utils.isValidStr(rewardId):
+        elif prompt is not None and not isinstance(prompt, str):
+            raise TypeError(f'prompt argument is malformed: \"{prompt}\"')
+        elif not utils.isValidStr(rewardId):
             raise TypeError(f'rewardId argument is malformed: \"{rewardId}\"')
-        if not utils.isValidStr(title):
+        elif not utils.isValidStr(title):
             raise TypeError(f'title argument is malformed: \"{title}\"')
 
         self.__cost: int = cost

--- a/src/CynanBot/twitch/api/twitchSubGift.py
+++ b/src/CynanBot/twitch/api/twitchSubGift.py
@@ -18,22 +18,20 @@ class TwitchSubGift():
     ):
         if cumulativeTotal is not None and not utils.isValidInt(cumulativeTotal):
             raise TypeError(f'cumulativeTotal argument is malformed: \"{cumulativeTotal}\"')
-        elif cumulativeTotal is not None and (cumulativeTotal < 1 or cumulativeTotal > utils.getIntMaxSafeSize()):
+        if cumulativeTotal is not None and (cumulativeTotal < 1 or cumulativeTotal > utils.getIntMaxSafeSize()):
             raise TypeError(f'cumulativeTotal argument is out of bounds: {cumulativeTotal}')
-        elif not utils.isValidInt(durationMonths):
+        if not utils.isValidInt(durationMonths):
             raise TypeError(f'durationMonths argument is malformed: \"{durationMonths}\"')
-        elif durationMonths < 1 or durationMonths > utils.getIntMaxSafeSize():
+        if durationMonths < 1 or durationMonths > utils.getIntMaxSafeSize():
             raise ValueError(f'durationMonths argument is out of boudns: {durationMonths}')
-        elif communityGiftId is not None and not isinstance(communityGiftId, str):
-            raise TypeError(f'communityGiftId argument is malformed: \"{communityGiftId}\"')
-        elif not utils.isValidStr(recipientUserId):
+        assert communityGiftId is None or isinstance(communityGiftId, str), f"malformed {communityGiftId=}"
+        if not utils.isValidStr(recipientUserId):
             raise TypeError(f'recipientUserId argument is malformed: \"{recipientUserId}\"')
-        elif not utils.isValidStr(recipientUserLogin):
+        if not utils.isValidStr(recipientUserLogin):
             raise TypeError(f'recipientUserLogin argument is malformed: \"{recipientUserLogin}\"')
-        elif not utils.isValidStr(recipientUserName):
+        if not utils.isValidStr(recipientUserName):
             raise TypeError(f'recipientUserName argument is malformed: \"{recipientUserName}\"')
-        elif not isinstance(subTier, TwitchSubscriberTier):
-            raise TypeError(f'subTier argument is malformed: \"{subTier}\"')
+        assert isinstance(subTier, TwitchSubscriberTier), f"malformed {subTier=}"
 
         self.__cumulativeTotal: Optional[int] = cumulativeTotal
         self.__durationMonths: int = durationMonths

--- a/src/CynanBot/twitch/api/twitchSubGift.py
+++ b/src/CynanBot/twitch/api/twitchSubGift.py
@@ -18,20 +18,22 @@ class TwitchSubGift():
     ):
         if cumulativeTotal is not None and not utils.isValidInt(cumulativeTotal):
             raise TypeError(f'cumulativeTotal argument is malformed: \"{cumulativeTotal}\"')
-        if cumulativeTotal is not None and (cumulativeTotal < 1 or cumulativeTotal > utils.getIntMaxSafeSize()):
+        elif cumulativeTotal is not None and (cumulativeTotal < 1 or cumulativeTotal > utils.getIntMaxSafeSize()):
             raise TypeError(f'cumulativeTotal argument is out of bounds: {cumulativeTotal}')
-        if not utils.isValidInt(durationMonths):
+        elif not utils.isValidInt(durationMonths):
             raise TypeError(f'durationMonths argument is malformed: \"{durationMonths}\"')
-        if durationMonths < 1 or durationMonths > utils.getIntMaxSafeSize():
+        elif durationMonths < 1 or durationMonths > utils.getIntMaxSafeSize():
             raise ValueError(f'durationMonths argument is out of boudns: {durationMonths}')
-        assert communityGiftId is None or isinstance(communityGiftId, str), f"malformed {communityGiftId=}"
-        if not utils.isValidStr(recipientUserId):
+        elif communityGiftId is not None and not isinstance(communityGiftId, str):
+            raise TypeError(f'communityGiftId argument is malformed: \"{communityGiftId}\"')
+        elif not utils.isValidStr(recipientUserId):
             raise TypeError(f'recipientUserId argument is malformed: \"{recipientUserId}\"')
-        if not utils.isValidStr(recipientUserLogin):
+        elif not utils.isValidStr(recipientUserLogin):
             raise TypeError(f'recipientUserLogin argument is malformed: \"{recipientUserLogin}\"')
-        if not utils.isValidStr(recipientUserName):
+        elif not utils.isValidStr(recipientUserName):
             raise TypeError(f'recipientUserName argument is malformed: \"{recipientUserName}\"')
-        assert isinstance(subTier, TwitchSubscriberTier), f"malformed {subTier=}"
+        elif not isinstance(subTier, TwitchSubscriberTier):
+            raise TypeError(f'subTier argument is malformed: \"{subTier}\"')
 
         self.__cumulativeTotal: Optional[int] = cumulativeTotal
         self.__durationMonths: int = durationMonths

--- a/src/CynanBot/twitch/api/twitchTokensDetails.py
+++ b/src/CynanBot/twitch/api/twitchTokensDetails.py
@@ -12,11 +12,10 @@ class TwitchTokensDetails():
         accessToken: str,
         refreshToken: str
     ):
-        if not isinstance(expirationTime, datetime):
-            raise TypeError(f'expirationTime argument is malformed: \"{expirationTime}\"')
-        elif not utils.isValidStr(accessToken):
+        assert isinstance(expirationTime, datetime), f"malformed {expirationTime=}"
+        if not utils.isValidStr(accessToken):
             raise TypeError(f'accessToken argument is malformed: \"{accessToken}\"')
-        elif not utils.isValidStr(refreshToken):
+        if not utils.isValidStr(refreshToken):
             raise TypeError(f'refreshToken argument is malformed: \"{refreshToken}\"')
 
         self.__expirationTime: datetime = expirationTime

--- a/src/CynanBot/twitch/api/twitchTokensDetails.py
+++ b/src/CynanBot/twitch/api/twitchTokensDetails.py
@@ -12,10 +12,11 @@ class TwitchTokensDetails():
         accessToken: str,
         refreshToken: str
     ):
-        assert isinstance(expirationTime, datetime), f"malformed {expirationTime=}"
-        if not utils.isValidStr(accessToken):
+        if not isinstance(expirationTime, datetime):
+            raise TypeError(f'expirationTime argument is malformed: \"{expirationTime}\"')
+        elif not utils.isValidStr(accessToken):
             raise TypeError(f'accessToken argument is malformed: \"{accessToken}\"')
-        if not utils.isValidStr(refreshToken):
+        elif not utils.isValidStr(refreshToken):
             raise TypeError(f'refreshToken argument is malformed: \"{refreshToken}\"')
 
         self.__expirationTime: datetime = expirationTime

--- a/src/CynanBot/twitch/api/twitchUserDetails.py
+++ b/src/CynanBot/twitch/api/twitchUserDetails.py
@@ -15,14 +15,12 @@ class TwitchUserDetails():
     ):
         if not utils.isValidStr(displayName):
             raise ValueError(f'displayName argument is malformed: \"{displayName}\"')
-        elif not utils.isValidStr(login):
+        if not utils.isValidStr(login):
             raise ValueError(f'login argument is malformed: \"{login}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(broadcasterType, TwitchBroadcasterType):
-            raise ValueError(f'broadcasterType argument is malformed: \"{broadcasterType}\"')
-        elif not isinstance(userType, TwitchUserType):
-            raise ValueError(f'userType argument is malformed: \"{userType}\"')
+        assert isinstance(broadcasterType, TwitchBroadcasterType), f"malformed {broadcasterType=}"
+        assert isinstance(userType, TwitchUserType), f"malformed {userType=}"
 
         self.__displayName: str = displayName
         self.__login: str = login

--- a/src/CynanBot/twitch/api/twitchUserDetails.py
+++ b/src/CynanBot/twitch/api/twitchUserDetails.py
@@ -15,12 +15,14 @@ class TwitchUserDetails():
     ):
         if not utils.isValidStr(displayName):
             raise ValueError(f'displayName argument is malformed: \"{displayName}\"')
-        if not utils.isValidStr(login):
+        elif not utils.isValidStr(login):
             raise ValueError(f'login argument is malformed: \"{login}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(broadcasterType, TwitchBroadcasterType), f"malformed {broadcasterType=}"
-        assert isinstance(userType, TwitchUserType), f"malformed {userType=}"
+        elif not isinstance(broadcasterType, TwitchBroadcasterType):
+            raise ValueError(f'broadcasterType argument is malformed: \"{broadcasterType}\"')
+        elif not isinstance(userType, TwitchUserType):
+            raise ValueError(f'userType argument is malformed: \"{userType}\"')
 
         self.__displayName: str = displayName
         self.__login: str = login

--- a/src/CynanBot/twitch/api/twitchUserSubscriptionDetails.py
+++ b/src/CynanBot/twitch/api/twitchUserSubscriptionDetails.py
@@ -13,12 +13,11 @@ class TwitchUserSubscriptionDetails():
     ):
         if not utils.isValidBool(isGift):
             raise ValueError(f'isGift argument is malformed: \"{isGift}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif not isinstance(subscriberTier, TwitchSubscriberTier):
-            raise ValueError(f'subscriberTier argument is malformed: \"{subscriberTier}\"')
+        assert isinstance(subscriberTier, TwitchSubscriberTier), f"malformed {subscriberTier=}"
 
         self.__isGift: bool = isGift
         self.__userId: str = userId

--- a/src/CynanBot/twitch/api/twitchUserSubscriptionDetails.py
+++ b/src/CynanBot/twitch/api/twitchUserSubscriptionDetails.py
@@ -13,11 +13,12 @@ class TwitchUserSubscriptionDetails():
     ):
         if not utils.isValidBool(isGift):
             raise ValueError(f'isGift argument is malformed: \"{isGift}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        assert isinstance(subscriberTier, TwitchSubscriberTier), f"malformed {subscriberTier=}"
+        elif not isinstance(subscriberTier, TwitchSubscriberTier):
+            raise ValueError(f'subscriberTier argument is malformed: \"{subscriberTier}\"')
 
         self.__isGift: bool = isGift
         self.__userId: str = userId

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketCondition.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketCondition.py
@@ -25,40 +25,23 @@ class TwitchWebsocketCondition():
         userLogin: Optional[str] = None,
         userName: Optional[str] = None
     ):
-        if broadcasterUserId is not None and not isinstance(broadcasterUserId, str):
-            raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif broadcasterUserLogin is not None and not isinstance(broadcasterUserLogin, str):
-            raise TypeError(f'broadcasterUserLogin argument is malformed: \"{broadcasterUserLogin}\"')
-        elif broadcasterUserName is not None and not isinstance(broadcasterUserName, str):
-            raise TypeError(f'broadcasterUserName argument is malformed: \"{broadcasterUserName}\"')
-        elif clientId is not None and not isinstance(clientId, str):
-            raise TypeError(f'clientId argument is malformed: \"{clientId}\"')
-        elif fromBroadcasterUserId is not None and not isinstance(fromBroadcasterUserId, str):
-            raise TypeError(f'fromBroadcasterUserId argument is malformed: \"{fromBroadcasterUserId}\"')
-        elif fromBroadcasterUserLogin is not None and not isinstance(fromBroadcasterUserLogin, str):
-            raise TypeError(f'fromBroadcasterUserLogin argument is malformed: \"{fromBroadcasterUserLogin}\"')
-        elif fromBroadcasterUserName is not None and not isinstance(fromBroadcasterUserName, str):
-            raise TypeError(f'fromBroadcasterUserName argument is malformed: \"{fromBroadcasterUserName}\"')
-        elif moderatorUserId is not None and not isinstance(moderatorUserId, str):
-            raise TypeError(f'moderatorUserId argument is malformed: \"{moderatorUserId}\"')
-        elif moderatorUserLogin is not None and not isinstance(moderatorUserLogin, str):
-            raise TypeError(f'moderatorUserLogin argument is malformed: \"{moderatorUserLogin}\"')
-        elif moderatorUserName is not None and not isinstance(moderatorUserName, str):
-            raise TypeError(f'moderatorUserName argument is malformed: \"{moderatorUserName}\"')
-        elif rewardId is not None and not isinstance(rewardId, str):
-            raise TypeError(f'rewardId argument is malformed: \"{rewardId}\"')
-        elif toBroadcasterUserId is not None and not isinstance(toBroadcasterUserId, str):
-            raise TypeError(f'toBroadcasterUserId argument is malformed: \"{toBroadcasterUserId}\"')
-        elif toBroadcasterUserLogin is not None and not isinstance(toBroadcasterUserLogin, str):
-            raise TypeError(f'toBroadcasterUserLogin argument is malformed: \"{toBroadcasterUserLogin}\"')
-        elif toBroadcasterUserName is not None and not isinstance(toBroadcasterUserName, str):
-            raise TypeError(f'toBroadcasterUserName argument is malformed: \"{toBroadcasterUserName}\"')
-        elif userId is not None and not isinstance(userId, str):
-            raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif userLogin is not None and not isinstance(userLogin, str):
-            raise TypeError(f'userLogin argument is malformed: \"{userLogin}\"')
-        elif userName is not None and not isinstance(userName, str):
-            raise TypeError(f'userName argument is malformed: \"{userName}\"')
+        assert broadcasterUserId is None or isinstance(broadcasterUserId, str), f"malformed {broadcasterUserId=}"
+        assert broadcasterUserLogin is None or isinstance(broadcasterUserLogin, str), f"malformed {broadcasterUserLogin=}"
+        assert broadcasterUserName is None or isinstance(broadcasterUserName, str), f"malformed {broadcasterUserName=}"
+        assert clientId is None or isinstance(clientId, str), f"malformed {clientId=}"
+        assert fromBroadcasterUserId is None or isinstance(fromBroadcasterUserId, str), f"malformed {fromBroadcasterUserId=}"
+        assert fromBroadcasterUserLogin is None or isinstance(fromBroadcasterUserLogin, str), f"malformed {fromBroadcasterUserLogin=}"
+        assert fromBroadcasterUserName is None or isinstance(fromBroadcasterUserName, str), f"malformed {fromBroadcasterUserName=}"
+        assert moderatorUserId is None or isinstance(moderatorUserId, str), f"malformed {moderatorUserId=}"
+        assert moderatorUserLogin is None or isinstance(moderatorUserLogin, str), f"malformed {moderatorUserLogin=}"
+        assert moderatorUserName is None or isinstance(moderatorUserName, str), f"malformed {moderatorUserName=}"
+        assert rewardId is None or isinstance(rewardId, str), f"malformed {rewardId=}"
+        assert toBroadcasterUserId is None or isinstance(toBroadcasterUserId, str), f"malformed {toBroadcasterUserId=}"
+        assert toBroadcasterUserLogin is None or isinstance(toBroadcasterUserLogin, str), f"malformed {toBroadcasterUserLogin=}"
+        assert toBroadcasterUserName is None or isinstance(toBroadcasterUserName, str), f"malformed {toBroadcasterUserName=}"
+        assert userId is None or isinstance(userId, str), f"malformed {userId=}"
+        assert userLogin is None or isinstance(userLogin, str), f"malformed {userLogin=}"
+        assert userName is None or isinstance(userName, str), f"malformed {userName=}"
 
         self.__broadcasterUserId: Optional[str] = broadcasterUserId
         self.__broadcasterUserLogin: Optional[str] = broadcasterUserLogin

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketCondition.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketCondition.py
@@ -25,23 +25,40 @@ class TwitchWebsocketCondition():
         userLogin: Optional[str] = None,
         userName: Optional[str] = None
     ):
-        assert broadcasterUserId is None or isinstance(broadcasterUserId, str), f"malformed {broadcasterUserId=}"
-        assert broadcasterUserLogin is None or isinstance(broadcasterUserLogin, str), f"malformed {broadcasterUserLogin=}"
-        assert broadcasterUserName is None or isinstance(broadcasterUserName, str), f"malformed {broadcasterUserName=}"
-        assert clientId is None or isinstance(clientId, str), f"malformed {clientId=}"
-        assert fromBroadcasterUserId is None or isinstance(fromBroadcasterUserId, str), f"malformed {fromBroadcasterUserId=}"
-        assert fromBroadcasterUserLogin is None or isinstance(fromBroadcasterUserLogin, str), f"malformed {fromBroadcasterUserLogin=}"
-        assert fromBroadcasterUserName is None or isinstance(fromBroadcasterUserName, str), f"malformed {fromBroadcasterUserName=}"
-        assert moderatorUserId is None or isinstance(moderatorUserId, str), f"malformed {moderatorUserId=}"
-        assert moderatorUserLogin is None or isinstance(moderatorUserLogin, str), f"malformed {moderatorUserLogin=}"
-        assert moderatorUserName is None or isinstance(moderatorUserName, str), f"malformed {moderatorUserName=}"
-        assert rewardId is None or isinstance(rewardId, str), f"malformed {rewardId=}"
-        assert toBroadcasterUserId is None or isinstance(toBroadcasterUserId, str), f"malformed {toBroadcasterUserId=}"
-        assert toBroadcasterUserLogin is None or isinstance(toBroadcasterUserLogin, str), f"malformed {toBroadcasterUserLogin=}"
-        assert toBroadcasterUserName is None or isinstance(toBroadcasterUserName, str), f"malformed {toBroadcasterUserName=}"
-        assert userId is None or isinstance(userId, str), f"malformed {userId=}"
-        assert userLogin is None or isinstance(userLogin, str), f"malformed {userLogin=}"
-        assert userName is None or isinstance(userName, str), f"malformed {userName=}"
+        if broadcasterUserId is not None and not isinstance(broadcasterUserId, str):
+            raise TypeError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
+        elif broadcasterUserLogin is not None and not isinstance(broadcasterUserLogin, str):
+            raise TypeError(f'broadcasterUserLogin argument is malformed: \"{broadcasterUserLogin}\"')
+        elif broadcasterUserName is not None and not isinstance(broadcasterUserName, str):
+            raise TypeError(f'broadcasterUserName argument is malformed: \"{broadcasterUserName}\"')
+        elif clientId is not None and not isinstance(clientId, str):
+            raise TypeError(f'clientId argument is malformed: \"{clientId}\"')
+        elif fromBroadcasterUserId is not None and not isinstance(fromBroadcasterUserId, str):
+            raise TypeError(f'fromBroadcasterUserId argument is malformed: \"{fromBroadcasterUserId}\"')
+        elif fromBroadcasterUserLogin is not None and not isinstance(fromBroadcasterUserLogin, str):
+            raise TypeError(f'fromBroadcasterUserLogin argument is malformed: \"{fromBroadcasterUserLogin}\"')
+        elif fromBroadcasterUserName is not None and not isinstance(fromBroadcasterUserName, str):
+            raise TypeError(f'fromBroadcasterUserName argument is malformed: \"{fromBroadcasterUserName}\"')
+        elif moderatorUserId is not None and not isinstance(moderatorUserId, str):
+            raise TypeError(f'moderatorUserId argument is malformed: \"{moderatorUserId}\"')
+        elif moderatorUserLogin is not None and not isinstance(moderatorUserLogin, str):
+            raise TypeError(f'moderatorUserLogin argument is malformed: \"{moderatorUserLogin}\"')
+        elif moderatorUserName is not None and not isinstance(moderatorUserName, str):
+            raise TypeError(f'moderatorUserName argument is malformed: \"{moderatorUserName}\"')
+        elif rewardId is not None and not isinstance(rewardId, str):
+            raise TypeError(f'rewardId argument is malformed: \"{rewardId}\"')
+        elif toBroadcasterUserId is not None and not isinstance(toBroadcasterUserId, str):
+            raise TypeError(f'toBroadcasterUserId argument is malformed: \"{toBroadcasterUserId}\"')
+        elif toBroadcasterUserLogin is not None and not isinstance(toBroadcasterUserLogin, str):
+            raise TypeError(f'toBroadcasterUserLogin argument is malformed: \"{toBroadcasterUserLogin}\"')
+        elif toBroadcasterUserName is not None and not isinstance(toBroadcasterUserName, str):
+            raise TypeError(f'toBroadcasterUserName argument is malformed: \"{toBroadcasterUserName}\"')
+        elif userId is not None and not isinstance(userId, str):
+            raise TypeError(f'userId argument is malformed: \"{userId}\"')
+        elif userLogin is not None and not isinstance(userLogin, str):
+            raise TypeError(f'userLogin argument is malformed: \"{userLogin}\"')
+        elif userName is not None and not isinstance(userName, str):
+            raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         self.__broadcasterUserId: Optional[str] = broadcasterUserId
         self.__broadcasterUserLogin: Optional[str] = broadcasterUserLogin

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketDataBundle.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketDataBundle.py
@@ -13,10 +13,8 @@ class TwitchWebsocketDataBundle():
         metadata: TwitchWebsocketMetadata,
         payload: Optional[TwitchWebsocketPayload] = None
     ):
-        if not isinstance(metadata, TwitchWebsocketMetadata):
-            raise TypeError(f'metadata argument is malformed: \"{metadata}\"')
-        if payload is not None and not isinstance(payload, TwitchWebsocketPayload):
-            raise TypeError(f'payload argument is malformed: \"{payload}\"')
+        assert isinstance(metadata, TwitchWebsocketMetadata), f"malformed {metadata=}"
+        assert payload is None or isinstance(payload, TwitchWebsocketPayload), f"malformed {payload=}"
 
         self.__metadata: TwitchWebsocketMetadata = metadata
         self.__payload: Optional[TwitchWebsocketPayload] = payload

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketDataBundle.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketDataBundle.py
@@ -13,8 +13,10 @@ class TwitchWebsocketDataBundle():
         metadata: TwitchWebsocketMetadata,
         payload: Optional[TwitchWebsocketPayload] = None
     ):
-        assert isinstance(metadata, TwitchWebsocketMetadata), f"malformed {metadata=}"
-        assert payload is None or isinstance(payload, TwitchWebsocketPayload), f"malformed {payload=}"
+        if not isinstance(metadata, TwitchWebsocketMetadata):
+            raise TypeError(f'metadata argument is malformed: \"{metadata}\"')
+        if payload is not None and not isinstance(payload, TwitchWebsocketPayload):
+            raise TypeError(f'payload argument is malformed: \"{payload}\"')
 
         self.__metadata: TwitchWebsocketMetadata = metadata
         self.__payload: Optional[TwitchWebsocketPayload] = payload

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketEvent.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketEvent.py
@@ -68,92 +68,75 @@ class TwitchWebsocketEvent():
     ):
         if isAnonymous is not None and not utils.isValidBool(isAnonymous):
             raise ValueError(f'isAnonymous argument is malformed: \"{isAnonymous}\"')
-        elif isGift is not None and not utils.isValidBool(isGift):
+        if isGift is not None and not utils.isValidBool(isGift):
             raise ValueError(f'isGift argument is malformed: \"{isGift}\'')
-        elif bits is not None and not utils.isValidInt(bits):
+        if bits is not None and not utils.isValidInt(bits):
             raise ValueError(f'bits argument is malformed: \"{bits}\"')
-        elif cumulativeMonths is not None and not utils.isValidInt(cumulativeMonths):
+        if cumulativeMonths is not None and not utils.isValidInt(cumulativeMonths):
             raise ValueError(f'cumulativeMonths argument is malformed: \"{cumulativeMonths}\"')
-        elif total is not None and not utils.isValidInt(total):
+        if total is not None and not utils.isValidInt(total):
             raise ValueError(f'total argument is malformed: \"{total}\"')
-        elif viewers is not None and not utils.isValidInt(viewers):
+        if viewers is not None and not utils.isValidInt(viewers):
             raise ValueError(f'viewers argument is malformed: \"{viewers}\"')
-        elif endedAt is not None and not isinstance(endedAt, SimpleDateTime):
-            raise ValueError(f'endedAt argument is malformed: \"{endedAt}\"')
-        elif endsAt is not None and not isinstance(endsAt, SimpleDateTime):
-            raise ValueError(f'endsAt argument is malformed: \"{endsAt}\"')
-        elif followedAt is not None and not isinstance(followedAt, SimpleDateTime):
-            raise ValueError(f'followedAt argument is malformed: \"{followedAt}\"')
-        elif lockedAt is not None and not isinstance(lockedAt, SimpleDateTime):
-            raise ValueError(f'lockedAt argument is malformed: \"{lockedAt}\"')
-        elif locksAt is not None and not isinstance(locksAt, SimpleDateTime):
-            raise ValueError(f'locksAt argument is malformed: \"{locksAt}\"')
-        elif redeemedAt is not None and not isinstance(redeemedAt, SimpleDateTime):
-            raise ValueError(f'redeemedAt argument is malformed: \"{redeemedAt}\"')
-        elif startedAt is not None and not isinstance(startedAt, SimpleDateTime):
-            raise ValueError(f'startedAt argument is malformed: \"{startedAt}\"')
-        elif broadcasterUserId is not None and not utils.isValidStr(broadcasterUserId):
+        assert endedAt is None or isinstance(endedAt, SimpleDateTime), f"malformed {endedAt=}"
+        assert endsAt is None or isinstance(endsAt, SimpleDateTime), f"malformed {endsAt=}"
+        assert followedAt is None or isinstance(followedAt, SimpleDateTime), f"malformed {followedAt=}"
+        assert lockedAt is None or isinstance(lockedAt, SimpleDateTime), f"malformed {lockedAt=}"
+        assert locksAt is None or isinstance(locksAt, SimpleDateTime), f"malformed {locksAt=}"
+        assert redeemedAt is None or isinstance(redeemedAt, SimpleDateTime), f"malformed {redeemedAt=}"
+        assert startedAt is None or isinstance(startedAt, SimpleDateTime), f"malformed {startedAt=}"
+        if broadcasterUserId is not None and not utils.isValidStr(broadcasterUserId):
             raise ValueError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        elif broadcasterUserLogin is not None and not utils.isValidStr(broadcasterUserLogin):
+        if broadcasterUserLogin is not None and not utils.isValidStr(broadcasterUserLogin):
             raise ValueError(f'broadcasterUserLogin argument is malformed: \"{broadcasterUserLogin}\"')
-        elif broadcasterUserName is not None and not utils.isValidStr(broadcasterUserName):
+        if broadcasterUserName is not None and not utils.isValidStr(broadcasterUserName):
             raise ValueError(f'broadcasterUserName argument is malformed: \"{broadcasterUserName}\"')
-        elif categoryId is not None and not utils.isValidStr(categoryId):
+        if categoryId is not None and not utils.isValidStr(categoryId):
             raise ValueError(f'categoryId argument is malformed: \"{categoryId}\"')
-        elif categoryName is not None and not utils.isValidStr(categoryName):
+        if categoryName is not None and not utils.isValidStr(categoryName):
             raise ValueError(f'categoryName argument is malformed: \"{categoryName}\"')
-        elif eventId is not None and not utils.isValidStr(eventId):
+        if eventId is not None and not utils.isValidStr(eventId):
             raise ValueError(f'eventId argument is malformed: \"{eventId}\"')
-        elif fromBroadcasterUserId is not None and not utils.isValidStr(fromBroadcasterUserId):
+        if fromBroadcasterUserId is not None and not utils.isValidStr(fromBroadcasterUserId):
             raise ValueError(f'fromBroadcasterUserId argument is malformed: \"{fromBroadcasterUserId}\"')
-        elif fromBroadcasterUserLogin is not None and not utils.isValidStr(fromBroadcasterUserLogin):
+        if fromBroadcasterUserLogin is not None and not utils.isValidStr(fromBroadcasterUserLogin):
             raise ValueError(f'fromBroadcasterUserLogin argument is malformed: \"{fromBroadcasterUserLogin}\"')
-        elif fromBroadcasterUserName is not None and not utils.isValidStr(fromBroadcasterUserName):
+        if fromBroadcasterUserName is not None and not utils.isValidStr(fromBroadcasterUserName):
             raise ValueError(f'fromBroadcasterUserName argument is malformed: \"{fromBroadcasterUserName}\"')
-        elif message is not None and not utils.isValidStr(message):
+        if message is not None and not utils.isValidStr(message):
             raise ValueError(f'message argument is malformed: \"{message}\"')
-        elif rewardId is not None and not utils.isValidStr(rewardId):
+        if rewardId is not None and not utils.isValidStr(rewardId):
             raise ValueError(f'rewardId argument is malformed: \"{rewardId}\"')
-        elif text is not None and not utils.isValidStr(text):
+        if text is not None and not utils.isValidStr(text):
             raise ValueError(f'text argument is malformed: \"{text}\"')
-        elif title is not None and not utils.isValidStr(title):
+        if title is not None and not utils.isValidStr(title):
             raise ValueError(f'title argument is malformed: \"{title}\"')
-        elif toBroadcasterUserId is not None and not utils.isValidStr(toBroadcasterUserId):
+        if toBroadcasterUserId is not None and not utils.isValidStr(toBroadcasterUserId):
             raise ValueError(f'toBroadcasterUserId argument is malformed: \"{toBroadcasterUserId}\"')
-        elif toBroadcasterUserLogin is not None and not utils.isValidStr(toBroadcasterUserLogin):
+        if toBroadcasterUserLogin is not None and not utils.isValidStr(toBroadcasterUserLogin):
             raise ValueError(f'toBroadcasterUserLogin argument is malformed: \"{toBroadcasterUserLogin}\"')
-        elif toBroadcasterUserName is not None and not utils.isValidStr(toBroadcasterUserName):
+        if toBroadcasterUserName is not None and not utils.isValidStr(toBroadcasterUserName):
             raise ValueError(f'toBroadcasterUserName argument is malformed: \"{toBroadcasterUserName}\"')
-        elif userId is not None and not utils.isValidStr(userId):
+        if userId is not None and not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif userInput is not None and not utils.isValidStr(userInput):
+        if userInput is not None and not utils.isValidStr(userInput):
             raise ValueError(f'userInput argument is malformed: \"{userInput}\"')
-        elif userLogin is not None and not utils.isValidStr(userLogin):
+        if userLogin is not None and not utils.isValidStr(userLogin):
             raise ValueError(f'userLogin argument is malformed: \"{userLogin}\"')
-        elif userName is not None and not utils.isValidStr(userName):
+        if userName is not None and not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif winningOutcomeId is not None and not utils.isValidStr(winningOutcomeId):
+        if winningOutcomeId is not None and not utils.isValidStr(winningOutcomeId):
             raise ValueError(f'winningOutcomeId argument is malformed: \"{winningOutcomeId}\"')
-        elif tier is not None and not isinstance(tier, TwitchSubscriberTier):
-            raise ValueError(f'tier argument is malformed: \"{tier}\"')
-        elif channelPointsVoting is not None and not isinstance(channelPointsVoting, TwitchChannelPointsVoting):
-            raise ValueError(f'channelPointsVoting argument is malformed: \"{channelPointsVoting}\"')
-        elif choices is not None and not isinstance(choices, List):
-            raise ValueError(f'choices argument is malformed: \"{choices}\"')
-        elif pollStatus is not None and not isinstance(pollStatus, TwitchPollStatus):
-            raise ValueError(f'pollStatus argument is malformed: \"{pollStatus}\"')
-        elif rewardRedemptionStatus is not None and not isinstance(rewardRedemptionStatus, TwitchRewardRedemptionStatus):
-            raise ValueError(f'rewardRedemptionStatus argument is malformed: \"{rewardRedemptionStatus}\"')
-        elif communitySubGift is not None and not isinstance(communitySubGift, TwitchCommunitySubGift):
-            raise ValueError(f'communitySubGift argument is malformed: \"{communitySubGift}\"')
-        elif noticeType is not None and not isinstance(noticeType, TwitchWebsocketNoticeType):
-            raise ValueError(f'noticeType argument is malformed: \"{noticeType}\"')
-        elif outcomes is not None and not isinstance(outcomes, List):
-            raise ValueError(f'outcomes argument is malformed: \"{outcomes}\"')
-        elif reward is not None and not isinstance(reward, TwitchReward):
-            raise ValueError(f'reward argument is malformed: \"{reward}\"')
-        elif subGift is not None and not isinstance(subGift, TwitchSubGift):
-            raise ValueError(f'subGift argument is malformed: \"{subGift}\"')
+        assert tier is None or isinstance(tier, TwitchSubscriberTier), f"malformed {tier=}"
+        assert channelPointsVoting is None or isinstance(channelPointsVoting, TwitchChannelPointsVoting), f"malformed {channelPointsVoting=}"
+        assert choices is None or isinstance(choices, List), f"malformed {choices=}"
+        assert pollStatus is None or isinstance(pollStatus, TwitchPollStatus), f"malformed {pollStatus=}"
+        assert rewardRedemptionStatus is None or isinstance(rewardRedemptionStatus, TwitchRewardRedemptionStatus), f"malformed {rewardRedemptionStatus=}"
+        assert communitySubGift is None or isinstance(communitySubGift, TwitchCommunitySubGift), f"malformed {communitySubGift=}"
+        assert noticeType is None or isinstance(noticeType, TwitchWebsocketNoticeType), f"malformed {noticeType=}"
+        assert outcomes is None or isinstance(outcomes, List), f"malformed {outcomes=}"
+        assert reward is None or isinstance(reward, TwitchReward), f"malformed {reward=}"
+        assert subGift is None or isinstance(subGift, TwitchSubGift), f"malformed {subGift=}"
 
         self.__isAnonymous: Optional[bool] = isAnonymous
         self.__isGift: Optional[bool] = isGift

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketEvent.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketEvent.py
@@ -68,75 +68,92 @@ class TwitchWebsocketEvent():
     ):
         if isAnonymous is not None and not utils.isValidBool(isAnonymous):
             raise ValueError(f'isAnonymous argument is malformed: \"{isAnonymous}\"')
-        if isGift is not None and not utils.isValidBool(isGift):
+        elif isGift is not None and not utils.isValidBool(isGift):
             raise ValueError(f'isGift argument is malformed: \"{isGift}\'')
-        if bits is not None and not utils.isValidInt(bits):
+        elif bits is not None and not utils.isValidInt(bits):
             raise ValueError(f'bits argument is malformed: \"{bits}\"')
-        if cumulativeMonths is not None and not utils.isValidInt(cumulativeMonths):
+        elif cumulativeMonths is not None and not utils.isValidInt(cumulativeMonths):
             raise ValueError(f'cumulativeMonths argument is malformed: \"{cumulativeMonths}\"')
-        if total is not None and not utils.isValidInt(total):
+        elif total is not None and not utils.isValidInt(total):
             raise ValueError(f'total argument is malformed: \"{total}\"')
-        if viewers is not None and not utils.isValidInt(viewers):
+        elif viewers is not None and not utils.isValidInt(viewers):
             raise ValueError(f'viewers argument is malformed: \"{viewers}\"')
-        assert endedAt is None or isinstance(endedAt, SimpleDateTime), f"malformed {endedAt=}"
-        assert endsAt is None or isinstance(endsAt, SimpleDateTime), f"malformed {endsAt=}"
-        assert followedAt is None or isinstance(followedAt, SimpleDateTime), f"malformed {followedAt=}"
-        assert lockedAt is None or isinstance(lockedAt, SimpleDateTime), f"malformed {lockedAt=}"
-        assert locksAt is None or isinstance(locksAt, SimpleDateTime), f"malformed {locksAt=}"
-        assert redeemedAt is None or isinstance(redeemedAt, SimpleDateTime), f"malformed {redeemedAt=}"
-        assert startedAt is None or isinstance(startedAt, SimpleDateTime), f"malformed {startedAt=}"
-        if broadcasterUserId is not None and not utils.isValidStr(broadcasterUserId):
+        elif endedAt is not None and not isinstance(endedAt, SimpleDateTime):
+            raise ValueError(f'endedAt argument is malformed: \"{endedAt}\"')
+        elif endsAt is not None and not isinstance(endsAt, SimpleDateTime):
+            raise ValueError(f'endsAt argument is malformed: \"{endsAt}\"')
+        elif followedAt is not None and not isinstance(followedAt, SimpleDateTime):
+            raise ValueError(f'followedAt argument is malformed: \"{followedAt}\"')
+        elif lockedAt is not None and not isinstance(lockedAt, SimpleDateTime):
+            raise ValueError(f'lockedAt argument is malformed: \"{lockedAt}\"')
+        elif locksAt is not None and not isinstance(locksAt, SimpleDateTime):
+            raise ValueError(f'locksAt argument is malformed: \"{locksAt}\"')
+        elif redeemedAt is not None and not isinstance(redeemedAt, SimpleDateTime):
+            raise ValueError(f'redeemedAt argument is malformed: \"{redeemedAt}\"')
+        elif startedAt is not None and not isinstance(startedAt, SimpleDateTime):
+            raise ValueError(f'startedAt argument is malformed: \"{startedAt}\"')
+        elif broadcasterUserId is not None and not utils.isValidStr(broadcasterUserId):
             raise ValueError(f'broadcasterUserId argument is malformed: \"{broadcasterUserId}\"')
-        if broadcasterUserLogin is not None and not utils.isValidStr(broadcasterUserLogin):
+        elif broadcasterUserLogin is not None and not utils.isValidStr(broadcasterUserLogin):
             raise ValueError(f'broadcasterUserLogin argument is malformed: \"{broadcasterUserLogin}\"')
-        if broadcasterUserName is not None and not utils.isValidStr(broadcasterUserName):
+        elif broadcasterUserName is not None and not utils.isValidStr(broadcasterUserName):
             raise ValueError(f'broadcasterUserName argument is malformed: \"{broadcasterUserName}\"')
-        if categoryId is not None and not utils.isValidStr(categoryId):
+        elif categoryId is not None and not utils.isValidStr(categoryId):
             raise ValueError(f'categoryId argument is malformed: \"{categoryId}\"')
-        if categoryName is not None and not utils.isValidStr(categoryName):
+        elif categoryName is not None and not utils.isValidStr(categoryName):
             raise ValueError(f'categoryName argument is malformed: \"{categoryName}\"')
-        if eventId is not None and not utils.isValidStr(eventId):
+        elif eventId is not None and not utils.isValidStr(eventId):
             raise ValueError(f'eventId argument is malformed: \"{eventId}\"')
-        if fromBroadcasterUserId is not None and not utils.isValidStr(fromBroadcasterUserId):
+        elif fromBroadcasterUserId is not None and not utils.isValidStr(fromBroadcasterUserId):
             raise ValueError(f'fromBroadcasterUserId argument is malformed: \"{fromBroadcasterUserId}\"')
-        if fromBroadcasterUserLogin is not None and not utils.isValidStr(fromBroadcasterUserLogin):
+        elif fromBroadcasterUserLogin is not None and not utils.isValidStr(fromBroadcasterUserLogin):
             raise ValueError(f'fromBroadcasterUserLogin argument is malformed: \"{fromBroadcasterUserLogin}\"')
-        if fromBroadcasterUserName is not None and not utils.isValidStr(fromBroadcasterUserName):
+        elif fromBroadcasterUserName is not None and not utils.isValidStr(fromBroadcasterUserName):
             raise ValueError(f'fromBroadcasterUserName argument is malformed: \"{fromBroadcasterUserName}\"')
-        if message is not None and not utils.isValidStr(message):
+        elif message is not None and not utils.isValidStr(message):
             raise ValueError(f'message argument is malformed: \"{message}\"')
-        if rewardId is not None and not utils.isValidStr(rewardId):
+        elif rewardId is not None and not utils.isValidStr(rewardId):
             raise ValueError(f'rewardId argument is malformed: \"{rewardId}\"')
-        if text is not None and not utils.isValidStr(text):
+        elif text is not None and not utils.isValidStr(text):
             raise ValueError(f'text argument is malformed: \"{text}\"')
-        if title is not None and not utils.isValidStr(title):
+        elif title is not None and not utils.isValidStr(title):
             raise ValueError(f'title argument is malformed: \"{title}\"')
-        if toBroadcasterUserId is not None and not utils.isValidStr(toBroadcasterUserId):
+        elif toBroadcasterUserId is not None and not utils.isValidStr(toBroadcasterUserId):
             raise ValueError(f'toBroadcasterUserId argument is malformed: \"{toBroadcasterUserId}\"')
-        if toBroadcasterUserLogin is not None and not utils.isValidStr(toBroadcasterUserLogin):
+        elif toBroadcasterUserLogin is not None and not utils.isValidStr(toBroadcasterUserLogin):
             raise ValueError(f'toBroadcasterUserLogin argument is malformed: \"{toBroadcasterUserLogin}\"')
-        if toBroadcasterUserName is not None and not utils.isValidStr(toBroadcasterUserName):
+        elif toBroadcasterUserName is not None and not utils.isValidStr(toBroadcasterUserName):
             raise ValueError(f'toBroadcasterUserName argument is malformed: \"{toBroadcasterUserName}\"')
-        if userId is not None and not utils.isValidStr(userId):
+        elif userId is not None and not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if userInput is not None and not utils.isValidStr(userInput):
+        elif userInput is not None and not utils.isValidStr(userInput):
             raise ValueError(f'userInput argument is malformed: \"{userInput}\"')
-        if userLogin is not None and not utils.isValidStr(userLogin):
+        elif userLogin is not None and not utils.isValidStr(userLogin):
             raise ValueError(f'userLogin argument is malformed: \"{userLogin}\"')
-        if userName is not None and not utils.isValidStr(userName):
+        elif userName is not None and not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        if winningOutcomeId is not None and not utils.isValidStr(winningOutcomeId):
+        elif winningOutcomeId is not None and not utils.isValidStr(winningOutcomeId):
             raise ValueError(f'winningOutcomeId argument is malformed: \"{winningOutcomeId}\"')
-        assert tier is None or isinstance(tier, TwitchSubscriberTier), f"malformed {tier=}"
-        assert channelPointsVoting is None or isinstance(channelPointsVoting, TwitchChannelPointsVoting), f"malformed {channelPointsVoting=}"
-        assert choices is None or isinstance(choices, List), f"malformed {choices=}"
-        assert pollStatus is None or isinstance(pollStatus, TwitchPollStatus), f"malformed {pollStatus=}"
-        assert rewardRedemptionStatus is None or isinstance(rewardRedemptionStatus, TwitchRewardRedemptionStatus), f"malformed {rewardRedemptionStatus=}"
-        assert communitySubGift is None or isinstance(communitySubGift, TwitchCommunitySubGift), f"malformed {communitySubGift=}"
-        assert noticeType is None or isinstance(noticeType, TwitchWebsocketNoticeType), f"malformed {noticeType=}"
-        assert outcomes is None or isinstance(outcomes, List), f"malformed {outcomes=}"
-        assert reward is None or isinstance(reward, TwitchReward), f"malformed {reward=}"
-        assert subGift is None or isinstance(subGift, TwitchSubGift), f"malformed {subGift=}"
+        elif tier is not None and not isinstance(tier, TwitchSubscriberTier):
+            raise ValueError(f'tier argument is malformed: \"{tier}\"')
+        elif channelPointsVoting is not None and not isinstance(channelPointsVoting, TwitchChannelPointsVoting):
+            raise ValueError(f'channelPointsVoting argument is malformed: \"{channelPointsVoting}\"')
+        elif choices is not None and not isinstance(choices, List):
+            raise ValueError(f'choices argument is malformed: \"{choices}\"')
+        elif pollStatus is not None and not isinstance(pollStatus, TwitchPollStatus):
+            raise ValueError(f'pollStatus argument is malformed: \"{pollStatus}\"')
+        elif rewardRedemptionStatus is not None and not isinstance(rewardRedemptionStatus, TwitchRewardRedemptionStatus):
+            raise ValueError(f'rewardRedemptionStatus argument is malformed: \"{rewardRedemptionStatus}\"')
+        elif communitySubGift is not None and not isinstance(communitySubGift, TwitchCommunitySubGift):
+            raise ValueError(f'communitySubGift argument is malformed: \"{communitySubGift}\"')
+        elif noticeType is not None and not isinstance(noticeType, TwitchWebsocketNoticeType):
+            raise ValueError(f'noticeType argument is malformed: \"{noticeType}\"')
+        elif outcomes is not None and not isinstance(outcomes, List):
+            raise ValueError(f'outcomes argument is malformed: \"{outcomes}\"')
+        elif reward is not None and not isinstance(reward, TwitchReward):
+            raise ValueError(f'reward argument is malformed: \"{reward}\"')
+        elif subGift is not None and not isinstance(subGift, TwitchSubGift):
+            raise ValueError(f'subGift argument is malformed: \"{subGift}\"')
 
         self.__isAnonymous: Optional[bool] = isAnonymous
         self.__isGift: Optional[bool] = isGift

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketMetadata.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketMetadata.py
@@ -18,16 +18,12 @@ class TwitchWebsocketMetadata():
         messageType: Optional[TwitchWebsocketMessageType],
         subscriptionType: Optional[TwitchWebsocketSubscriptionType]
     ):
-        if not isinstance(messageTimestamp, SimpleDateTime):
-            raise TypeError(f'messageTimestamp argument is malformed: \"{messageTimestamp}\"')
-        elif not utils.isValidStr(messageId):
+        assert isinstance(messageTimestamp, SimpleDateTime), f"malformed {messageTimestamp=}"
+        if not utils.isValidStr(messageId):
             raise TypeError(f'messageId argument is malformed: \"{messageId}\"')
-        elif subscriptionVersion is not None and not isinstance(subscriptionVersion, str):
-            raise TypeError(f'subscriptionVersion argument is malformed: \"{subscriptionVersion}\"')
-        elif messageType is not None and not isinstance(messageType, TwitchWebsocketMessageType):
-            raise TypeError(f'messageType argument is malformed: \"{messageType}\"')
-        elif subscriptionType is not None and not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        assert subscriptionVersion is None or isinstance(subscriptionVersion, str), f"malformed {subscriptionVersion=}"
+        assert messageType is None or isinstance(messageType, TwitchWebsocketMessageType), f"malformed {messageType=}"
+        assert subscriptionType is None or isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
 
         self.__messageTimestamp: SimpleDateTime = messageTimestamp
         self.__messageId: str = messageId

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketMetadata.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketMetadata.py
@@ -18,12 +18,16 @@ class TwitchWebsocketMetadata():
         messageType: Optional[TwitchWebsocketMessageType],
         subscriptionType: Optional[TwitchWebsocketSubscriptionType]
     ):
-        assert isinstance(messageTimestamp, SimpleDateTime), f"malformed {messageTimestamp=}"
-        if not utils.isValidStr(messageId):
+        if not isinstance(messageTimestamp, SimpleDateTime):
+            raise TypeError(f'messageTimestamp argument is malformed: \"{messageTimestamp}\"')
+        elif not utils.isValidStr(messageId):
             raise TypeError(f'messageId argument is malformed: \"{messageId}\"')
-        assert subscriptionVersion is None or isinstance(subscriptionVersion, str), f"malformed {subscriptionVersion=}"
-        assert messageType is None or isinstance(messageType, TwitchWebsocketMessageType), f"malformed {messageType=}"
-        assert subscriptionType is None or isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        elif subscriptionVersion is not None and not isinstance(subscriptionVersion, str):
+            raise TypeError(f'subscriptionVersion argument is malformed: \"{subscriptionVersion}\"')
+        elif messageType is not None and not isinstance(messageType, TwitchWebsocketMessageType):
+            raise TypeError(f'messageType argument is malformed: \"{messageType}\"')
+        elif subscriptionType is not None and not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
 
         self.__messageTimestamp: SimpleDateTime = messageTimestamp
         self.__messageId: str = messageId

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketPayload.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketPayload.py
@@ -16,12 +16,9 @@ class TwitchWebsocketPayload():
         session: Optional[TwitchWebsocketSession] = None,
         subscription: Optional[TwitchWebsocketSubscription] = None
     ):
-        if event is not None and not isinstance(event, TwitchWebsocketEvent):
-            raise TypeError(f'event argument is malformed: \"{event}\"')
-        elif session is not None and not isinstance(session, TwitchWebsocketSession):
-            raise TypeError(f'session argument is malformed: \"{session}\"')
-        elif subscription is not None and not isinstance(subscription, TwitchWebsocketSubscription):
-            raise TypeError(f'subscription argument is malformed: \"{subscription}\"')
+        assert event is None or isinstance(event, TwitchWebsocketEvent), f"malformed {event=}"
+        assert session is None or isinstance(session, TwitchWebsocketSession), f"malformed {session=}"
+        assert subscription is None or isinstance(subscription, TwitchWebsocketSubscription), f"malformed {subscription=}"
 
         self.__event: Optional[TwitchWebsocketEvent] = event
         self.__session: Optional[TwitchWebsocketSession] = session

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketPayload.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketPayload.py
@@ -16,9 +16,12 @@ class TwitchWebsocketPayload():
         session: Optional[TwitchWebsocketSession] = None,
         subscription: Optional[TwitchWebsocketSubscription] = None
     ):
-        assert event is None or isinstance(event, TwitchWebsocketEvent), f"malformed {event=}"
-        assert session is None or isinstance(session, TwitchWebsocketSession), f"malformed {session=}"
-        assert subscription is None or isinstance(subscription, TwitchWebsocketSubscription), f"malformed {subscription=}"
+        if event is not None and not isinstance(event, TwitchWebsocketEvent):
+            raise TypeError(f'event argument is malformed: \"{event}\"')
+        elif session is not None and not isinstance(session, TwitchWebsocketSession):
+            raise TypeError(f'session argument is malformed: \"{session}\"')
+        elif subscription is not None and not isinstance(subscription, TwitchWebsocketSubscription):
+            raise TypeError(f'subscription argument is malformed: \"{subscription}\"')
 
         self.__event: Optional[TwitchWebsocketEvent] = event
         self.__session: Optional[TwitchWebsocketSession] = session

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketSession.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketSession.py
@@ -18,14 +18,12 @@ class TwitchWebsocketSession():
     ):
         if not utils.isValidInt(keepAliveTimeoutSeconds):
             raise ValueError(f'keepAliveTimeoutSeconds argument is malformed: \"{keepAliveTimeoutSeconds}\"')
-        elif not isinstance(connectedAt, SimpleDateTime):
-            raise ValueError(f'connectedAt argument is malformed: \"{connectedAt}\"')
-        elif reconnectUrl is not None and not utils.isValidUrl(reconnectUrl):
+        assert isinstance(connectedAt, SimpleDateTime), f"malformed {connectedAt=}"
+        if reconnectUrl is not None and not utils.isValidUrl(reconnectUrl):
             raise ValueError(f'reconnectUrl argument is malformed: \"{reconnectUrl}\"')
-        elif not utils.isValidStr(sessionId):
+        if not utils.isValidStr(sessionId):
             raise ValueError(f'sessionId argument is malformed: \"{sessionId}\"')
-        elif status is not None and not isinstance(status, TwitchWebsocketConnectionStatus):
-            raise ValueError(f'status argument is malformed: \"{status}\"')
+        assert status is None or isinstance(status, TwitchWebsocketConnectionStatus), f"malformed {status=}"
 
         self.__keepAliveTimeoutSeconds: int = keepAliveTimeoutSeconds
         self.__connectedAt: SimpleDateTime = connectedAt

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketSession.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketSession.py
@@ -18,12 +18,14 @@ class TwitchWebsocketSession():
     ):
         if not utils.isValidInt(keepAliveTimeoutSeconds):
             raise ValueError(f'keepAliveTimeoutSeconds argument is malformed: \"{keepAliveTimeoutSeconds}\"')
-        assert isinstance(connectedAt, SimpleDateTime), f"malformed {connectedAt=}"
-        if reconnectUrl is not None and not utils.isValidUrl(reconnectUrl):
+        elif not isinstance(connectedAt, SimpleDateTime):
+            raise ValueError(f'connectedAt argument is malformed: \"{connectedAt}\"')
+        elif reconnectUrl is not None and not utils.isValidUrl(reconnectUrl):
             raise ValueError(f'reconnectUrl argument is malformed: \"{reconnectUrl}\"')
-        if not utils.isValidStr(sessionId):
+        elif not utils.isValidStr(sessionId):
             raise ValueError(f'sessionId argument is malformed: \"{sessionId}\"')
-        assert status is None or isinstance(status, TwitchWebsocketConnectionStatus), f"malformed {status=}"
+        elif status is not None and not isinstance(status, TwitchWebsocketConnectionStatus):
+            raise ValueError(f'status argument is malformed: \"{status}\"')
 
         self.__keepAliveTimeoutSeconds: int = keepAliveTimeoutSeconds
         self.__connectedAt: SimpleDateTime = connectedAt

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketSubscription.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketSubscription.py
@@ -27,20 +27,15 @@ class TwitchWebsocketSubscription():
     ):
         if not utils.isValidInt(cost):
             raise ValueError(f'cost argument is malformed: \"{cost}\"')
-        elif not isinstance(createdAt, SimpleDateTime):
-            raise ValueError(f'createdAt argument is malformed: \"{createdAt}\"')
-        elif not utils.isValidStr(subscriptionId):
+        assert isinstance(createdAt, SimpleDateTime), f"malformed {createdAt=}"
+        if not utils.isValidStr(subscriptionId):
             raise ValueError(f'subscriptionId argument is malformed: \"{subscriptionId}\"')
-        elif not utils.isValidStr(version):
+        if not utils.isValidStr(version):
             raise ValueError(f'version argument is malformed: \"{version}\"')
-        elif not isinstance(condition, TwitchWebsocketCondition):
-            raise ValueError(f'condition argument is malformed: \"{condition}\"')
-        elif not isinstance(status, TwitchWebsocketConnectionStatus):
-            raise ValueError(f'status argument is malformed: \"{status}\"')
-        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise ValueError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
-        elif not isinstance(transport, TwitchWebsocketTransport):
-            raise ValueError(f'transport argument is malformed: \"{transport}\"')
+        assert isinstance(condition, TwitchWebsocketCondition), f"malformed {condition=}"
+        assert isinstance(status, TwitchWebsocketConnectionStatus), f"malformed {status=}"
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        assert isinstance(transport, TwitchWebsocketTransport), f"malformed {transport=}"
 
         self.__cost: int = cost
         self.__createdAt: SimpleDateTime = createdAt

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketSubscription.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketSubscription.py
@@ -27,15 +27,20 @@ class TwitchWebsocketSubscription():
     ):
         if not utils.isValidInt(cost):
             raise ValueError(f'cost argument is malformed: \"{cost}\"')
-        assert isinstance(createdAt, SimpleDateTime), f"malformed {createdAt=}"
-        if not utils.isValidStr(subscriptionId):
+        elif not isinstance(createdAt, SimpleDateTime):
+            raise ValueError(f'createdAt argument is malformed: \"{createdAt}\"')
+        elif not utils.isValidStr(subscriptionId):
             raise ValueError(f'subscriptionId argument is malformed: \"{subscriptionId}\"')
-        if not utils.isValidStr(version):
+        elif not utils.isValidStr(version):
             raise ValueError(f'version argument is malformed: \"{version}\"')
-        assert isinstance(condition, TwitchWebsocketCondition), f"malformed {condition=}"
-        assert isinstance(status, TwitchWebsocketConnectionStatus), f"malformed {status=}"
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
-        assert isinstance(transport, TwitchWebsocketTransport), f"malformed {transport=}"
+        elif not isinstance(condition, TwitchWebsocketCondition):
+            raise ValueError(f'condition argument is malformed: \"{condition}\"')
+        elif not isinstance(status, TwitchWebsocketConnectionStatus):
+            raise ValueError(f'status argument is malformed: \"{status}\"')
+        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise ValueError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        elif not isinstance(transport, TwitchWebsocketTransport):
+            raise ValueError(f'transport argument is malformed: \"{transport}\"')
 
         self.__cost: int = cost
         self.__createdAt: SimpleDateTime = createdAt

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketTransport.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketTransport.py
@@ -16,16 +16,11 @@ class TwitchWebsocketTransport():
         sessionId: Optional[str] = None,
         method: TwitchWebsocketTransportMethod = TwitchWebsocketTransportMethod.WEBSOCKET,
     ):
-        if connectedAt is not None and not isinstance(connectedAt, SimpleDateTime):
-            raise TypeError(f'connectedAt argument is malformed: \"{connectedAt}\"')
-        elif disconnectedAt is not None and not isinstance(disconnectedAt, SimpleDateTime):
-            raise TypeError(f'disconnectedAt argument is malformed: \"{disconnectedAt}\"')
-        elif secret is not None and not isinstance(secret, str):
-            raise TypeError(f'secret argument is malformed: \"{secret}\"')
-        elif sessionId is not None and not isinstance(sessionId, str):
-            raise TypeError(f'sessionId argument is malformed: \"{sessionId}\"')
-        elif not isinstance(method, TwitchWebsocketTransportMethod):
-            raise TypeError(f'method argument is malformed: \"{method}\"')
+        assert connectedAt is None or isinstance(connectedAt, SimpleDateTime), f"malformed {connectedAt=}"
+        assert disconnectedAt is None or isinstance(disconnectedAt, SimpleDateTime), f"malformed {disconnectedAt=}"
+        assert secret is None or isinstance(secret, str), f"malformed {secret=}"
+        assert sessionId is None or isinstance(sessionId, str), f"malformed {sessionId=}"
+        assert isinstance(method, TwitchWebsocketTransportMethod), f"malformed {method=}"
 
         self.__connectedAt: Optional[SimpleDateTime] = connectedAt
         self.__disconnectedAt: Optional[SimpleDateTime] = disconnectedAt

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketTransport.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketTransport.py
@@ -16,11 +16,16 @@ class TwitchWebsocketTransport():
         sessionId: Optional[str] = None,
         method: TwitchWebsocketTransportMethod = TwitchWebsocketTransportMethod.WEBSOCKET,
     ):
-        assert connectedAt is None or isinstance(connectedAt, SimpleDateTime), f"malformed {connectedAt=}"
-        assert disconnectedAt is None or isinstance(disconnectedAt, SimpleDateTime), f"malformed {disconnectedAt=}"
-        assert secret is None or isinstance(secret, str), f"malformed {secret=}"
-        assert sessionId is None or isinstance(sessionId, str), f"malformed {sessionId=}"
-        assert isinstance(method, TwitchWebsocketTransportMethod), f"malformed {method=}"
+        if connectedAt is not None and not isinstance(connectedAt, SimpleDateTime):
+            raise TypeError(f'connectedAt argument is malformed: \"{connectedAt}\"')
+        elif disconnectedAt is not None and not isinstance(disconnectedAt, SimpleDateTime):
+            raise TypeError(f'disconnectedAt argument is malformed: \"{disconnectedAt}\"')
+        elif secret is not None and not isinstance(secret, str):
+            raise TypeError(f'secret argument is malformed: \"{secret}\"')
+        elif sessionId is not None and not isinstance(sessionId, str):
+            raise TypeError(f'sessionId argument is malformed: \"{sessionId}\"')
+        elif not isinstance(method, TwitchWebsocketTransportMethod):
+            raise TypeError(f'method argument is malformed: \"{method}\"')
 
         self.__connectedAt: Optional[SimpleDateTime] = connectedAt
         self.__disconnectedAt: Optional[SimpleDateTime] = disconnectedAt

--- a/src/CynanBot/twitch/configuration/absChannelJoinEvent.py
+++ b/src/CynanBot/twitch/configuration/absChannelJoinEvent.py
@@ -7,8 +7,7 @@ from CynanBot.twitch.configuration.channelJoinEventType import \
 class AbsChannelJoinEvent(ABC):
 
     def __init__(self, eventType: ChannelJoinEventType):
-        if not isinstance(eventType, ChannelJoinEventType):
-            raise ValueError(f'eventType argument is malformed: \"{eventType}\"')
+        assert isinstance(eventType, ChannelJoinEventType), f"malformed {eventType=}"
 
         self.__eventType: ChannelJoinEventType = eventType
 

--- a/src/CynanBot/twitch/configuration/absChannelJoinEvent.py
+++ b/src/CynanBot/twitch/configuration/absChannelJoinEvent.py
@@ -7,7 +7,8 @@ from CynanBot.twitch.configuration.channelJoinEventType import \
 class AbsChannelJoinEvent(ABC):
 
     def __init__(self, eventType: ChannelJoinEventType):
-        assert isinstance(eventType, ChannelJoinEventType), f"malformed {eventType=}"
+        if not isinstance(eventType, ChannelJoinEventType):
+            raise ValueError(f'eventType argument is malformed: \"{eventType}\"')
 
         self.__eventType: ChannelJoinEventType = eventType
 

--- a/src/CynanBot/twitch/configuration/channelJoinHelper.py
+++ b/src/CynanBot/twitch/configuration/channelJoinHelper.py
@@ -25,25 +25,22 @@ class ChannelJoinHelper():
         maxChannelsToJoinIfUnverified: int = 10,
         maxChannelsToJoinIfVerified: int = 100
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not utils.isValidBool(verified):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        if not utils.isValidBool(verified):
             raise ValueError(f'verified argument is malformed: \"{verified}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
-        elif not utils.isValidNum(sleepTimeSeconds):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        elif sleepTimeSeconds < 10 or sleepTimeSeconds > 20:
+        if sleepTimeSeconds < 10 or sleepTimeSeconds > 20:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        elif not utils.isValidInt(maxChannelsToJoinIfUnverified):
+        if not utils.isValidInt(maxChannelsToJoinIfUnverified):
             raise ValueError(f'maxChannelsToJoinIfUnverified argument is malformed: \"{maxChannelsToJoinIfUnverified}\"')
-        elif maxChannelsToJoinIfUnverified < 5 or maxChannelsToJoinIfUnverified > 10:
+        if maxChannelsToJoinIfUnverified < 5 or maxChannelsToJoinIfUnverified > 10:
             raise ValueError(f'maxChannelsToJoinIfUnverified argument is out of bounds: {maxChannelsToJoinIfUnverified}')
-        elif not utils.isValidInt(maxChannelsToJoinIfVerified):
+        if not utils.isValidInt(maxChannelsToJoinIfVerified):
             raise ValueError(f'maxChannelsToJoinIfVerified argument is malformed: \"{maxChannelsToJoinIfVerified}\"')
-        elif maxChannelsToJoinIfVerified < 5 or maxChannelsToJoinIfVerified > 200:
+        if maxChannelsToJoinIfVerified < 5 or maxChannelsToJoinIfVerified > 200:
             raise ValueError(f'maxChannelsToJoinIfVerified argument is out of bounds: {maxChannelsToJoinIfVerified}')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -124,7 +121,6 @@ class ChannelJoinHelper():
         self.__isJoiningChannels = False
 
     def setChannelJoinListener(self, listener: Optional[ChannelJoinListener]):
-        if listener is not None and not isinstance(listener, ChannelJoinListener):
-            raise ValueError(f'listener argument is malformed: \"{listener}\"')
+        assert listener is None or isinstance(listener, ChannelJoinListener), f"malformed {listener=}"
 
         self.__channelJoinListener = listener

--- a/src/CynanBot/twitch/configuration/channelJoinHelper.py
+++ b/src/CynanBot/twitch/configuration/channelJoinHelper.py
@@ -25,22 +25,25 @@ class ChannelJoinHelper():
         maxChannelsToJoinIfUnverified: int = 10,
         maxChannelsToJoinIfVerified: int = 100
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        if not utils.isValidBool(verified):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not utils.isValidBool(verified):
             raise ValueError(f'verified argument is malformed: \"{verified}\"')
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
-        if not utils.isValidNum(sleepTimeSeconds):
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise ValueError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        elif not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        if sleepTimeSeconds < 10 or sleepTimeSeconds > 20:
+        elif sleepTimeSeconds < 10 or sleepTimeSeconds > 20:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        if not utils.isValidInt(maxChannelsToJoinIfUnverified):
+        elif not utils.isValidInt(maxChannelsToJoinIfUnverified):
             raise ValueError(f'maxChannelsToJoinIfUnverified argument is malformed: \"{maxChannelsToJoinIfUnverified}\"')
-        if maxChannelsToJoinIfUnverified < 5 or maxChannelsToJoinIfUnverified > 10:
+        elif maxChannelsToJoinIfUnverified < 5 or maxChannelsToJoinIfUnverified > 10:
             raise ValueError(f'maxChannelsToJoinIfUnverified argument is out of bounds: {maxChannelsToJoinIfUnverified}')
-        if not utils.isValidInt(maxChannelsToJoinIfVerified):
+        elif not utils.isValidInt(maxChannelsToJoinIfVerified):
             raise ValueError(f'maxChannelsToJoinIfVerified argument is malformed: \"{maxChannelsToJoinIfVerified}\"')
-        if maxChannelsToJoinIfVerified < 5 or maxChannelsToJoinIfVerified > 200:
+        elif maxChannelsToJoinIfVerified < 5 or maxChannelsToJoinIfVerified > 200:
             raise ValueError(f'maxChannelsToJoinIfVerified argument is out of bounds: {maxChannelsToJoinIfVerified}')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
@@ -121,6 +124,7 @@ class ChannelJoinHelper():
         self.__isJoiningChannels = False
 
     def setChannelJoinListener(self, listener: Optional[ChannelJoinListener]):
-        assert listener is None or isinstance(listener, ChannelJoinListener), f"malformed {listener=}"
+        if listener is not None and not isinstance(listener, ChannelJoinListener):
+            raise ValueError(f'listener argument is malformed: \"{listener}\"')
 
         self.__channelJoinListener = listener

--- a/src/CynanBot/twitch/configuration/twitchChannelPointRedemptionHandler.py
+++ b/src/CynanBot/twitch/configuration/twitchChannelPointRedemptionHandler.py
@@ -44,26 +44,23 @@ class TwitchChannelPointRedemptionHandler(AbsTwitchChannelPointRedemptionHandler
     ):
         if not isinstance(casualGamePollRedemption, CasualGamePollRedemption) and not isinstance(casualGamePollRedemption, StubPointRedemption):
             raise TypeError(f'casualGamePollRedemption argument is malformed: \"{casualGamePollRedemption}\"')
-        elif not isinstance(cutenessRedemption, CutenessRedemption) and not isinstance(cutenessRedemption, StubPointRedemption):
+        if not isinstance(cutenessRedemption, CutenessRedemption) and not isinstance(cutenessRedemption, StubPointRedemption):
             raise TypeError(f'cutenessRedemption argument is malformed: \"{cutenessRedemption}\"')
-        elif not isinstance(pkmnBattleRedemption, PkmnBattleRedemption) and not isinstance(pkmnBattleRedemption, StubPointRedemption):
+        if not isinstance(pkmnBattleRedemption, PkmnBattleRedemption) and not isinstance(pkmnBattleRedemption, StubPointRedemption):
             raise TypeError(f'pkmnBattleRedemption argument is malformed: \"{pkmnBattleRedemption}\"')
-        elif not isinstance(pkmnCatchRedemption, PkmnCatchRedemption) and not isinstance(pkmnCatchRedemption, StubPointRedemption):
+        if not isinstance(pkmnCatchRedemption, PkmnCatchRedemption) and not isinstance(pkmnCatchRedemption, StubPointRedemption):
             raise TypeError(f'pkmnCatchRedemption argument is malformed: \"{pkmnCatchRedemption}\"')
-        elif not isinstance(pkmnEvolveRedemption, PkmnEvolveRedemption) and not isinstance(pkmnEvolveRedemption, StubPointRedemption):
+        if not isinstance(pkmnEvolveRedemption, PkmnEvolveRedemption) and not isinstance(pkmnEvolveRedemption, StubPointRedemption):
             raise TypeError(f'pkmnEvolveRedemption argument is malformed: \"{pkmnEvolveRedemption}\"')
-        elif not isinstance(pkmnShinyRedemption, PkmnShinyRedemption) and not isinstance(pkmnShinyRedemption, StubPointRedemption):
+        if not isinstance(pkmnShinyRedemption, PkmnShinyRedemption) and not isinstance(pkmnShinyRedemption, StubPointRedemption):
             raise TypeError(f'pkmnShinyRedemption argument is malformed: \"{pkmnShinyRedemption}\"')
-        elif not isinstance(superTriviaGameRedemption, SuperTriviaGameRedemption) and not isinstance(superTriviaGameRedemption, StubPointRedemption):
+        if not isinstance(superTriviaGameRedemption, SuperTriviaGameRedemption) and not isinstance(superTriviaGameRedemption, StubPointRedemption):
             raise TypeError(f'superTriviaGameRedemption argument is malformed: \"{superTriviaGameRedemption}\"')
-        elif not isinstance(triviaGameRedemption, TriviaGameRedemption) and not isinstance(triviaGameRedemption, StubPointRedemption):
+        if not isinstance(triviaGameRedemption, TriviaGameRedemption) and not isinstance(triviaGameRedemption, StubPointRedemption):
             raise TypeError(f'triviaGameRedemption argument is malformed: \"{triviaGameRedemption}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchChannelProvider, TwitchChannelProvider):
-            raise TypeError(f'twitchChannelProvider argument is malformed: \"{twitchChannelProvider}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchChannelProvider, TwitchChannelProvider), f"malformed {twitchChannelProvider=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__casualGamePollRedemption: AbsChannelPointRedemption = casualGamePollRedemption
         self.__cutenessRedemption: AbsChannelPointRedemption = cutenessRedemption
@@ -85,10 +82,8 @@ class TwitchChannelPointRedemptionHandler(AbsTwitchChannelPointRedemptionHandler
     ):
         if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
-            raise ValueError(f'dataBundle argument is malformed: \"{dataBundle}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
 
         event = dataBundle.requirePayload().getEvent()
 

--- a/src/CynanBot/twitch/configuration/twitchChannelPointRedemptionHandler.py
+++ b/src/CynanBot/twitch/configuration/twitchChannelPointRedemptionHandler.py
@@ -44,23 +44,26 @@ class TwitchChannelPointRedemptionHandler(AbsTwitchChannelPointRedemptionHandler
     ):
         if not isinstance(casualGamePollRedemption, CasualGamePollRedemption) and not isinstance(casualGamePollRedemption, StubPointRedemption):
             raise TypeError(f'casualGamePollRedemption argument is malformed: \"{casualGamePollRedemption}\"')
-        if not isinstance(cutenessRedemption, CutenessRedemption) and not isinstance(cutenessRedemption, StubPointRedemption):
+        elif not isinstance(cutenessRedemption, CutenessRedemption) and not isinstance(cutenessRedemption, StubPointRedemption):
             raise TypeError(f'cutenessRedemption argument is malformed: \"{cutenessRedemption}\"')
-        if not isinstance(pkmnBattleRedemption, PkmnBattleRedemption) and not isinstance(pkmnBattleRedemption, StubPointRedemption):
+        elif not isinstance(pkmnBattleRedemption, PkmnBattleRedemption) and not isinstance(pkmnBattleRedemption, StubPointRedemption):
             raise TypeError(f'pkmnBattleRedemption argument is malformed: \"{pkmnBattleRedemption}\"')
-        if not isinstance(pkmnCatchRedemption, PkmnCatchRedemption) and not isinstance(pkmnCatchRedemption, StubPointRedemption):
+        elif not isinstance(pkmnCatchRedemption, PkmnCatchRedemption) and not isinstance(pkmnCatchRedemption, StubPointRedemption):
             raise TypeError(f'pkmnCatchRedemption argument is malformed: \"{pkmnCatchRedemption}\"')
-        if not isinstance(pkmnEvolveRedemption, PkmnEvolveRedemption) and not isinstance(pkmnEvolveRedemption, StubPointRedemption):
+        elif not isinstance(pkmnEvolveRedemption, PkmnEvolveRedemption) and not isinstance(pkmnEvolveRedemption, StubPointRedemption):
             raise TypeError(f'pkmnEvolveRedemption argument is malformed: \"{pkmnEvolveRedemption}\"')
-        if not isinstance(pkmnShinyRedemption, PkmnShinyRedemption) and not isinstance(pkmnShinyRedemption, StubPointRedemption):
+        elif not isinstance(pkmnShinyRedemption, PkmnShinyRedemption) and not isinstance(pkmnShinyRedemption, StubPointRedemption):
             raise TypeError(f'pkmnShinyRedemption argument is malformed: \"{pkmnShinyRedemption}\"')
-        if not isinstance(superTriviaGameRedemption, SuperTriviaGameRedemption) and not isinstance(superTriviaGameRedemption, StubPointRedemption):
+        elif not isinstance(superTriviaGameRedemption, SuperTriviaGameRedemption) and not isinstance(superTriviaGameRedemption, StubPointRedemption):
             raise TypeError(f'superTriviaGameRedemption argument is malformed: \"{superTriviaGameRedemption}\"')
-        if not isinstance(triviaGameRedemption, TriviaGameRedemption) and not isinstance(triviaGameRedemption, StubPointRedemption):
+        elif not isinstance(triviaGameRedemption, TriviaGameRedemption) and not isinstance(triviaGameRedemption, StubPointRedemption):
             raise TypeError(f'triviaGameRedemption argument is malformed: \"{triviaGameRedemption}\"')
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchChannelProvider, TwitchChannelProvider), f"malformed {twitchChannelProvider=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchChannelProvider, TwitchChannelProvider):
+            raise TypeError(f'twitchChannelProvider argument is malformed: \"{twitchChannelProvider}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__casualGamePollRedemption: AbsChannelPointRedemption = casualGamePollRedemption
         self.__cutenessRedemption: AbsChannelPointRedemption = cutenessRedemption
@@ -82,8 +85,10 @@ class TwitchChannelPointRedemptionHandler(AbsTwitchChannelPointRedemptionHandler
     ):
         if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
+            raise ValueError(f'dataBundle argument is malformed: \"{dataBundle}\"')
 
         event = dataBundle.requirePayload().getEvent()
 

--- a/src/CynanBot/twitch/configuration/twitchChannelPointsMessage.py
+++ b/src/CynanBot/twitch/configuration/twitchChannelPointsMessage.py
@@ -19,15 +19,13 @@ class TwitchChannelPointsMessage():
     ):
         if not utils.isValidStr(eventId):
             raise TypeError(f'eventId argument is malformed: \"{eventId}\"')
-        elif redemptionMessage is not None and not isinstance(redemptionMessage, str):
-            raise TypeError(f'redemptionMessage argument is malformed: \"{redemptionMessage}\"')
-        elif not utils.isValidStr(rewardId):
+        assert redemptionMessage is None or isinstance(redemptionMessage, str), f"malformed {redemptionMessage=}"
+        if not utils.isValidStr(rewardId):
             raise TypeError(f'rewardId argument is malformed: \"{rewardId}\"')
-        elif not isinstance(twitchUser, UserInterface):
-            raise TypeError(f'twitchUser argument is malformed: \"{twitchUser}\"')
-        elif not utils.isValidStr(userId):
+        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         self.__eventId: str = eventId

--- a/src/CynanBot/twitch/configuration/twitchChannelPointsMessage.py
+++ b/src/CynanBot/twitch/configuration/twitchChannelPointsMessage.py
@@ -19,13 +19,15 @@ class TwitchChannelPointsMessage():
     ):
         if not utils.isValidStr(eventId):
             raise TypeError(f'eventId argument is malformed: \"{eventId}\"')
-        assert redemptionMessage is None or isinstance(redemptionMessage, str), f"malformed {redemptionMessage=}"
-        if not utils.isValidStr(rewardId):
+        elif redemptionMessage is not None and not isinstance(redemptionMessage, str):
+            raise TypeError(f'redemptionMessage argument is malformed: \"{redemptionMessage}\"')
+        elif not utils.isValidStr(rewardId):
             raise TypeError(f'rewardId argument is malformed: \"{rewardId}\"')
-        assert isinstance(twitchUser, UserInterface), f"malformed {twitchUser=}"
-        if not utils.isValidStr(userId):
+        elif not isinstance(twitchUser, UserInterface):
+            raise TypeError(f'twitchUser argument is malformed: \"{twitchUser}\"')
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
 
         self.__eventId: str = eventId

--- a/src/CynanBot/twitch/configuration/twitchIo/twitchIoChannel.py
+++ b/src/CynanBot/twitch/configuration/twitchIo/twitchIoChannel.py
@@ -17,10 +17,8 @@ class TwitchIoChannel(TwitchChannel, TwitchMessageable):
         channel: Channel,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        if not isinstance(channel, Channel):
-            raise ValueError(f'channel argument is malformed: \"{channel}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(channel, Channel), f"malformed {channel=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__channel: Channel = channel
         self.__twitchChannelId: Optional[str] = None

--- a/src/CynanBot/twitch/configuration/twitchIo/twitchIoChannel.py
+++ b/src/CynanBot/twitch/configuration/twitchIo/twitchIoChannel.py
@@ -17,8 +17,10 @@ class TwitchIoChannel(TwitchChannel, TwitchMessageable):
         channel: Channel,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        assert isinstance(channel, Channel), f"malformed {channel=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not isinstance(channel, Channel):
+            raise ValueError(f'channel argument is malformed: \"{channel}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__channel: Channel = channel
         self.__twitchChannelId: Optional[str] = None

--- a/src/CynanBot/twitch/configuration/twitchIo/twitchIoConfiguration.py
+++ b/src/CynanBot/twitch/configuration/twitchIo/twitchIoConfiguration.py
@@ -22,14 +22,12 @@ from CynanBot.users.userIdsRepositoryInterface import \
 class TwitchIoConfiguration(TwitchConfiguration):
 
     def __init__(self, userIdsRepository: UserIdsRepositoryInterface):
-        if not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__userIdsRepository: UserIdsRepositoryInterface = userIdsRepository
 
     def getChannel(self, channel: Channel) -> TwitchChannel:
-        if not isinstance(channel, Channel):
-            raise ValueError(f'channel argument is malformed: \"{channel}\"')
+        assert isinstance(channel, Channel), f"malformed {channel=}"
 
         return TwitchIoChannel(
             channel = channel,
@@ -37,8 +35,7 @@ class TwitchIoConfiguration(TwitchConfiguration):
         )
 
     def getContext(self, context: Context) -> TwitchContext:
-        if not isinstance(context, Context):
-            raise ValueError(f'context argument is malformed: \"{context}\"')
+        assert isinstance(context, Context), f"malformed {context=}"
 
         return TwitchIoContext(
             context = context,
@@ -46,8 +43,7 @@ class TwitchIoConfiguration(TwitchConfiguration):
         )
 
     def getMessage(self, message: Message) -> TwitchMessage:
-        if not isinstance(message, Message):
-            raise ValueError(f'message argument is malformed: \"{message}\"')
+        assert isinstance(message, Message), f"malformed {message=}"
 
         return TwitchIoMessage(
             message = message,

--- a/src/CynanBot/twitch/configuration/twitchIo/twitchIoConfiguration.py
+++ b/src/CynanBot/twitch/configuration/twitchIo/twitchIoConfiguration.py
@@ -22,12 +22,14 @@ from CynanBot.users.userIdsRepositoryInterface import \
 class TwitchIoConfiguration(TwitchConfiguration):
 
     def __init__(self, userIdsRepository: UserIdsRepositoryInterface):
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__userIdsRepository: UserIdsRepositoryInterface = userIdsRepository
 
     def getChannel(self, channel: Channel) -> TwitchChannel:
-        assert isinstance(channel, Channel), f"malformed {channel=}"
+        if not isinstance(channel, Channel):
+            raise ValueError(f'channel argument is malformed: \"{channel}\"')
 
         return TwitchIoChannel(
             channel = channel,
@@ -35,7 +37,8 @@ class TwitchIoConfiguration(TwitchConfiguration):
         )
 
     def getContext(self, context: Context) -> TwitchContext:
-        assert isinstance(context, Context), f"malformed {context=}"
+        if not isinstance(context, Context):
+            raise ValueError(f'context argument is malformed: \"{context}\"')
 
         return TwitchIoContext(
             context = context,
@@ -43,7 +46,8 @@ class TwitchIoConfiguration(TwitchConfiguration):
         )
 
     def getMessage(self, message: Message) -> TwitchMessage:
-        assert isinstance(message, Message), f"malformed {message=}"
+        if not isinstance(message, Message):
+            raise ValueError(f'message argument is malformed: \"{message}\"')
 
         return TwitchIoMessage(
             message = message,

--- a/src/CynanBot/twitch/configuration/twitchIo/twitchIoContext.py
+++ b/src/CynanBot/twitch/configuration/twitchIo/twitchIoContext.py
@@ -20,10 +20,8 @@ class TwitchIoContext(TwitchContext, TwitchMessageable):
         context: Context,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        if not isinstance(context, Context):
-            raise ValueError(f'context argument is malformed: \"{context}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(context, Context), f"malformed {context=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__context: Context = context
         self.__twitchChannelId: Optional[str] = None

--- a/src/CynanBot/twitch/configuration/twitchIo/twitchIoContext.py
+++ b/src/CynanBot/twitch/configuration/twitchIo/twitchIoContext.py
@@ -20,8 +20,10 @@ class TwitchIoContext(TwitchContext, TwitchMessageable):
         context: Context,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        assert isinstance(context, Context), f"malformed {context=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not isinstance(context, Context):
+            raise ValueError(f'context argument is malformed: \"{context}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__context: Context = context
         self.__twitchChannelId: Optional[str] = None

--- a/src/CynanBot/twitch/configuration/twitchIo/twitchIoMessage.py
+++ b/src/CynanBot/twitch/configuration/twitchIo/twitchIoMessage.py
@@ -22,10 +22,8 @@ class TwitchIoMessage(TwitchMessage):
         message: Message,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        if not isinstance(message, Message):
-            raise ValueError(f'message argument is malformed: \"{message}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert isinstance(message, Message), f"malformed {message=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__message: Message = message
         self.__author: TwitchAuthor = TwitchIoAuthor(message.author)

--- a/src/CynanBot/twitch/configuration/twitchIo/twitchIoMessage.py
+++ b/src/CynanBot/twitch/configuration/twitchIo/twitchIoMessage.py
@@ -22,8 +22,10 @@ class TwitchIoMessage(TwitchMessage):
         message: Message,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        assert isinstance(message, Message), f"malformed {message=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if not isinstance(message, Message):
+            raise ValueError(f'message argument is malformed: \"{message}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise ValueError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__message: Message = message
         self.__author: TwitchAuthor = TwitchIoAuthor(message.author)

--- a/src/CynanBot/twitch/isLiveOnTwitchRepository.py
+++ b/src/CynanBot/twitch/isLiveOnTwitchRepository.py
@@ -25,16 +25,11 @@ class IsLiveOnTwitchRepository(IsLiveOnTwitchRepositoryInterface):
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         cacheTimeDelta: timedelta = timedelta(minutes = 10)
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
-            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise TypeError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(cacheTimeDelta, timedelta):
-            raise TypeError(f'cacheTimeDelta argument is malformed: \"{cacheTimeDelta}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(cacheTimeDelta, timedelta), f"malformed {cacheTimeDelta=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/twitch/isLiveOnTwitchRepository.py
+++ b/src/CynanBot/twitch/isLiveOnTwitchRepository.py
@@ -25,11 +25,16 @@ class IsLiveOnTwitchRepository(IsLiveOnTwitchRepositoryInterface):
         twitchTokensRepository: TwitchTokensRepositoryInterface,
         cacheTimeDelta: timedelta = timedelta(minutes = 10)
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(cacheTimeDelta, timedelta), f"malformed {cacheTimeDelta=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
+            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise TypeError(f'twitchTokensRepositoryInterface argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(cacheTimeDelta, timedelta):
+            raise TypeError(f'cacheTimeDelta argument is malformed: \"{cacheTimeDelta}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__timber: TimberInterface = timber

--- a/src/CynanBot/twitch/outboundMessage.py
+++ b/src/CynanBot/twitch/outboundMessage.py
@@ -12,12 +12,10 @@ class OutboundMessage():
         message: str,
         messageable: TwitchMessageable
     ):
-        if not isinstance(delayUntilTime, datetime):
-            raise TypeError(f'delayUntilTime argument is malformed: \"{delayUntilTime}\"')
-        elif not utils.isValidStr(message):
+        assert isinstance(delayUntilTime, datetime), f"malformed {delayUntilTime=}"
+        if not utils.isValidStr(message):
             raise TypeError(f'message argument is malformed: \"{message}\"')
-        elif not isinstance(messageable, TwitchMessageable):
-            raise TypeError(f'messageable argument is malformed: \"{messageable}\"')
+        assert isinstance(messageable, TwitchMessageable), f"malformed {messageable=}"
 
         self.__delayUntilTime: datetime = delayUntilTime
         self.__message: str = message

--- a/src/CynanBot/twitch/outboundMessage.py
+++ b/src/CynanBot/twitch/outboundMessage.py
@@ -12,10 +12,12 @@ class OutboundMessage():
         message: str,
         messageable: TwitchMessageable
     ):
-        assert isinstance(delayUntilTime, datetime), f"malformed {delayUntilTime=}"
-        if not utils.isValidStr(message):
+        if not isinstance(delayUntilTime, datetime):
+            raise TypeError(f'delayUntilTime argument is malformed: \"{delayUntilTime}\"')
+        elif not utils.isValidStr(message):
             raise TypeError(f'message argument is malformed: \"{message}\"')
-        assert isinstance(messageable, TwitchMessageable), f"malformed {messageable=}"
+        elif not isinstance(messageable, TwitchMessageable):
+            raise TypeError(f'messageable argument is malformed: \"{messageable}\"')
 
         self.__delayUntilTime: datetime = delayUntilTime
         self.__message: str = message

--- a/src/CynanBot/twitch/twitchCheerHandler.py
+++ b/src/CynanBot/twitch/twitchCheerHandler.py
@@ -36,18 +36,12 @@ class TwitchCheerHandler(AbsTwitchCheerHandler):
         triviaGameMachine: Optional[TriviaGameMachineInterface],
         twitchChannelProvider: TwitchChannelProvider
     ):
-        if cheerActionHelper is not None and not isinstance(cheerActionHelper, CheerActionHelperInterface):
-            raise TypeError(f'cheerActionHelper argument is malformed: \"{cheerActionHelper}\"')
-        elif streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
-            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif triviaGameBuilder is not None and not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
-            raise TypeError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
-        elif triviaGameMachine is not None and not isinstance(triviaGameMachine, TriviaGameMachineInterface):
-            raise TypeError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
-        elif not isinstance(twitchChannelProvider, TwitchChannelProvider):
-            raise TypeError(f'twitchChannelProvider argument is malformed: \"{twitchChannelProvider}\"')
+        assert cheerActionHelper is None or isinstance(cheerActionHelper, CheerActionHelperInterface), f"malformed {cheerActionHelper=}"
+        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert triviaGameBuilder is None or isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
+        assert triviaGameMachine is None or isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
+        assert isinstance(twitchChannelProvider, TwitchChannelProvider), f"malformed {twitchChannelProvider=}"
 
         self.__cheerActionHelper: Optional[CheerActionHelperInterface] = cheerActionHelper
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
@@ -64,10 +58,8 @@ class TwitchCheerHandler(AbsTwitchCheerHandler):
     ):
         if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
-            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
 
         event = dataBundle.requirePayload().getEvent()
 
@@ -119,16 +111,14 @@ class TwitchCheerHandler(AbsTwitchCheerHandler):
     ) -> bool:
         if not utils.isValidInt(bits):
             raise ValueError(f'bits argument is malformed: \"{bits}\"')
-        elif bits < 1 or bits > utils.getIntMaxSafeSize():
+        if bits < 1 or bits > utils.getIntMaxSafeSize():
             raise ValueError(f'bits argument is out of bounds: {bits}')
-        elif not utils.isValidStr(cheerUserId):
+        if not utils.isValidStr(cheerUserId):
             raise ValueError(f'cheerUserId argument is malformed: \"{cheerUserId}\"')
-        elif not utils.isValidStr(cheerUserLogin):
+        if not utils.isValidStr(cheerUserLogin):
             raise ValueError(f'cheerUserLogin argument is malformed: \"{cheerUserLogin}\"')
-        elif message is not None and not isinstance(message, str):
-            raise ValueError(f'message argument is malformed: \"{message}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert message is None or isinstance(message, str), f"malformed {message=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         if self.__cheerActionHelper is None:
             return False
@@ -150,10 +140,9 @@ class TwitchCheerHandler(AbsTwitchCheerHandler):
     ):
         if not utils.isValidInt(bits):
             raise ValueError(f'bits argument is malformed: \"{bits}\"')
-        elif bits < 1 or bits > utils.getIntMaxSafeSize():
+        if bits < 1 or bits > utils.getIntMaxSafeSize():
             raise ValueError(f'bits argument is out of bounds: {bits}')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         if self.__triviaGameBuilder is None or self.__triviaGameMachine is None:
             return
@@ -191,16 +180,14 @@ class TwitchCheerHandler(AbsTwitchCheerHandler):
     ):
         if not utils.isValidInt(bits):
             raise ValueError(f'bits argument is malformed: \"{bits}\"')
-        elif bits <= 0 or bits > utils.getIntMaxSafeSize():
+        if bits <= 0 or bits > utils.getIntMaxSafeSize():
             raise ValueError(f'bits argument is out of bounds: {bits}')
-        elif not utils.isValidStr(cheerUserId):
+        if not utils.isValidStr(cheerUserId):
             raise ValueError(f'cheerUserId argument is malformed: \"{cheerUserId}\"')
-        elif not utils.isValidStr(cheerUserLogin):
+        if not utils.isValidStr(cheerUserLogin):
             raise ValueError(f'cheerUserLogin argument is malformed: \"{cheerUserLogin}\"')
-        elif message is not None and not isinstance(message, str):
-            raise ValueError(f'message argument is malformed: \"{message}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert message is None or isinstance(message, str), f"malformed {message=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         if self.__streamAlertsManager is None:
             return

--- a/src/CynanBot/twitch/twitchCheerHandler.py
+++ b/src/CynanBot/twitch/twitchCheerHandler.py
@@ -36,12 +36,18 @@ class TwitchCheerHandler(AbsTwitchCheerHandler):
         triviaGameMachine: Optional[TriviaGameMachineInterface],
         twitchChannelProvider: TwitchChannelProvider
     ):
-        assert cheerActionHelper is None or isinstance(cheerActionHelper, CheerActionHelperInterface), f"malformed {cheerActionHelper=}"
-        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert triviaGameBuilder is None or isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
-        assert triviaGameMachine is None or isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
-        assert isinstance(twitchChannelProvider, TwitchChannelProvider), f"malformed {twitchChannelProvider=}"
+        if cheerActionHelper is not None and not isinstance(cheerActionHelper, CheerActionHelperInterface):
+            raise TypeError(f'cheerActionHelper argument is malformed: \"{cheerActionHelper}\"')
+        elif streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
+            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif triviaGameBuilder is not None and not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
+            raise TypeError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
+        elif triviaGameMachine is not None and not isinstance(triviaGameMachine, TriviaGameMachineInterface):
+            raise TypeError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
+        elif not isinstance(twitchChannelProvider, TwitchChannelProvider):
+            raise TypeError(f'twitchChannelProvider argument is malformed: \"{twitchChannelProvider}\"')
 
         self.__cheerActionHelper: Optional[CheerActionHelperInterface] = cheerActionHelper
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
@@ -58,8 +64,10 @@ class TwitchCheerHandler(AbsTwitchCheerHandler):
     ):
         if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
+            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
 
         event = dataBundle.requirePayload().getEvent()
 
@@ -111,14 +119,16 @@ class TwitchCheerHandler(AbsTwitchCheerHandler):
     ) -> bool:
         if not utils.isValidInt(bits):
             raise ValueError(f'bits argument is malformed: \"{bits}\"')
-        if bits < 1 or bits > utils.getIntMaxSafeSize():
+        elif bits < 1 or bits > utils.getIntMaxSafeSize():
             raise ValueError(f'bits argument is out of bounds: {bits}')
-        if not utils.isValidStr(cheerUserId):
+        elif not utils.isValidStr(cheerUserId):
             raise ValueError(f'cheerUserId argument is malformed: \"{cheerUserId}\"')
-        if not utils.isValidStr(cheerUserLogin):
+        elif not utils.isValidStr(cheerUserLogin):
             raise ValueError(f'cheerUserLogin argument is malformed: \"{cheerUserLogin}\"')
-        assert message is None or isinstance(message, str), f"malformed {message=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        elif message is not None and not isinstance(message, str):
+            raise ValueError(f'message argument is malformed: \"{message}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         if self.__cheerActionHelper is None:
             return False
@@ -140,9 +150,10 @@ class TwitchCheerHandler(AbsTwitchCheerHandler):
     ):
         if not utils.isValidInt(bits):
             raise ValueError(f'bits argument is malformed: \"{bits}\"')
-        if bits < 1 or bits > utils.getIntMaxSafeSize():
+        elif bits < 1 or bits > utils.getIntMaxSafeSize():
             raise ValueError(f'bits argument is out of bounds: {bits}')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         if self.__triviaGameBuilder is None or self.__triviaGameMachine is None:
             return
@@ -180,14 +191,16 @@ class TwitchCheerHandler(AbsTwitchCheerHandler):
     ):
         if not utils.isValidInt(bits):
             raise ValueError(f'bits argument is malformed: \"{bits}\"')
-        if bits <= 0 or bits > utils.getIntMaxSafeSize():
+        elif bits <= 0 or bits > utils.getIntMaxSafeSize():
             raise ValueError(f'bits argument is out of bounds: {bits}')
-        if not utils.isValidStr(cheerUserId):
+        elif not utils.isValidStr(cheerUserId):
             raise ValueError(f'cheerUserId argument is malformed: \"{cheerUserId}\"')
-        if not utils.isValidStr(cheerUserLogin):
+        elif not utils.isValidStr(cheerUserLogin):
             raise ValueError(f'cheerUserLogin argument is malformed: \"{cheerUserLogin}\"')
-        assert message is None or isinstance(message, str), f"malformed {message=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        elif message is not None and not isinstance(message, str):
+            raise ValueError(f'message argument is malformed: \"{message}\"')
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         if self.__streamAlertsManager is None:
             return

--- a/src/CynanBot/twitch/twitchFollowerRepository.py
+++ b/src/CynanBot/twitch/twitchFollowerRepository.py
@@ -25,14 +25,10 @@ class TwitchFollowerRepository(TwitchFollowerRepositoryInterface):
         userIdsRepository: UserIdsRepositoryInterface,
         cacheTimeDelta: timedelta = timedelta(hours = 8)
     ):
-        if not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
-            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(cacheTimeDelta, timedelta):
-            raise TypeError(f'cacheTimeDelta argument is malformed: \"{cacheTimeDelta}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(cacheTimeDelta, timedelta), f"malformed {cacheTimeDelta=}"
 
         self.__timber: TimberInterface = timber
         self.__twitchApiService: TwitchApiServiceInterface = twitchApiService
@@ -52,9 +48,9 @@ class TwitchFollowerRepository(TwitchFollowerRepositoryInterface):
     ) -> Optional[TwitchFollower]:
         if not utils.isValidStr(twitchAccessToken):
             raise TypeError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        elif not utils.isValidStr(twitchChannelId):
+        if not utils.isValidStr(twitchChannelId):
             raise TypeError(f'twitchChannelId argument is malformed: \"{twitchChannelId}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         follower: Optional[TwitchFollower] = self.__cache[twitchChannelId][userId]

--- a/src/CynanBot/twitch/twitchFollowerRepository.py
+++ b/src/CynanBot/twitch/twitchFollowerRepository.py
@@ -25,10 +25,14 @@ class TwitchFollowerRepository(TwitchFollowerRepositoryInterface):
         userIdsRepository: UserIdsRepositoryInterface,
         cacheTimeDelta: timedelta = timedelta(hours = 8)
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(cacheTimeDelta, timedelta), f"malformed {cacheTimeDelta=}"
+        if not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
+            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(cacheTimeDelta, timedelta):
+            raise TypeError(f'cacheTimeDelta argument is malformed: \"{cacheTimeDelta}\"')
 
         self.__timber: TimberInterface = timber
         self.__twitchApiService: TwitchApiServiceInterface = twitchApiService
@@ -48,9 +52,9 @@ class TwitchFollowerRepository(TwitchFollowerRepositoryInterface):
     ) -> Optional[TwitchFollower]:
         if not utils.isValidStr(twitchAccessToken):
             raise TypeError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
-        if not utils.isValidStr(twitchChannelId):
+        elif not utils.isValidStr(twitchChannelId):
             raise TypeError(f'twitchChannelId argument is malformed: \"{twitchChannelId}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
 
         follower: Optional[TwitchFollower] = self.__cache[twitchChannelId][userId]

--- a/src/CynanBot/twitch/twitchPollHandler.py
+++ b/src/CynanBot/twitch/twitchPollHandler.py
@@ -22,10 +22,8 @@ class TwitchPollHandler(AbsTwitchPollHandler):
         streamAlertsManager: Optional[StreamAlertsManagerInterface],
         timber: TimberInterface
     ):
-        if streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
-            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
         self.__timber: TimberInterface = timber
@@ -38,10 +36,8 @@ class TwitchPollHandler(AbsTwitchPollHandler):
     ):
         if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
-            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
 
         payload = dataBundle.requirePayload()
         event = payload.getEvent()
@@ -76,12 +72,10 @@ class TwitchPollHandler(AbsTwitchPollHandler):
     ):
         if not utils.isValidStr(title):
             raise ValueError(f'title argument is malformed: \"{title}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(user, UserInterface):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise ValueError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
 
         if subscriptionType is not TwitchWebsocketSubscriptionType.CHANNEL_POLL_BEGIN:
             return

--- a/src/CynanBot/twitch/twitchPollHandler.py
+++ b/src/CynanBot/twitch/twitchPollHandler.py
@@ -22,8 +22,10 @@ class TwitchPollHandler(AbsTwitchPollHandler):
         streamAlertsManager: Optional[StreamAlertsManagerInterface],
         timber: TimberInterface
     ):
-        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
+            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
 
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
         self.__timber: TimberInterface = timber
@@ -36,8 +38,10 @@ class TwitchPollHandler(AbsTwitchPollHandler):
     ):
         if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
+            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
 
         payload = dataBundle.requirePayload()
         event = payload.getEvent()
@@ -72,10 +76,12 @@ class TwitchPollHandler(AbsTwitchPollHandler):
     ):
         if not utils.isValidStr(title):
             raise ValueError(f'title argument is malformed: \"{title}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        elif not isinstance(user, UserInterface):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise ValueError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
 
         if subscriptionType is not TwitchWebsocketSubscriptionType.CHANNEL_POLL_BEGIN:
             return

--- a/src/CynanBot/twitch/twitchPredictionHandler.py
+++ b/src/CynanBot/twitch/twitchPredictionHandler.py
@@ -33,15 +33,11 @@ class TwitchPredictionHandler(AbsTwitchPredictionHandler):
         websocketConnectionServer: Optional[WebsocketConnectionServerInterface],
         websocketEventType: str = 'channelPrediction',
     ):
-        if streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
-            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif twitchPredictionWebsocketUtils is not None and not isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface):
-            raise TypeError(f'twitchPredictionWebsocketUtils argument is malformed: \"{twitchPredictionWebsocketUtils}\"')
-        elif websocketConnectionServer is not None and not isinstance(websocketConnectionServer, WebsocketConnectionServerInterface):
-            raise TypeError(f'websocketConnectionServer argument is malformed: \"{websocketConnectionServer}\"')
-        elif not utils.isValidStr(websocketEventType):
+        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert twitchPredictionWebsocketUtils is None or isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface), f"malformed {twitchPredictionWebsocketUtils=}"
+        assert websocketConnectionServer is None or isinstance(websocketConnectionServer, WebsocketConnectionServerInterface), f"malformed {websocketConnectionServer=}"
+        if not utils.isValidStr(websocketEventType):
             raise TypeError(f'websocketEventType argument is malformed: \"{websocketEventType}\"')
 
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
@@ -58,10 +54,8 @@ class TwitchPredictionHandler(AbsTwitchPredictionHandler):
     ):
         if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
-            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
 
         payload = dataBundle.requirePayload()
         event = payload.getEvent()
@@ -104,12 +98,10 @@ class TwitchPredictionHandler(AbsTwitchPredictionHandler):
     ):
         if not utils.isValidStr(title):
             raise TypeError(f'title argument is malformed: \"{title}\"')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
 
         if subscriptionType is not TwitchWebsocketSubscriptionType.CHANNEL_PREDICTION_BEGIN:
             return
@@ -140,16 +132,12 @@ class TwitchPredictionHandler(AbsTwitchPredictionHandler):
         event: TwitchWebsocketEvent,
         subscriptionType: TwitchWebsocketSubscriptionType
     ):
-        if not isinstance(outcomes, List):
-            raise TypeError(f'outcomes argument is malformed: \"{outcomes}\"')
-        elif not utils.isValidStr(title):
+        assert isinstance(outcomes, List), f"malformed {outcomes=}"
+        if not utils.isValidStr(title):
             raise TypeError(f'title argument is malformed: \"{title}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(event, TwitchWebsocketEvent):
-            raise TypeError(f'event argument is malformed: \"{event}\"')
-        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(event, TwitchWebsocketEvent), f"malformed {event=}"
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
 
         if self.__twitchPredictionWebsocketUtils is None or self.__websocketConnectionServer is None:
             return

--- a/src/CynanBot/twitch/twitchPredictionHandler.py
+++ b/src/CynanBot/twitch/twitchPredictionHandler.py
@@ -33,11 +33,15 @@ class TwitchPredictionHandler(AbsTwitchPredictionHandler):
         websocketConnectionServer: Optional[WebsocketConnectionServerInterface],
         websocketEventType: str = 'channelPrediction',
     ):
-        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert twitchPredictionWebsocketUtils is None or isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface), f"malformed {twitchPredictionWebsocketUtils=}"
-        assert websocketConnectionServer is None or isinstance(websocketConnectionServer, WebsocketConnectionServerInterface), f"malformed {websocketConnectionServer=}"
-        if not utils.isValidStr(websocketEventType):
+        if streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
+            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif twitchPredictionWebsocketUtils is not None and not isinstance(twitchPredictionWebsocketUtils, TwitchPredictionWebsocketUtilsInterface):
+            raise TypeError(f'twitchPredictionWebsocketUtils argument is malformed: \"{twitchPredictionWebsocketUtils}\"')
+        elif websocketConnectionServer is not None and not isinstance(websocketConnectionServer, WebsocketConnectionServerInterface):
+            raise TypeError(f'websocketConnectionServer argument is malformed: \"{websocketConnectionServer}\"')
+        elif not utils.isValidStr(websocketEventType):
             raise TypeError(f'websocketEventType argument is malformed: \"{websocketEventType}\"')
 
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
@@ -54,8 +58,10 @@ class TwitchPredictionHandler(AbsTwitchPredictionHandler):
     ):
         if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
+            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
 
         payload = dataBundle.requirePayload()
         event = payload.getEvent()
@@ -98,10 +104,12 @@ class TwitchPredictionHandler(AbsTwitchPredictionHandler):
     ):
         if not utils.isValidStr(title):
             raise TypeError(f'title argument is malformed: \"{title}\"')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
 
         if subscriptionType is not TwitchWebsocketSubscriptionType.CHANNEL_PREDICTION_BEGIN:
             return
@@ -132,12 +140,16 @@ class TwitchPredictionHandler(AbsTwitchPredictionHandler):
         event: TwitchWebsocketEvent,
         subscriptionType: TwitchWebsocketSubscriptionType
     ):
-        assert isinstance(outcomes, List), f"malformed {outcomes=}"
-        if not utils.isValidStr(title):
+        if not isinstance(outcomes, List):
+            raise TypeError(f'outcomes argument is malformed: \"{outcomes}\"')
+        elif not utils.isValidStr(title):
             raise TypeError(f'title argument is malformed: \"{title}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(event, TwitchWebsocketEvent), f"malformed {event=}"
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(event, TwitchWebsocketEvent):
+            raise TypeError(f'event argument is malformed: \"{event}\"')
+        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
 
         if self.__twitchPredictionWebsocketUtils is None or self.__websocketConnectionServer is None:
             return

--- a/src/CynanBot/twitch/twitchPredictionWebsocketUtils.py
+++ b/src/CynanBot/twitch/twitchPredictionWebsocketUtils.py
@@ -18,10 +18,8 @@ class TwitchPredictionWebsocketUtils(TwitchPredictionWebsocketUtilsInterface):
         event: TwitchWebsocketEvent,
         subscriptionType: TwitchWebsocketSubscriptionType
     ) -> Optional[Dict[str, Any]]:
-        if not isinstance(event, TwitchWebsocketEvent):
-            raise TypeError(f'event argument is malformed: \"{event}\"')
-        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        assert isinstance(event, TwitchWebsocketEvent), f"malformed {event=}"
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
 
         eventId = event.getEventId()
         if not utils.isValidStr(eventId):
@@ -140,8 +138,7 @@ class TwitchPredictionWebsocketUtils(TwitchPredictionWebsocketUtilsInterface):
         self,
         color: TwitchOutcomeColor
     ) -> Dict[str, int]:
-        if not isinstance(color, TwitchOutcomeColor):
-            raise TypeError(f'color argument is malformed: \"{color}\"')
+        assert isinstance(color, TwitchOutcomeColor), f"malformed {color=}"
 
         if color is TwitchOutcomeColor.BLUE:
             return {
@@ -185,8 +182,7 @@ class TwitchPredictionWebsocketUtils(TwitchPredictionWebsocketUtilsInterface):
         self,
         subscriptionType: TwitchWebsocketSubscriptionType
     ) -> str:
-        if not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
 
         if subscriptionType is TwitchWebsocketSubscriptionType.CHANNEL_PREDICTION_BEGIN:
             return 'prediction_begin'

--- a/src/CynanBot/twitch/twitchPredictionWebsocketUtils.py
+++ b/src/CynanBot/twitch/twitchPredictionWebsocketUtils.py
@@ -18,8 +18,10 @@ class TwitchPredictionWebsocketUtils(TwitchPredictionWebsocketUtilsInterface):
         event: TwitchWebsocketEvent,
         subscriptionType: TwitchWebsocketSubscriptionType
     ) -> Optional[Dict[str, Any]]:
-        assert isinstance(event, TwitchWebsocketEvent), f"malformed {event=}"
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        if not isinstance(event, TwitchWebsocketEvent):
+            raise TypeError(f'event argument is malformed: \"{event}\"')
+        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
 
         eventId = event.getEventId()
         if not utils.isValidStr(eventId):
@@ -138,7 +140,8 @@ class TwitchPredictionWebsocketUtils(TwitchPredictionWebsocketUtilsInterface):
         self,
         color: TwitchOutcomeColor
     ) -> Dict[str, int]:
-        assert isinstance(color, TwitchOutcomeColor), f"malformed {color=}"
+        if not isinstance(color, TwitchOutcomeColor):
+            raise TypeError(f'color argument is malformed: \"{color}\"')
 
         if color is TwitchOutcomeColor.BLUE:
             return {
@@ -182,7 +185,8 @@ class TwitchPredictionWebsocketUtils(TwitchPredictionWebsocketUtilsInterface):
         self,
         subscriptionType: TwitchWebsocketSubscriptionType
     ) -> str:
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        if not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
 
         if subscriptionType is TwitchWebsocketSubscriptionType.CHANNEL_PREDICTION_BEGIN:
             return 'prediction_begin'

--- a/src/CynanBot/twitch/twitchRaidHandler.py
+++ b/src/CynanBot/twitch/twitchRaidHandler.py
@@ -22,10 +22,8 @@ class TwitchRaidHandler(AbsTwitchRaidHandler):
         streamAlertsManager: Optional[StreamAlertsManagerInterface],
         timber: TimberInterface
     ):
-        if not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
-            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
 
         self.__timber: TimberInterface = timber
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
@@ -38,10 +36,8 @@ class TwitchRaidHandler(AbsTwitchRaidHandler):
     ):
         if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
-            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
 
         event = dataBundle.requirePayload().getEvent()
 
@@ -79,14 +75,13 @@ class TwitchRaidHandler(AbsTwitchRaidHandler):
     ):
         if not utils.isValidInt(viewers):
             raise TypeError(f'viewers argument is malformed: \"{viewers}\"')
-        elif viewers < 0 or viewers > utils.getIntMaxSafeSize():
+        if viewers < 0 or viewers > utils.getIntMaxSafeSize():
             raise ValueError(f'viewers argument is out of bounds: {viewers}')
-        elif not utils.isValidStr(userId):
+        if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(fromUserName):
+        if not utils.isValidStr(fromUserName):
             raise TypeError(f'fromUserName argument is malformed: \"{fromUserName}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         if self.__streamAlertsManager is None:
             return

--- a/src/CynanBot/twitch/twitchRaidHandler.py
+++ b/src/CynanBot/twitch/twitchRaidHandler.py
@@ -22,8 +22,10 @@ class TwitchRaidHandler(AbsTwitchRaidHandler):
         streamAlertsManager: Optional[StreamAlertsManagerInterface],
         timber: TimberInterface
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
+        if not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
+            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
 
         self.__timber: TimberInterface = timber
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
@@ -36,8 +38,10 @@ class TwitchRaidHandler(AbsTwitchRaidHandler):
     ):
         if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
+            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
 
         event = dataBundle.requirePayload().getEvent()
 
@@ -75,13 +79,14 @@ class TwitchRaidHandler(AbsTwitchRaidHandler):
     ):
         if not utils.isValidInt(viewers):
             raise TypeError(f'viewers argument is malformed: \"{viewers}\"')
-        if viewers < 0 or viewers > utils.getIntMaxSafeSize():
+        elif viewers < 0 or viewers > utils.getIntMaxSafeSize():
             raise ValueError(f'viewers argument is out of bounds: {viewers}')
-        if not utils.isValidStr(userId):
+        elif not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(fromUserName):
+        elif not utils.isValidStr(fromUserName):
             raise TypeError(f'fromUserName argument is malformed: \"{fromUserName}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
 
         if self.__streamAlertsManager is None:
             return

--- a/src/CynanBot/twitch/twitchSubscriptionHandler.py
+++ b/src/CynanBot/twitch/twitchSubscriptionHandler.py
@@ -46,20 +46,13 @@ class TwitchSubscriptionHandler(AbsTwitchSubscriptionHandler):
         twitchTokensUtils: TwitchTokensUtilsInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        if streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
-            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif triviaGameBuilder is not None and not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
-            raise TypeError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
-        elif triviaGameMachine is not None and not isinstance(triviaGameMachine, TriviaGameMachineInterface):
-            raise TypeError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
-        elif not isinstance(twitchChannelProvider, TwitchChannelProvider):
-            raise TypeError(f'twitchChannelProvider argument is malformed: \"{twitchChannelProvider}\"')
-        elif not isinstance(twitchTokensUtils, TwitchTokensUtilsInterface):
-            raise TypeError(f'twitchTokensUtils argument is malformed: \"{twitchTokensUtils}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert triviaGameBuilder is None or isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
+        assert triviaGameMachine is None or isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
+        assert isinstance(twitchChannelProvider, TwitchChannelProvider), f"malformed {twitchChannelProvider=}"
+        assert isinstance(twitchTokensUtils, TwitchTokensUtilsInterface), f"malformed {twitchTokensUtils=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
 
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
         self.__timber: TimberInterface = timber
@@ -77,10 +70,8 @@ class TwitchSubscriptionHandler(AbsTwitchSubscriptionHandler):
     ):
         if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
-            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
 
         payload = dataBundle.requirePayload()
         event = payload.getEvent()
@@ -137,14 +128,10 @@ class TwitchSubscriptionHandler(AbsTwitchSubscriptionHandler):
         communitySubGift: Optional[TwitchCommunitySubGift],
         subscriptionType: TwitchWebsocketSubscriptionType
     ):
-        if not isinstance(tier, TwitchSubscriberTier):
-            raise TypeError(f'tier argument is malformed: \"{tier}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
-        elif communitySubGift is not None and not isinstance(communitySubGift, TwitchCommunitySubGift):
-            raise TypeError(f'communitySubGift argument is malformed: \"{communitySubGift}\"')
-        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        assert isinstance(tier, TwitchSubscriberTier), f"malformed {tier=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
+        assert communitySubGift is None or isinstance(communitySubGift, TwitchCommunitySubGift), f"malformed {communitySubGift=}"
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
 
         if self.__triviaGameBuilder is None or self.__triviaGameMachine is None:
             return
@@ -189,26 +176,20 @@ class TwitchSubscriptionHandler(AbsTwitchSubscriptionHandler):
     ):
         if isAnonymous is not None and not utils.isValidBool(isAnonymous):
             raise TypeError(f'isAnonymous argument is malformed: \"{isAnonymous}\"')
-        elif isGift is not None and not utils.isValidBool(isGift):
+        if isGift is not None and not utils.isValidBool(isGift):
             raise TypeError(f'isGift argument is malformed: \"{isGift}\"')
-        elif message is not None and not isinstance(message, str):
-            raise TypeError(f'message argument is malformed: \"{message}\"')
-        elif userId is not None and not utils.isValidStr(userId):
+        assert message is None or isinstance(message, str), f"malformed {message=}"
+        if userId is not None and not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        elif userInput is not None and not isinstance(userInput, str):
-            raise TypeError(f'userInput argument is malformed: \"{userInput}\"')
-        elif userLogin is not None and not utils.isValidStr(userLogin):
+        assert userInput is None or isinstance(userInput, str), f"malformed {userInput=}"
+        if userLogin is not None and not utils.isValidStr(userLogin):
             raise TypeError(f'userLogin argument is malformed: \"{userLogin}\"')
-        elif userName is not None and not utils.isValidStr(userName):
+        if userName is not None and not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
-        elif communitySubGift is not None and not isinstance(communitySubGift, TwitchCommunitySubGift):
-            raise TypeError(f'communitySubGift argument is malformed: \"{communitySubGift}\"')
-        elif not isinstance(tier, TwitchSubscriberTier):
-            raise TypeError(f'tier argument is malformed: \"{tier}\"')
-        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
-        elif not isinstance(user, UserInterface):
-            raise TypeError(f'user argument is malformed: \"{user}\"')
+        assert communitySubGift is None or isinstance(communitySubGift, TwitchCommunitySubGift), f"malformed {communitySubGift=}"
+        assert isinstance(tier, TwitchSubscriberTier), f"malformed {tier=}"
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        assert isinstance(user, UserInterface), f"malformed {user=}"
 
         if self.__streamAlertsManager is None:
             return

--- a/src/CynanBot/twitch/twitchSubscriptionHandler.py
+++ b/src/CynanBot/twitch/twitchSubscriptionHandler.py
@@ -46,13 +46,20 @@ class TwitchSubscriptionHandler(AbsTwitchSubscriptionHandler):
         twitchTokensUtils: TwitchTokensUtilsInterface,
         userIdsRepository: UserIdsRepositoryInterface
     ):
-        assert streamAlertsManager is None or isinstance(streamAlertsManager, StreamAlertsManagerInterface), f"malformed {streamAlertsManager=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert triviaGameBuilder is None or isinstance(triviaGameBuilder, TriviaGameBuilderInterface), f"malformed {triviaGameBuilder=}"
-        assert triviaGameMachine is None or isinstance(triviaGameMachine, TriviaGameMachineInterface), f"malformed {triviaGameMachine=}"
-        assert isinstance(twitchChannelProvider, TwitchChannelProvider), f"malformed {twitchChannelProvider=}"
-        assert isinstance(twitchTokensUtils, TwitchTokensUtilsInterface), f"malformed {twitchTokensUtils=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        if streamAlertsManager is not None and not isinstance(streamAlertsManager, StreamAlertsManagerInterface):
+            raise TypeError(f'streamAlertsManager argument is malformed: \"{streamAlertsManager}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif triviaGameBuilder is not None and not isinstance(triviaGameBuilder, TriviaGameBuilderInterface):
+            raise TypeError(f'triviaGameBuilder argument is malformed: \"{triviaGameBuilder}\"')
+        elif triviaGameMachine is not None and not isinstance(triviaGameMachine, TriviaGameMachineInterface):
+            raise TypeError(f'triviaGameMachine argument is malformed: \"{triviaGameMachine}\"')
+        elif not isinstance(twitchChannelProvider, TwitchChannelProvider):
+            raise TypeError(f'twitchChannelProvider argument is malformed: \"{twitchChannelProvider}\"')
+        elif not isinstance(twitchTokensUtils, TwitchTokensUtilsInterface):
+            raise TypeError(f'twitchTokensUtils argument is malformed: \"{twitchTokensUtils}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
 
         self.__streamAlertsManager: Optional[StreamAlertsManagerInterface] = streamAlertsManager
         self.__timber: TimberInterface = timber
@@ -70,8 +77,10 @@ class TwitchSubscriptionHandler(AbsTwitchSubscriptionHandler):
     ):
         if not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
+            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
 
         payload = dataBundle.requirePayload()
         event = payload.getEvent()
@@ -128,10 +137,14 @@ class TwitchSubscriptionHandler(AbsTwitchSubscriptionHandler):
         communitySubGift: Optional[TwitchCommunitySubGift],
         subscriptionType: TwitchWebsocketSubscriptionType
     ):
-        assert isinstance(tier, TwitchSubscriberTier), f"malformed {tier=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
-        assert communitySubGift is None or isinstance(communitySubGift, TwitchCommunitySubGift), f"malformed {communitySubGift=}"
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        if not isinstance(tier, TwitchSubscriberTier):
+            raise TypeError(f'tier argument is malformed: \"{tier}\"')
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
+        elif communitySubGift is not None and not isinstance(communitySubGift, TwitchCommunitySubGift):
+            raise TypeError(f'communitySubGift argument is malformed: \"{communitySubGift}\"')
+        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
 
         if self.__triviaGameBuilder is None or self.__triviaGameMachine is None:
             return
@@ -176,20 +189,26 @@ class TwitchSubscriptionHandler(AbsTwitchSubscriptionHandler):
     ):
         if isAnonymous is not None and not utils.isValidBool(isAnonymous):
             raise TypeError(f'isAnonymous argument is malformed: \"{isAnonymous}\"')
-        if isGift is not None and not utils.isValidBool(isGift):
+        elif isGift is not None and not utils.isValidBool(isGift):
             raise TypeError(f'isGift argument is malformed: \"{isGift}\"')
-        assert message is None or isinstance(message, str), f"malformed {message=}"
-        if userId is not None and not utils.isValidStr(userId):
+        elif message is not None and not isinstance(message, str):
+            raise TypeError(f'message argument is malformed: \"{message}\"')
+        elif userId is not None and not utils.isValidStr(userId):
             raise TypeError(f'userId argument is malformed: \"{userId}\"')
-        assert userInput is None or isinstance(userInput, str), f"malformed {userInput=}"
-        if userLogin is not None and not utils.isValidStr(userLogin):
+        elif userInput is not None and not isinstance(userInput, str):
+            raise TypeError(f'userInput argument is malformed: \"{userInput}\"')
+        elif userLogin is not None and not utils.isValidStr(userLogin):
             raise TypeError(f'userLogin argument is malformed: \"{userLogin}\"')
-        if userName is not None and not utils.isValidStr(userName):
+        elif userName is not None and not utils.isValidStr(userName):
             raise TypeError(f'userName argument is malformed: \"{userName}\"')
-        assert communitySubGift is None or isinstance(communitySubGift, TwitchCommunitySubGift), f"malformed {communitySubGift=}"
-        assert isinstance(tier, TwitchSubscriberTier), f"malformed {tier=}"
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
-        assert isinstance(user, UserInterface), f"malformed {user=}"
+        elif communitySubGift is not None and not isinstance(communitySubGift, TwitchCommunitySubGift):
+            raise TypeError(f'communitySubGift argument is malformed: \"{communitySubGift}\"')
+        elif not isinstance(tier, TwitchSubscriberTier):
+            raise TypeError(f'tier argument is malformed: \"{tier}\"')
+        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise TypeError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        elif not isinstance(user, UserInterface):
+            raise TypeError(f'user argument is malformed: \"{user}\"')
 
         if self.__streamAlertsManager is None:
             return

--- a/src/CynanBot/twitch/twitchTokensRepository.py
+++ b/src/CynanBot/twitch/twitchTokensRepository.py
@@ -31,18 +31,12 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
         tokensExpirationBuffer: timedelta = timedelta(minutes = 10),
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise TypeError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
-            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
-        elif seedFileReader is not None and not isinstance(seedFileReader, JsonReaderInterface):
-            raise TypeError(f'seedFileReader argument is malformed: \"{seedFileReader}\"')
-        elif not isinstance(tokensExpirationBuffer, timedelta):
-            raise TypeError(f'tokensExpirationBuffer argument is malformed: \"{tokensExpirationBuffer}\"')
-        elif not isinstance(timeZone, timezone):
-            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
+        assert seedFileReader is None or isinstance(seedFileReader, JsonReaderInterface), f"malformed {seedFileReader=}"
+        assert isinstance(tokensExpirationBuffer, timedelta), f"malformed {tokensExpirationBuffer=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -59,7 +53,7 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
     async def addUser(self, code: str, twitchChannel: str):
         if not utils.isValidStr(code):
             raise TypeError(f'code argument is malformed: \"{code}\"')
-        elif not utils.isValidStr(twitchChannel):
+        if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__timber.log('TwitchTokensRepository', f'Adding user \"{twitchChannel}\"...')
@@ -267,9 +261,8 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
         twitchChannel: str,
         tokensDetails: TwitchTokensDetails
     ):
-        if not isinstance(tokensDetails, TwitchTokensDetails):
-            raise TypeError(f'tokenDetails argument is malformed: \"{tokensDetails}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert isinstance(tokensDetails, TwitchTokensDetails), f"malformed {tokensDetails=}"
+        if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__timber.log('TwitchTokensRepository', f'Refreshing Twitch tokens for \"{twitchChannel}\"...')
@@ -355,9 +348,8 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
         expirationTime: datetime,
         twitchChannel: str
     ):
-        if not isinstance(expirationTime, datetime):
-            raise TypeError(f'expirationTime argument is malformed: \"{expirationTime}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert isinstance(expirationTime, datetime), f"malformed {expirationTime=}"
+        if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -375,8 +367,7 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
         self.__tokenExpirationTimes[twitchChannel.lower()] = expirationTime
 
     def setListener(self, listener: Optional[TwitchTokensRepositoryListener]):
-        if listener is not None and not isinstance(listener, TwitchTokensRepositoryListener):
-            raise TypeError(f'listener argument is malformed: \"{listener}\"')
+        assert listener is None or isinstance(listener, TwitchTokensRepositoryListener), f"malformed {listener=}"
 
         self.__twitchTokensRepositoryListener = listener
 
@@ -385,9 +376,8 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
         tokensDetails: Optional[TwitchTokensDetails],
         twitchChannel: str
     ):
-        if tokensDetails is not None and not isinstance(tokensDetails, TwitchTokensDetails):
-            raise TypeError(f'tokenDetails argument is malformed: \"{tokensDetails}\"')
-        elif not utils.isValidStr(twitchChannel):
+        assert tokensDetails is None or isinstance(tokensDetails, TwitchTokensDetails), f"malformed {tokensDetails=}"
+        if not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()

--- a/src/CynanBot/twitch/twitchTokensRepository.py
+++ b/src/CynanBot/twitch/twitchTokensRepository.py
@@ -31,12 +31,18 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
         tokensExpirationBuffer: timedelta = timedelta(minutes = 10),
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
-        assert seedFileReader is None or isinstance(seedFileReader, JsonReaderInterface), f"malformed {seedFileReader=}"
-        assert isinstance(tokensExpirationBuffer, timedelta), f"malformed {tokensExpirationBuffer=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise TypeError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
+            raise TypeError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
+        elif seedFileReader is not None and not isinstance(seedFileReader, JsonReaderInterface):
+            raise TypeError(f'seedFileReader argument is malformed: \"{seedFileReader}\"')
+        elif not isinstance(tokensExpirationBuffer, timedelta):
+            raise TypeError(f'tokensExpirationBuffer argument is malformed: \"{tokensExpirationBuffer}\"')
+        elif not isinstance(timeZone, timezone):
+            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
         self.__timber: TimberInterface = timber
@@ -53,7 +59,7 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
     async def addUser(self, code: str, twitchChannel: str):
         if not utils.isValidStr(code):
             raise TypeError(f'code argument is malformed: \"{code}\"')
-        if not utils.isValidStr(twitchChannel):
+        elif not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__timber.log('TwitchTokensRepository', f'Adding user \"{twitchChannel}\"...')
@@ -261,8 +267,9 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
         twitchChannel: str,
         tokensDetails: TwitchTokensDetails
     ):
-        assert isinstance(tokensDetails, TwitchTokensDetails), f"malformed {tokensDetails=}"
-        if not utils.isValidStr(twitchChannel):
+        if not isinstance(tokensDetails, TwitchTokensDetails):
+            raise TypeError(f'tokenDetails argument is malformed: \"{tokensDetails}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         self.__timber.log('TwitchTokensRepository', f'Refreshing Twitch tokens for \"{twitchChannel}\"...')
@@ -348,8 +355,9 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
         expirationTime: datetime,
         twitchChannel: str
     ):
-        assert isinstance(expirationTime, datetime), f"malformed {expirationTime=}"
-        if not utils.isValidStr(twitchChannel):
+        if not isinstance(expirationTime, datetime):
+            raise TypeError(f'expirationTime argument is malformed: \"{expirationTime}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -367,7 +375,8 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
         self.__tokenExpirationTimes[twitchChannel.lower()] = expirationTime
 
     def setListener(self, listener: Optional[TwitchTokensRepositoryListener]):
-        assert listener is None or isinstance(listener, TwitchTokensRepositoryListener), f"malformed {listener=}"
+        if listener is not None and not isinstance(listener, TwitchTokensRepositoryListener):
+            raise TypeError(f'listener argument is malformed: \"{listener}\"')
 
         self.__twitchTokensRepositoryListener = listener
 
@@ -376,8 +385,9 @@ class TwitchTokensRepository(TwitchTokensRepositoryInterface):
         tokensDetails: Optional[TwitchTokensDetails],
         twitchChannel: str
     ):
-        assert tokensDetails is None or isinstance(tokensDetails, TwitchTokensDetails), f"malformed {tokensDetails=}"
-        if not utils.isValidStr(twitchChannel):
+        if tokensDetails is not None and not isinstance(tokensDetails, TwitchTokensDetails):
+            raise TypeError(f'tokenDetails argument is malformed: \"{tokensDetails}\"')
+        elif not utils.isValidStr(twitchChannel):
             raise TypeError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
 
         connection = await self.__getDatabaseConnection()

--- a/src/CynanBot/twitch/twitchTokensUtils.py
+++ b/src/CynanBot/twitch/twitchTokensUtils.py
@@ -17,10 +17,8 @@ class TwitchTokensUtils(TwitchTokensUtilsInterface):
         administratorProvider: AdministratorProviderInterface,
         twitchTokensRepository: TwitchTokensRepositoryInterface
     ):
-        if not isinstance(administratorProvider, AdministratorProviderInterface):
-            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__twitchTokensRepository: TwitchTokensRepositoryInterface = twitchTokensRepository

--- a/src/CynanBot/twitch/twitchTokensUtils.py
+++ b/src/CynanBot/twitch/twitchTokensUtils.py
@@ -17,8 +17,10 @@ class TwitchTokensUtils(TwitchTokensUtilsInterface):
         administratorProvider: AdministratorProviderInterface,
         twitchTokensRepository: TwitchTokensRepositoryInterface
     ):
-        assert isinstance(administratorProvider, AdministratorProviderInterface), f"malformed {administratorProvider=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        if not isinstance(administratorProvider, AdministratorProviderInterface):
+            raise TypeError(f'administratorProvider argument is malformed: \"{administratorProvider}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
 
         self.__administratorProvider: AdministratorProviderInterface = administratorProvider
         self.__twitchTokensRepository: TwitchTokensRepositoryInterface = twitchTokensRepository

--- a/src/CynanBot/twitch/twitchUtils.py
+++ b/src/CynanBot/twitch/twitchUtils.py
@@ -28,30 +28,26 @@ class TwitchUtils(TwitchUtilsInterface):
         maxRetries: int = 3,
         timeZone: tzinfo = timezone.utc
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(sentMessageLogger, SentMessageLoggerInterface):
-            raise TypeError(f'sentMessageLogger argument is malformed: \"{sentMessageLogger}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidNum(queueTimeoutSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(sentMessageLogger, SentMessageLoggerInterface), f"malformed {sentMessageLogger=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidNum(queueTimeoutSeconds):
             raise TypeError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
+        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
-        elif not utils.isValidNum(sleepBeforeRetryTimeSeconds):
+        if not utils.isValidNum(sleepBeforeRetryTimeSeconds):
             raise TypeError(f'sleepBeforeRetryTimeSeconds argument is malformed: \"{sleepBeforeRetryTimeSeconds}\"')
-        elif sleepBeforeRetryTimeSeconds < 0.25 or sleepBeforeRetryTimeSeconds > 3:
+        if sleepBeforeRetryTimeSeconds < 0.25 or sleepBeforeRetryTimeSeconds > 3:
             raise ValueError(f'sleepBeforeRetryTimeSeconds argument is out of bounds: {sleepBeforeRetryTimeSeconds}')
-        elif not utils.isValidNum(sleepTimeSeconds):
+        if not utils.isValidNum(sleepTimeSeconds):
             raise TypeError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        elif sleepTimeSeconds < 0.25 or sleepTimeSeconds > 3:
+        if sleepTimeSeconds < 0.25 or sleepTimeSeconds > 3:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        elif not utils.isValidInt(maxRetries):
+        if not utils.isValidInt(maxRetries):
             raise TypeError(f'maxRetries argument is malformed: \"{maxRetries}\"')
-        elif maxRetries < 0 or maxRetries > utils.getIntMaxSafeSize():
+        if maxRetries < 0 or maxRetries > utils.getIntMaxSafeSize():
             raise ValueError(f'maxRetries argument is out of bounds: {maxRetries}')
-        elif not isinstance(timeZone, tzinfo):
-            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
         self.__sentMessageLogger: SentMessageLoggerInterface = sentMessageLogger
@@ -75,17 +71,16 @@ class TwitchUtils(TwitchUtilsInterface):
         maxMessages: int = 3,
         perMessageMaxSize: int = 494
     ):
-        if not isinstance(messageable, TwitchMessageable):
-            raise TypeError(f'messageable argument is malformed: \"{messageable}\"')
-        elif not utils.isValidInt(maxMessages):
+        assert isinstance(messageable, TwitchMessageable), f"malformed {messageable=}"
+        if not utils.isValidInt(maxMessages):
             raise TypeError(f'maxMessages argument is malformed: \"{maxMessages}\"')
-        elif maxMessages < 1 or maxMessages > 5:
+        if maxMessages < 1 or maxMessages > 5:
             raise ValueError(f'maxMessages is out of bounds: {maxMessages}')
-        elif not utils.isValidInt(perMessageMaxSize):
+        if not utils.isValidInt(perMessageMaxSize):
             raise TypeError(f'perMessageMaxSize argument is malformed: \"{perMessageMaxSize}\"')
-        elif perMessageMaxSize < 300:
+        if perMessageMaxSize < 300:
             raise ValueError(f'perMessageMaxSize is too small: {perMessageMaxSize}')
-        elif perMessageMaxSize > self.getMaxMessageSize():
+        if perMessageMaxSize > self.getMaxMessageSize():
             raise ValueError(f'perMessageMaxSize is too big: {perMessageMaxSize} (max size is {self.getMaxMessageSize()})')
 
         if not utils.isValidStr(message):
@@ -115,9 +110,8 @@ class TwitchUtils(TwitchUtilsInterface):
         messageable: TwitchMessageable,
         message: str
     ):
-        if not isinstance(messageable, TwitchMessageable):
-            raise TypeError(f'messageable argument is malformed: \"{messageable}\"')
-        elif not utils.isValidStr(message):
+        assert isinstance(messageable, TwitchMessageable), f"malformed {messageable=}"
+        if not utils.isValidStr(message):
             raise TypeError(f'message argument is malformed: \"{message}\"')
 
         successfullySent = False
@@ -150,8 +144,7 @@ class TwitchUtils(TwitchUtilsInterface):
             self.__timber.log('TwitchUtils', f'Failed to send message after {numberOfRetries} retries (twitchChannel={messageable.getTwitchChannelName()}) (len={len(message)}) \"{message}\"')
 
     async def __sendOutboundMessage(self, outboundMessage: OutboundMessage):
-        if not isinstance(outboundMessage, OutboundMessage):
-            raise TypeError(f'outboundMessage argument is malformed: \"{outboundMessage}\"')
+        assert isinstance(outboundMessage, OutboundMessage), f"malformed {outboundMessage=}"
 
         try:
             self.__messageQueue.put(outboundMessage, block = True, timeout = self.__queueTimeoutSeconds)
@@ -197,13 +190,12 @@ class TwitchUtils(TwitchUtilsInterface):
         delaySeconds: int,
         message: str
     ):
-        if not isinstance(messageable, TwitchMessageable):
-            raise TypeError(f'messageable argument is malformed: \"{messageable}\"')
-        elif not utils.isValidInt(delaySeconds):
+        assert isinstance(messageable, TwitchMessageable), f"malformed {messageable=}"
+        if not utils.isValidInt(delaySeconds):
             raise TypeError(f'delaySeconds argument is malformed: \"{delaySeconds}\"')
-        elif delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
+        if delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
             raise ValueError(f'delaySeconds argument is out of bounds: {delaySeconds}')
-        elif not utils.isValidStr(message):
+        if not utils.isValidStr(message):
             raise TypeError(f'message argument is malformed: \"{message}\"')
 
         now = datetime.now(self.__timeZone)

--- a/src/CynanBot/twitch/twitchUtils.py
+++ b/src/CynanBot/twitch/twitchUtils.py
@@ -28,26 +28,30 @@ class TwitchUtils(TwitchUtilsInterface):
         maxRetries: int = 3,
         timeZone: tzinfo = timezone.utc
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(sentMessageLogger, SentMessageLoggerInterface), f"malformed {sentMessageLogger=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidNum(queueTimeoutSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise TypeError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(sentMessageLogger, SentMessageLoggerInterface):
+            raise TypeError(f'sentMessageLogger argument is malformed: \"{sentMessageLogger}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidNum(queueTimeoutSeconds):
             raise TypeError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
+        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
-        if not utils.isValidNum(sleepBeforeRetryTimeSeconds):
+        elif not utils.isValidNum(sleepBeforeRetryTimeSeconds):
             raise TypeError(f'sleepBeforeRetryTimeSeconds argument is malformed: \"{sleepBeforeRetryTimeSeconds}\"')
-        if sleepBeforeRetryTimeSeconds < 0.25 or sleepBeforeRetryTimeSeconds > 3:
+        elif sleepBeforeRetryTimeSeconds < 0.25 or sleepBeforeRetryTimeSeconds > 3:
             raise ValueError(f'sleepBeforeRetryTimeSeconds argument is out of bounds: {sleepBeforeRetryTimeSeconds}')
-        if not utils.isValidNum(sleepTimeSeconds):
+        elif not utils.isValidNum(sleepTimeSeconds):
             raise TypeError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        if sleepTimeSeconds < 0.25 or sleepTimeSeconds > 3:
+        elif sleepTimeSeconds < 0.25 or sleepTimeSeconds > 3:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        if not utils.isValidInt(maxRetries):
+        elif not utils.isValidInt(maxRetries):
             raise TypeError(f'maxRetries argument is malformed: \"{maxRetries}\"')
-        if maxRetries < 0 or maxRetries > utils.getIntMaxSafeSize():
+        elif maxRetries < 0 or maxRetries > utils.getIntMaxSafeSize():
             raise ValueError(f'maxRetries argument is out of bounds: {maxRetries}')
-        assert isinstance(timeZone, tzinfo), f"malformed {timeZone=}"
+        elif not isinstance(timeZone, tzinfo):
+            raise TypeError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
         self.__sentMessageLogger: SentMessageLoggerInterface = sentMessageLogger
@@ -71,16 +75,17 @@ class TwitchUtils(TwitchUtilsInterface):
         maxMessages: int = 3,
         perMessageMaxSize: int = 494
     ):
-        assert isinstance(messageable, TwitchMessageable), f"malformed {messageable=}"
-        if not utils.isValidInt(maxMessages):
+        if not isinstance(messageable, TwitchMessageable):
+            raise TypeError(f'messageable argument is malformed: \"{messageable}\"')
+        elif not utils.isValidInt(maxMessages):
             raise TypeError(f'maxMessages argument is malformed: \"{maxMessages}\"')
-        if maxMessages < 1 or maxMessages > 5:
+        elif maxMessages < 1 or maxMessages > 5:
             raise ValueError(f'maxMessages is out of bounds: {maxMessages}')
-        if not utils.isValidInt(perMessageMaxSize):
+        elif not utils.isValidInt(perMessageMaxSize):
             raise TypeError(f'perMessageMaxSize argument is malformed: \"{perMessageMaxSize}\"')
-        if perMessageMaxSize < 300:
+        elif perMessageMaxSize < 300:
             raise ValueError(f'perMessageMaxSize is too small: {perMessageMaxSize}')
-        if perMessageMaxSize > self.getMaxMessageSize():
+        elif perMessageMaxSize > self.getMaxMessageSize():
             raise ValueError(f'perMessageMaxSize is too big: {perMessageMaxSize} (max size is {self.getMaxMessageSize()})')
 
         if not utils.isValidStr(message):
@@ -110,8 +115,9 @@ class TwitchUtils(TwitchUtilsInterface):
         messageable: TwitchMessageable,
         message: str
     ):
-        assert isinstance(messageable, TwitchMessageable), f"malformed {messageable=}"
-        if not utils.isValidStr(message):
+        if not isinstance(messageable, TwitchMessageable):
+            raise TypeError(f'messageable argument is malformed: \"{messageable}\"')
+        elif not utils.isValidStr(message):
             raise TypeError(f'message argument is malformed: \"{message}\"')
 
         successfullySent = False
@@ -144,7 +150,8 @@ class TwitchUtils(TwitchUtilsInterface):
             self.__timber.log('TwitchUtils', f'Failed to send message after {numberOfRetries} retries (twitchChannel={messageable.getTwitchChannelName()}) (len={len(message)}) \"{message}\"')
 
     async def __sendOutboundMessage(self, outboundMessage: OutboundMessage):
-        assert isinstance(outboundMessage, OutboundMessage), f"malformed {outboundMessage=}"
+        if not isinstance(outboundMessage, OutboundMessage):
+            raise TypeError(f'outboundMessage argument is malformed: \"{outboundMessage}\"')
 
         try:
             self.__messageQueue.put(outboundMessage, block = True, timeout = self.__queueTimeoutSeconds)
@@ -190,12 +197,13 @@ class TwitchUtils(TwitchUtilsInterface):
         delaySeconds: int,
         message: str
     ):
-        assert isinstance(messageable, TwitchMessageable), f"malformed {messageable=}"
-        if not utils.isValidInt(delaySeconds):
+        if not isinstance(messageable, TwitchMessageable):
+            raise TypeError(f'messageable argument is malformed: \"{messageable}\"')
+        elif not utils.isValidInt(delaySeconds):
             raise TypeError(f'delaySeconds argument is malformed: \"{delaySeconds}\"')
-        if delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
+        elif delaySeconds < 1 or delaySeconds > utils.getIntMaxSafeSize():
             raise ValueError(f'delaySeconds argument is out of bounds: {delaySeconds}')
-        if not utils.isValidStr(message):
+        elif not utils.isValidStr(message):
             raise TypeError(f'message argument is malformed: \"{message}\"')
 
         now = datetime.now(self.__timeZone)

--- a/src/CynanBot/twitch/twitchWebsocketDataBundleHandler.py
+++ b/src/CynanBot/twitch/twitchWebsocketDataBundleHandler.py
@@ -38,24 +38,15 @@ class TwitchWebsocketDataBundleHandler(TwitchWebsocketDataBundleListener):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if channelPointRedemptionHandler is not None and not isinstance(channelPointRedemptionHandler, AbsTwitchChannelPointRedemptionHandler):
-            raise TypeError(f'channelPointRedemptionHandler argument is malformed: \"{channelPointRedemptionHandler}\"')
-        elif cheerHandler is not None and not isinstance(cheerHandler, AbsTwitchCheerHandler):
-            raise TypeError(f'cheerHandler argument is malformed: \"{cheerHandler}\"')
-        elif pollHandler is not None and not isinstance(pollHandler, AbsTwitchPollHandler):
-            raise TypeError(f'pollHandler argument is malformed: \"{pollHandler}\"')
-        elif predictionHandler is not None and not isinstance(predictionHandler, AbsTwitchPredictionHandler):
-            raise TypeError(f'predictionHandler argument is malformed: \"{predictionHandler}\"')
-        elif raidHandler is not None and not isinstance(raidHandler, AbsTwitchRaidHandler):
-            raise TypeError(f'raidHandler argument is malformed: \"{raidHandler}\"')
-        elif subscriptionHandler is not None and not isinstance(subscriptionHandler, AbsTwitchSubscriptionHandler):
-            raise TypeError(f'subscriptionHandler argument is malformed: \"{subscriptionHandler}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert channelPointRedemptionHandler is None or isinstance(channelPointRedemptionHandler, AbsTwitchChannelPointRedemptionHandler), f"malformed {channelPointRedemptionHandler=}"
+        assert cheerHandler is None or isinstance(cheerHandler, AbsTwitchCheerHandler), f"malformed {cheerHandler=}"
+        assert pollHandler is None or isinstance(pollHandler, AbsTwitchPollHandler), f"malformed {pollHandler=}"
+        assert predictionHandler is None or isinstance(predictionHandler, AbsTwitchPredictionHandler), f"malformed {predictionHandler=}"
+        assert raidHandler is None or isinstance(raidHandler, AbsTwitchRaidHandler), f"malformed {raidHandler=}"
+        assert subscriptionHandler is None or isinstance(subscriptionHandler, AbsTwitchSubscriptionHandler), f"malformed {subscriptionHandler=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__channelPointRedemptionHandler: Optional[AbsTwitchChannelPointRedemptionHandler] = channelPointRedemptionHandler
         self.__cheerHandler: Optional[AbsTwitchCheerHandler] = cheerHandler
@@ -111,8 +102,7 @@ class TwitchWebsocketDataBundleHandler(TwitchWebsocketDataBundleListener):
             or subscriptionType is TwitchWebsocketSubscriptionType.SUBSCRIPTION_MESSAGE
 
     async def onNewWebsocketDataBundle(self, dataBundle: TwitchWebsocketDataBundle):
-        if not isinstance(dataBundle, TwitchWebsocketDataBundle):
-            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
+        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
 
         payload = dataBundle.getPayload()
         if payload is None:
@@ -204,8 +194,7 @@ class TwitchWebsocketDataBundleHandler(TwitchWebsocketDataBundleListener):
     async def __persistUserInfo(self, event: Optional[TwitchWebsocketEvent]):
         if event is None:
             return
-        elif not isinstance(event, TwitchWebsocketEvent):
-            raise TypeError(f'event argument is malformed: \"{event}\"')
+        elassert isinstance(event, TwitchWebsocketEvent), f"malformed {event=}"
 
         await self.__userIdsRepository.optionallySetUser(
             userId = event.getBroadcasterUserId(),

--- a/src/CynanBot/twitch/twitchWebsocketDataBundleHandler.py
+++ b/src/CynanBot/twitch/twitchWebsocketDataBundleHandler.py
@@ -38,15 +38,24 @@ class TwitchWebsocketDataBundleHandler(TwitchWebsocketDataBundleListener):
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert channelPointRedemptionHandler is None or isinstance(channelPointRedemptionHandler, AbsTwitchChannelPointRedemptionHandler), f"malformed {channelPointRedemptionHandler=}"
-        assert cheerHandler is None or isinstance(cheerHandler, AbsTwitchCheerHandler), f"malformed {cheerHandler=}"
-        assert pollHandler is None or isinstance(pollHandler, AbsTwitchPollHandler), f"malformed {pollHandler=}"
-        assert predictionHandler is None or isinstance(predictionHandler, AbsTwitchPredictionHandler), f"malformed {predictionHandler=}"
-        assert raidHandler is None or isinstance(raidHandler, AbsTwitchRaidHandler), f"malformed {raidHandler=}"
-        assert subscriptionHandler is None or isinstance(subscriptionHandler, AbsTwitchSubscriptionHandler), f"malformed {subscriptionHandler=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if channelPointRedemptionHandler is not None and not isinstance(channelPointRedemptionHandler, AbsTwitchChannelPointRedemptionHandler):
+            raise TypeError(f'channelPointRedemptionHandler argument is malformed: \"{channelPointRedemptionHandler}\"')
+        elif cheerHandler is not None and not isinstance(cheerHandler, AbsTwitchCheerHandler):
+            raise TypeError(f'cheerHandler argument is malformed: \"{cheerHandler}\"')
+        elif pollHandler is not None and not isinstance(pollHandler, AbsTwitchPollHandler):
+            raise TypeError(f'pollHandler argument is malformed: \"{pollHandler}\"')
+        elif predictionHandler is not None and not isinstance(predictionHandler, AbsTwitchPredictionHandler):
+            raise TypeError(f'predictionHandler argument is malformed: \"{predictionHandler}\"')
+        elif raidHandler is not None and not isinstance(raidHandler, AbsTwitchRaidHandler):
+            raise TypeError(f'raidHandler argument is malformed: \"{raidHandler}\"')
+        elif subscriptionHandler is not None and not isinstance(subscriptionHandler, AbsTwitchSubscriptionHandler):
+            raise TypeError(f'subscriptionHandler argument is malformed: \"{subscriptionHandler}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__channelPointRedemptionHandler: Optional[AbsTwitchChannelPointRedemptionHandler] = channelPointRedemptionHandler
         self.__cheerHandler: Optional[AbsTwitchCheerHandler] = cheerHandler
@@ -102,7 +111,8 @@ class TwitchWebsocketDataBundleHandler(TwitchWebsocketDataBundleListener):
             or subscriptionType is TwitchWebsocketSubscriptionType.SUBSCRIPTION_MESSAGE
 
     async def onNewWebsocketDataBundle(self, dataBundle: TwitchWebsocketDataBundle):
-        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
+        if not isinstance(dataBundle, TwitchWebsocketDataBundle):
+            raise TypeError(f'dataBundle argument is malformed: \"{dataBundle}\"')
 
         payload = dataBundle.getPayload()
         if payload is None:
@@ -194,7 +204,8 @@ class TwitchWebsocketDataBundleHandler(TwitchWebsocketDataBundleListener):
     async def __persistUserInfo(self, event: Optional[TwitchWebsocketEvent]):
         if event is None:
             return
-        elassert isinstance(event, TwitchWebsocketEvent), f"malformed {event=}"
+        elif not isinstance(event, TwitchWebsocketEvent):
+            raise TypeError(f'event argument is malformed: \"{event}\"')
 
         await self.__userIdsRepository.optionallySetUser(
             userId = event.getBroadcasterUserId(),

--- a/src/CynanBot/twitch/websocket/twitchWebsocketAllowedUsersRepository.py
+++ b/src/CynanBot/twitch/websocket/twitchWebsocketAllowedUsersRepository.py
@@ -21,14 +21,10 @@ class TwitchWebsocketAllowedUsersRepository(TwitchWebsocketAllowedUsersRepositor
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        if not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
-            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
-        elif not isinstance(usersRepository, UsersRepositoryInterface):
-            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
+        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
 
         self.__timber: TimberInterface = timber
         self.__twitchTokensRepository: TwitchTokensRepositoryInterface = twitchTokensRepository

--- a/src/CynanBot/twitch/websocket/twitchWebsocketAllowedUsersRepository.py
+++ b/src/CynanBot/twitch/websocket/twitchWebsocketAllowedUsersRepository.py
@@ -21,10 +21,14 @@ class TwitchWebsocketAllowedUsersRepository(TwitchWebsocketAllowedUsersRepositor
         userIdsRepository: UserIdsRepositoryInterface,
         usersRepository: UsersRepositoryInterface
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(userIdsRepository, UserIdsRepositoryInterface), f"malformed {userIdsRepository=}"
-        assert isinstance(usersRepository, UsersRepositoryInterface), f"malformed {usersRepository=}"
+        if not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise TypeError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(userIdsRepository, UserIdsRepositoryInterface):
+            raise TypeError(f'userIdsRepository argument is malformed: \"{userIdsRepository}\"')
+        elif not isinstance(usersRepository, UsersRepositoryInterface):
+            raise TypeError(f'usersRepository argument is malformed: \"{usersRepository}\"')
 
         self.__timber: TimberInterface = timber
         self.__twitchTokensRepository: TwitchTokensRepositoryInterface = twitchTokensRepository

--- a/src/CynanBot/twitch/websocket/twitchWebsocketClient.py
+++ b/src/CynanBot/twitch/websocket/twitchWebsocketClient.py
@@ -73,42 +73,33 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
         maxMessageAge: timedelta = timedelta(minutes = 3),
         timeZone: tzinfo = timezone.utc
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
-            raise ValueError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
-        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
-            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
-        elif not isinstance(twitchWebsocketAllowedUsersRepository, TwitchWebsocketAllowedUsersRepositoryInterface):
-            raise ValueError(f'twitchWebsocketAllowedUsersRepository argument is malformed: \"{twitchWebsocketAllowedUsersRepository}\"')
-        elif not isinstance(twitchWebsocketJsonMapper, TwitchWebsocketJsonMapperInterface):
-            raise ValueError(f'twitchWebsocketJsonMapper argument is malformed: \"{twitchWebsocketJsonMapper}\"')
-        elif not utils.isValidNum(queueSleepTimeSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
+        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
+        assert isinstance(twitchWebsocketAllowedUsersRepository, TwitchWebsocketAllowedUsersRepositoryInterface), f"malformed {twitchWebsocketAllowedUsersRepository=}"
+        assert isinstance(twitchWebsocketJsonMapper, TwitchWebsocketJsonMapperInterface), f"malformed {twitchWebsocketJsonMapper=}"
+        if not utils.isValidNum(queueSleepTimeSeconds):
             raise ValueError(f'queueSleepTimeSeconds argument is malformed: \"{queueSleepTimeSeconds}\"')
-        elif queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 15:
+        if queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 15:
             raise ValueError(f'queueSleepTimeSeconds argument is out of bounds: {queueSleepTimeSeconds}')
-        elif not utils.isValidNum(queueTimeoutSeconds):
+        if not utils.isValidNum(queueTimeoutSeconds):
             raise ValueError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
+        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
-        elif not utils.isValidNum(websocketCreationDelayTimeSeconds):
+        if not utils.isValidNum(websocketCreationDelayTimeSeconds):
             raise ValueError(f'websocketCreationDelayTimeSeconds argument is malformed: \"{websocketCreationDelayTimeSeconds}\"')
-        elif websocketCreationDelayTimeSeconds < 0.1 or websocketCreationDelayTimeSeconds > 8:
+        if websocketCreationDelayTimeSeconds < 0.1 or websocketCreationDelayTimeSeconds > 8:
             raise ValueError(f'websocketCreationDelayTimeSeconds argument is out of bounds: {websocketCreationDelayTimeSeconds}')
-        elif not utils.isValidNum(websocketSleepTimeSeconds):
+        if not utils.isValidNum(websocketSleepTimeSeconds):
             raise ValueError(f'websocketSleepTimeSeconds argument is malformed: \"{websocketSleepTimeSeconds}\"')
-        elif websocketSleepTimeSeconds < 3 or websocketSleepTimeSeconds > 15:
+        if websocketSleepTimeSeconds < 3 or websocketSleepTimeSeconds > 15:
             raise ValueError(f'websocketSleepTimeSeconds argument is out of bounds: {websocketSleepTimeSeconds}')
-        elif not isinstance(subscriptionTypes, Set):
-            raise ValueError(f'subscriptionTypes argument is malformed: \"{subscriptionTypes}\"')
-        elif not utils.isValidUrl(twitchWebsocketUrl):
+        assert isinstance(subscriptionTypes, Set), f"malformed {subscriptionTypes=}"
+        if not utils.isValidUrl(twitchWebsocketUrl):
             raise ValueError(f'twitchWebsocketUrl argument is malformed: \"{twitchWebsocketUrl}\"')
-        elif not isinstance(maxMessageAge, timedelta):
-            raise ValueError(f'maxMessageAge argument is malformed: \"{maxMessageAge}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(maxMessageAge, timedelta), f"malformed {maxMessageAge=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
         self.__timber: TimberInterface = timber
@@ -136,8 +127,7 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
     async def __createEventSubSubscription(self, sessionId: str, user: TwitchWebsocketUser):
         if not utils.isValidStr(sessionId):
             raise ValueError(f'sessionId argument is malformed: \"{sessionId}\"')
-        elif not isinstance(user, TwitchWebsocketUser):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
 
         transport = TwitchWebsocketTransport(
             sessionId = sessionId,
@@ -186,10 +176,8 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
         user: TwitchWebsocketUser,
         subscriptionType: TwitchWebsocketSubscriptionType
     ) -> TwitchWebsocketCondition:
-        if not isinstance(user, TwitchWebsocketUser):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
-            raise ValueError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
+        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
+        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
 
         if subscriptionType is TwitchWebsocketSubscriptionType.CHANNEL_POINTS_REDEMPTION:
             return TwitchWebsocketCondition(
@@ -239,10 +227,8 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
         user: TwitchWebsocketUser,
         dataBundle: TwitchWebsocketDataBundle
     ):
-        if not isinstance(user, TwitchWebsocketUser):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
-        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
-            raise ValueError(f'dataBundle argument is malformed: \"{dataBundle}\"')
+        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
+        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
 
         payload = dataBundle.getPayload()
 
@@ -282,10 +268,8 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
     ):
         if not utils.isValidStr(newSessionId):
             raise ValueError(f'newSessionId argument is malformed: \"{newSessionId}\"')
-        elif oldSessionId is not None and not isinstance(oldSessionId, str):
-            raise ValueError(f'oldSessionId argument is malformed: \"{oldSessionId}\"')
-        elif not isinstance(user, TwitchWebsocketUser):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert oldSessionId is None or isinstance(oldSessionId, str), f"malformed {oldSessionId=}"
+        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
 
         self.__sessionIdFor[user] = newSessionId
         self.__timber.log('TwitchWebsocketClient', f'Session ID for \"{user}\" has been changed to \"{newSessionId}\" from \"{oldSessionId}\". Creating EventSub subscription(s)...')
@@ -303,17 +287,15 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
     ):
         if not utils.isValidUrl(newTwitchWebsocketUrl):
             raise ValueError(f'newTwitchWebsocketUrl argument is malformed: \"{newTwitchWebsocketUrl}\"')
-        elif not utils.isValidUrl(oldTwitchWebsocketUrl):
+        if not utils.isValidUrl(oldTwitchWebsocketUrl):
             raise ValueError(f'oldTwitchWebsocketUrl argument is malformed: \"{oldTwitchWebsocketUrl}\"')
-        elif not isinstance(user, TwitchWebsocketUser):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
 
         self.__twitchWebsocketUrlFor[user] = newTwitchWebsocketUrl
         self.__timber.log('TwitchWebsocketClient', f'Twitch websocket URL for \"{user}\" has been changed to \"{newTwitchWebsocketUrl}\" from \"{oldTwitchWebsocketUrl}\"')
 
     async def __isValidMessage(self, dataBundle: TwitchWebsocketDataBundle) -> bool:
-        if not isinstance(dataBundle, TwitchWebsocketDataBundle):
-            raise ValueError(f'dataBundle argument is malformed: \"{dataBundle}\"')
+        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
 
         # ensure that this isn't a message we've seen before
         if self.__messageIdCache.contains(dataBundle.getMetadata().getMessageId()):
@@ -337,8 +319,7 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
         message: Optional[Any],
         user: TwitchWebsocketUser
     ) -> Optional[List[TwitchWebsocketDataBundle]]:
-        if not isinstance(user, TwitchWebsocketUser):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
 
         if message is None:
             self.__timber.log('TwitchWebsocketClient', f'Received message object that is None: \"{message}\"')
@@ -379,8 +360,7 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
             return None
 
     def setDataBundleListener(self, listener: Optional[TwitchWebsocketDataBundleListener]):
-        if listener is not None and not isinstance(listener, TwitchWebsocketDataBundleListener):
-            raise ValueError(f'listener argument is malformed: \"{listener}\"')
+        assert listener is None or isinstance(listener, TwitchWebsocketDataBundleListener), f"malformed {listener=}"
 
         self.__dataBundleListener = listener
 
@@ -420,8 +400,7 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
             await asyncio.sleep(self.__queueSleepTimeSeconds)
 
     async def __startWebsocketConnectionFor(self, user: TwitchWebsocketUser):
-        if not isinstance(user, TwitchWebsocketUser):
-            raise ValueError(f'user argument is malformed: \"{user}\"')
+        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
 
         while True:
             twitchWebsocketUrl = self.__twitchWebsocketUrlFor[user]
@@ -455,8 +434,7 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
         self.__timber.log('TwitchWebsocketClient', f'Finished establishing websocket connections for {len(users)} user(s)')
 
     async def __submitDataBundle(self, dataBundle: TwitchWebsocketDataBundle):
-        if not isinstance(dataBundle, TwitchWebsocketDataBundle):
-            raise ValueError(f'dataBundle argument is malformed: \"{dataBundle}\"')
+        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
 
         try:
             self.__dataBundleQueue.put(dataBundle, block = True, timeout = self.__queueTimeoutSeconds)

--- a/src/CynanBot/twitch/websocket/twitchWebsocketClient.py
+++ b/src/CynanBot/twitch/websocket/twitchWebsocketClient.py
@@ -73,33 +73,42 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
         maxMessageAge: timedelta = timedelta(minutes = 3),
         timeZone: tzinfo = timezone.utc
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
-        assert isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface), f"malformed {twitchTokensRepository=}"
-        assert isinstance(twitchWebsocketAllowedUsersRepository, TwitchWebsocketAllowedUsersRepositoryInterface), f"malformed {twitchWebsocketAllowedUsersRepository=}"
-        assert isinstance(twitchWebsocketJsonMapper, TwitchWebsocketJsonMapperInterface), f"malformed {twitchWebsocketJsonMapper=}"
-        if not utils.isValidNum(queueSleepTimeSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
+            raise ValueError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
+        elif not isinstance(twitchTokensRepository, TwitchTokensRepositoryInterface):
+            raise ValueError(f'twitchTokensRepository argument is malformed: \"{twitchTokensRepository}\"')
+        elif not isinstance(twitchWebsocketAllowedUsersRepository, TwitchWebsocketAllowedUsersRepositoryInterface):
+            raise ValueError(f'twitchWebsocketAllowedUsersRepository argument is malformed: \"{twitchWebsocketAllowedUsersRepository}\"')
+        elif not isinstance(twitchWebsocketJsonMapper, TwitchWebsocketJsonMapperInterface):
+            raise ValueError(f'twitchWebsocketJsonMapper argument is malformed: \"{twitchWebsocketJsonMapper}\"')
+        elif not utils.isValidNum(queueSleepTimeSeconds):
             raise ValueError(f'queueSleepTimeSeconds argument is malformed: \"{queueSleepTimeSeconds}\"')
-        if queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 15:
+        elif queueSleepTimeSeconds < 1 or queueSleepTimeSeconds > 15:
             raise ValueError(f'queueSleepTimeSeconds argument is out of bounds: {queueSleepTimeSeconds}')
-        if not utils.isValidNum(queueTimeoutSeconds):
+        elif not utils.isValidNum(queueTimeoutSeconds):
             raise ValueError(f'queueTimeoutSeconds argument is malformed: \"{queueTimeoutSeconds}\"')
-        if queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
+        elif queueTimeoutSeconds < 1 or queueTimeoutSeconds > 5:
             raise ValueError(f'queueTimeoutSeconds argument is out of bounds: {queueTimeoutSeconds}')
-        if not utils.isValidNum(websocketCreationDelayTimeSeconds):
+        elif not utils.isValidNum(websocketCreationDelayTimeSeconds):
             raise ValueError(f'websocketCreationDelayTimeSeconds argument is malformed: \"{websocketCreationDelayTimeSeconds}\"')
-        if websocketCreationDelayTimeSeconds < 0.1 or websocketCreationDelayTimeSeconds > 8:
+        elif websocketCreationDelayTimeSeconds < 0.1 or websocketCreationDelayTimeSeconds > 8:
             raise ValueError(f'websocketCreationDelayTimeSeconds argument is out of bounds: {websocketCreationDelayTimeSeconds}')
-        if not utils.isValidNum(websocketSleepTimeSeconds):
+        elif not utils.isValidNum(websocketSleepTimeSeconds):
             raise ValueError(f'websocketSleepTimeSeconds argument is malformed: \"{websocketSleepTimeSeconds}\"')
-        if websocketSleepTimeSeconds < 3 or websocketSleepTimeSeconds > 15:
+        elif websocketSleepTimeSeconds < 3 or websocketSleepTimeSeconds > 15:
             raise ValueError(f'websocketSleepTimeSeconds argument is out of bounds: {websocketSleepTimeSeconds}')
-        assert isinstance(subscriptionTypes, Set), f"malformed {subscriptionTypes=}"
-        if not utils.isValidUrl(twitchWebsocketUrl):
+        elif not isinstance(subscriptionTypes, Set):
+            raise ValueError(f'subscriptionTypes argument is malformed: \"{subscriptionTypes}\"')
+        elif not utils.isValidUrl(twitchWebsocketUrl):
             raise ValueError(f'twitchWebsocketUrl argument is malformed: \"{twitchWebsocketUrl}\"')
-        assert isinstance(maxMessageAge, timedelta), f"malformed {maxMessageAge=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        elif not isinstance(maxMessageAge, timedelta):
+            raise ValueError(f'maxMessageAge argument is malformed: \"{maxMessageAge}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
         self.__timber: TimberInterface = timber
@@ -127,7 +136,8 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
     async def __createEventSubSubscription(self, sessionId: str, user: TwitchWebsocketUser):
         if not utils.isValidStr(sessionId):
             raise ValueError(f'sessionId argument is malformed: \"{sessionId}\"')
-        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
+        elif not isinstance(user, TwitchWebsocketUser):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         transport = TwitchWebsocketTransport(
             sessionId = sessionId,
@@ -176,8 +186,10 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
         user: TwitchWebsocketUser,
         subscriptionType: TwitchWebsocketSubscriptionType
     ) -> TwitchWebsocketCondition:
-        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
-        assert isinstance(subscriptionType, TwitchWebsocketSubscriptionType), f"malformed {subscriptionType=}"
+        if not isinstance(user, TwitchWebsocketUser):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(subscriptionType, TwitchWebsocketSubscriptionType):
+            raise ValueError(f'subscriptionType argument is malformed: \"{subscriptionType}\"')
 
         if subscriptionType is TwitchWebsocketSubscriptionType.CHANNEL_POINTS_REDEMPTION:
             return TwitchWebsocketCondition(
@@ -227,8 +239,10 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
         user: TwitchWebsocketUser,
         dataBundle: TwitchWebsocketDataBundle
     ):
-        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
-        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
+        if not isinstance(user, TwitchWebsocketUser):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
+        elif not isinstance(dataBundle, TwitchWebsocketDataBundle):
+            raise ValueError(f'dataBundle argument is malformed: \"{dataBundle}\"')
 
         payload = dataBundle.getPayload()
 
@@ -268,8 +282,10 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
     ):
         if not utils.isValidStr(newSessionId):
             raise ValueError(f'newSessionId argument is malformed: \"{newSessionId}\"')
-        assert oldSessionId is None or isinstance(oldSessionId, str), f"malformed {oldSessionId=}"
-        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
+        elif oldSessionId is not None and not isinstance(oldSessionId, str):
+            raise ValueError(f'oldSessionId argument is malformed: \"{oldSessionId}\"')
+        elif not isinstance(user, TwitchWebsocketUser):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         self.__sessionIdFor[user] = newSessionId
         self.__timber.log('TwitchWebsocketClient', f'Session ID for \"{user}\" has been changed to \"{newSessionId}\" from \"{oldSessionId}\". Creating EventSub subscription(s)...')
@@ -287,15 +303,17 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
     ):
         if not utils.isValidUrl(newTwitchWebsocketUrl):
             raise ValueError(f'newTwitchWebsocketUrl argument is malformed: \"{newTwitchWebsocketUrl}\"')
-        if not utils.isValidUrl(oldTwitchWebsocketUrl):
+        elif not utils.isValidUrl(oldTwitchWebsocketUrl):
             raise ValueError(f'oldTwitchWebsocketUrl argument is malformed: \"{oldTwitchWebsocketUrl}\"')
-        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
+        elif not isinstance(user, TwitchWebsocketUser):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         self.__twitchWebsocketUrlFor[user] = newTwitchWebsocketUrl
         self.__timber.log('TwitchWebsocketClient', f'Twitch websocket URL for \"{user}\" has been changed to \"{newTwitchWebsocketUrl}\" from \"{oldTwitchWebsocketUrl}\"')
 
     async def __isValidMessage(self, dataBundle: TwitchWebsocketDataBundle) -> bool:
-        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
+        if not isinstance(dataBundle, TwitchWebsocketDataBundle):
+            raise ValueError(f'dataBundle argument is malformed: \"{dataBundle}\"')
 
         # ensure that this isn't a message we've seen before
         if self.__messageIdCache.contains(dataBundle.getMetadata().getMessageId()):
@@ -319,7 +337,8 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
         message: Optional[Any],
         user: TwitchWebsocketUser
     ) -> Optional[List[TwitchWebsocketDataBundle]]:
-        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
+        if not isinstance(user, TwitchWebsocketUser):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         if message is None:
             self.__timber.log('TwitchWebsocketClient', f'Received message object that is None: \"{message}\"')
@@ -360,7 +379,8 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
             return None
 
     def setDataBundleListener(self, listener: Optional[TwitchWebsocketDataBundleListener]):
-        assert listener is None or isinstance(listener, TwitchWebsocketDataBundleListener), f"malformed {listener=}"
+        if listener is not None and not isinstance(listener, TwitchWebsocketDataBundleListener):
+            raise ValueError(f'listener argument is malformed: \"{listener}\"')
 
         self.__dataBundleListener = listener
 
@@ -400,7 +420,8 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
             await asyncio.sleep(self.__queueSleepTimeSeconds)
 
     async def __startWebsocketConnectionFor(self, user: TwitchWebsocketUser):
-        assert isinstance(user, TwitchWebsocketUser), f"malformed {user=}"
+        if not isinstance(user, TwitchWebsocketUser):
+            raise ValueError(f'user argument is malformed: \"{user}\"')
 
         while True:
             twitchWebsocketUrl = self.__twitchWebsocketUrlFor[user]
@@ -434,7 +455,8 @@ class TwitchWebsocketClient(TwitchWebsocketClientInterface):
         self.__timber.log('TwitchWebsocketClient', f'Finished establishing websocket connections for {len(users)} user(s)')
 
     async def __submitDataBundle(self, dataBundle: TwitchWebsocketDataBundle):
-        assert isinstance(dataBundle, TwitchWebsocketDataBundle), f"malformed {dataBundle=}"
+        if not isinstance(dataBundle, TwitchWebsocketDataBundle):
+            raise ValueError(f'dataBundle argument is malformed: \"{dataBundle}\"')
 
         try:
             self.__dataBundleQueue.put(dataBundle, block = True, timeout = self.__queueTimeoutSeconds)

--- a/src/CynanBot/twitch/websocket/twitchWebsocketJsonMapper.py
+++ b/src/CynanBot/twitch/websocket/twitchWebsocketJsonMapper.py
@@ -49,8 +49,7 @@ from CynanBot.twitch.websocket.twitchWebsocketJsonMapperInterface import \
 class TwitchWebsocketJsonMapper(TwitchWebsocketJsonMapperInterface):
 
     def __init__(self, timber: TimberInterface):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
 
         self.__timber: TimberInterface = timber
 

--- a/src/CynanBot/twitch/websocket/twitchWebsocketJsonMapper.py
+++ b/src/CynanBot/twitch/websocket/twitchWebsocketJsonMapper.py
@@ -49,7 +49,8 @@ from CynanBot.twitch.websocket.twitchWebsocketJsonMapperInterface import \
 class TwitchWebsocketJsonMapper(TwitchWebsocketJsonMapperInterface):
 
     def __init__(self, timber: TimberInterface):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
 
         self.__timber: TimberInterface = timber
 

--- a/src/CynanBot/users/modifyUserData.py
+++ b/src/CynanBot/users/modifyUserData.py
@@ -10,11 +10,10 @@ class ModifyUserData():
         userId: str,
         userName: str
     ):
-        if not isinstance(actionType, ModifyUserActionType):
-            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
-        elif not utils.isValidStr(userId):
+        assert isinstance(actionType, ModifyUserActionType), f"malformed {actionType=}"
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__actionType: ModifyUserActionType = actionType

--- a/src/CynanBot/users/modifyUserData.py
+++ b/src/CynanBot/users/modifyUserData.py
@@ -10,10 +10,11 @@ class ModifyUserData():
         userId: str,
         userName: str
     ):
-        assert isinstance(actionType, ModifyUserActionType), f"malformed {actionType=}"
-        if not utils.isValidStr(userId):
+        if not isinstance(actionType, ModifyUserActionType):
+            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__actionType: ModifyUserActionType = actionType

--- a/src/CynanBot/users/modifyUserDataHelper.py
+++ b/src/CynanBot/users/modifyUserDataHelper.py
@@ -17,12 +17,9 @@ class ModifyUserDataHelper(Clearable):
         timeToLive: timedelta = timedelta(minutes = 2, seconds = 30),
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(timeToLive, timedelta):
-            raise ValueError(f'timeToLive argument is malformed: \"{timeToLive}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(timeToLive, timedelta), f"malformed {timeToLive=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__timber: TimberInterface = timber
         self.__timeToLive: timedelta = timeToLive
@@ -61,8 +58,7 @@ class ModifyUserDataHelper(Clearable):
         await modifyUserEventListener.onModifyUserEvent(modifyUserData)
 
     def setModifyUserEventListener(self, listener: Optional[ModifyUserEventListener]):
-        if listener is not None and not isinstance(listener, ModifyUserEventListener):
-            raise ValueError(f'listener argument is malformed: \"{listener}\"')
+        assert listener is None or isinstance(listener, ModifyUserEventListener), f"malformed {listener=}"
 
         self.__modifyUserEventListener = listener
 
@@ -72,13 +68,12 @@ class ModifyUserDataHelper(Clearable):
         userId: str,
         userName: str
     ):
-        if not isinstance(actionType, ModifyUserActionType):
-            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
-        elif not utils.isValidStr(userId):
+        assert isinstance(actionType, ModifyUserActionType), f"malformed {actionType=}"
+        if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif userId == '0':
+        if userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__setTime = datetime.now(self.__timeZone)

--- a/src/CynanBot/users/modifyUserDataHelper.py
+++ b/src/CynanBot/users/modifyUserDataHelper.py
@@ -17,9 +17,12 @@ class ModifyUserDataHelper(Clearable):
         timeToLive: timedelta = timedelta(minutes = 2, seconds = 30),
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(timeToLive, timedelta), f"malformed {timeToLive=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        if not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(timeToLive, timedelta):
+            raise ValueError(f'timeToLive argument is malformed: \"{timeToLive}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__timber: TimberInterface = timber
         self.__timeToLive: timedelta = timeToLive
@@ -58,7 +61,8 @@ class ModifyUserDataHelper(Clearable):
         await modifyUserEventListener.onModifyUserEvent(modifyUserData)
 
     def setModifyUserEventListener(self, listener: Optional[ModifyUserEventListener]):
-        assert listener is None or isinstance(listener, ModifyUserEventListener), f"malformed {listener=}"
+        if listener is not None and not isinstance(listener, ModifyUserEventListener):
+            raise ValueError(f'listener argument is malformed: \"{listener}\"')
 
         self.__modifyUserEventListener = listener
 
@@ -68,12 +72,13 @@ class ModifyUserDataHelper(Clearable):
         userId: str,
         userName: str
     ):
-        assert isinstance(actionType, ModifyUserActionType), f"malformed {actionType=}"
-        if not utils.isValidStr(userId):
+        if not isinstance(actionType, ModifyUserActionType):
+            raise ValueError(f'actionType argument is malformed: \"{actionType}\"')
+        elif not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if userId == '0':
+        elif userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         self.__setTime = datetime.now(self.__timeZone)

--- a/src/CynanBot/users/pkmnCatchBoosterPack.py
+++ b/src/CynanBot/users/pkmnCatchBoosterPack.py
@@ -11,9 +11,8 @@ class PkmnCatchBoosterPack():
         pkmnCatchType: Optional[PkmnCatchType],
         rewardId: str
     ):
-        if pkmnCatchType is not None and not isinstance(pkmnCatchType, PkmnCatchType):
-            raise ValueError(f'pkmnCatchType argument is malformed: \"{pkmnCatchType}\"')
-        elif not utils.isValidStr(rewardId):
+        assert pkmnCatchType is None or isinstance(pkmnCatchType, PkmnCatchType), f"malformed {pkmnCatchType=}"
+        if not utils.isValidStr(rewardId):
             raise ValueError(f'rewardId argument is malformed: \"{rewardId}\"')
 
         self.__pkmnCatchType: Optional[PkmnCatchType] = pkmnCatchType

--- a/src/CynanBot/users/pkmnCatchBoosterPack.py
+++ b/src/CynanBot/users/pkmnCatchBoosterPack.py
@@ -11,8 +11,9 @@ class PkmnCatchBoosterPack():
         pkmnCatchType: Optional[PkmnCatchType],
         rewardId: str
     ):
-        assert pkmnCatchType is None or isinstance(pkmnCatchType, PkmnCatchType), f"malformed {pkmnCatchType=}"
-        if not utils.isValidStr(rewardId):
+        if pkmnCatchType is not None and not isinstance(pkmnCatchType, PkmnCatchType):
+            raise ValueError(f'pkmnCatchType argument is malformed: \"{pkmnCatchType}\"')
+        elif not utils.isValidStr(rewardId):
             raise ValueError(f'rewardId argument is malformed: \"{rewardId}\"')
 
         self.__pkmnCatchType: Optional[PkmnCatchType] = pkmnCatchType

--- a/src/CynanBot/users/user.py
+++ b/src/CynanBot/users/user.py
@@ -88,142 +88,131 @@ class User(UserInterface):
     ):
         if not utils.isValidBool(areCheerActionsEnabled):
             raise TypeError(f'areCheerActionsEnabled argument is malformed: \"{areCheerActionsEnabled}\"')
-        elif not utils.isValidBool(areRecurringActionsEnabled):
+        if not utils.isValidBool(areRecurringActionsEnabled):
             raise TypeError(f'areRecurringActionsEnabled argument is malformed: \"{areRecurringActionsEnabled}\"')
-        elif not utils.isValidBool(isAnivContentScanningEnabled):
+        if not utils.isValidBool(isAnivContentScanningEnabled):
             raise TypeError(f'isAnivContentScanningEnabled argument is malformed: \"{isAnivContentScanningEnabled}\"')
-        elif not utils.isValidBool(isCasualGamePollEnabled):
+        if not utils.isValidBool(isCasualGamePollEnabled):
             raise TypeError(f'isCasualGamePollEnabled argument is malformed: \"{isCasualGamePollEnabled}\"')
-        elif not utils.isValidBool(isCatJamMessageEnabled):
+        if not utils.isValidBool(isCatJamMessageEnabled):
             raise TypeError(f'isCatJamMessageEnabled argument is malformed: \"{isCatJamMessageEnabled}\"')
-        elif not utils.isValidBool(isChannelPredictionChartEnabled):
+        if not utils.isValidBool(isChannelPredictionChartEnabled):
             raise TypeError(f'isChannelPredictionChartEnabled argument is malformed: \"{isChannelPredictionChartEnabled}\"')
-        elif not utils.isValidBool(isChatBandEnabled):
+        if not utils.isValidBool(isChatBandEnabled):
             raise TypeError(f'isChatBandEnabled argument is malformed: \"{isChatBandEnabled}\"')
-        elif not utils.isValidBool(isChatLoggingEnabled):
+        if not utils.isValidBool(isChatLoggingEnabled):
             raise TypeError(f'isChatLoggingEnabled argument is malformed: \"{isChatLoggingEnabled}\"')
-        elif not utils.isValidBool(isCutenessEnabled):
+        if not utils.isValidBool(isCutenessEnabled):
             raise TypeError(f'isCutenessEnabled argument is malformed: \"{isCutenessEnabled}\"')
-        elif not utils.isValidBool(isCynanSourceEnabled):
+        if not utils.isValidBool(isCynanSourceEnabled):
             raise TypeError(f'isCynanSourceEnabled argument is malformed: \"{isCynanSourceEnabled}\"')
-        elif not utils.isValidBool(isDeerForceMessageEnabled):
+        if not utils.isValidBool(isDeerForceMessageEnabled):
             raise TypeError(f'isDeerForceMessageEnabled argument is malformed: \"{isDeerForceMessageEnabled}\"')
-        elif not utils.isValidBool(isEnabled):
+        if not utils.isValidBool(isEnabled):
             raise TypeError(f'isEnabled argument is malformed: \"{isEnabled}\"')
-        elif not utils.isValidBool(isEyesMessageEnabled):
+        if not utils.isValidBool(isEyesMessageEnabled):
             raise TypeError(f'isEyesMessageEnabled argument is malformed: \"{isEyesMessageEnabled}\"')
-        elif not utils.isValidBool(isGiftSubscriptionThanksMessageEnabled):
+        if not utils.isValidBool(isGiftSubscriptionThanksMessageEnabled):
             raise TypeError(f'isGiftSubscriptionThanksMessageEnabled argument is malformed: \"{isGiftSubscriptionThanksMessageEnabled}\"')
-        elif not utils.isValidBool(isGiveCutenessEnabled):
+        if not utils.isValidBool(isGiveCutenessEnabled):
             raise TypeError(f'isGiveCutenessEnabled argument is malformed: \"{isGiveCutenessEnabled}\"')
-        elif not utils.isValidBool(isImytSlurpMessageEnabled):
+        if not utils.isValidBool(isImytSlurpMessageEnabled):
             raise TypeError(f'isImytSlurpMessageEnabled argument is malformed: \"{isImytSlurpMessageEnabled}\"')
-        elif not utils.isValidBool(isJamCatMessageEnabled):
+        if not utils.isValidBool(isJamCatMessageEnabled):
             raise TypeError(f'isJamCatMessageEnabled argument is malformed: \"{isJamCatMessageEnabled}\"')
-        elif not utils.isValidBool(isJishoEnabled):
+        if not utils.isValidBool(isJishoEnabled):
             raise TypeError(f'isJishoEnabled argument is malformed: \"{isJishoEnabled}\"')
-        elif not utils.isValidBool(isLoremIpsumEnabled):
+        if not utils.isValidBool(isLoremIpsumEnabled):
             raise TypeError(f'isLoremIpsumEnabled argument is malformed: \"{isLoremIpsumEnabled}\"')
-        elif not utils.isValidBool(isPkmnEnabled):
+        if not utils.isValidBool(isPkmnEnabled):
             raise TypeError(f'isPkmnEnabled argument is malformed: \"{isPkmnEnabled}\"')
-        elif not utils.isValidBool(isPokepediaEnabled):
+        if not utils.isValidBool(isPokepediaEnabled):
             raise TypeError(f'isPokepediaEnabled argument is malformed: \"{isPokepediaEnabled}\"')
-        elif not utils.isValidBool(isRaceEnabled):
+        if not utils.isValidBool(isRaceEnabled):
             raise TypeError(f'isRaceEnabled argument is malformed: \"{isRaceEnabled}\"')
-        elif not utils.isValidBool(isRaidLinkMessagingEnabled):
+        if not utils.isValidBool(isRaidLinkMessagingEnabled):
             raise TypeError(f'isRaidLinkMessagingEnabled argument is malformed: \"{isRaidLinkMessagingEnabled}\"')
-        elif not utils.isValidBool(isRatJamMessageEnabled):
+        if not utils.isValidBool(isRatJamMessageEnabled):
             raise TypeError(f'isRatJamMessageEnabled argument is malformed: \"{isRatJamMessageEnabled}\"')
-        elif not utils.isValidBool(isRewardIdPrintingEnabled):
+        if not utils.isValidBool(isRewardIdPrintingEnabled):
             raise TypeError(f'isRewardIdPrintingEnabled argument is malformed: \"{isRewardIdPrintingEnabled}\"')
-        elif not utils.isValidBool(isRoachMessageEnabled):
+        if not utils.isValidBool(isRoachMessageEnabled):
             raise TypeError(f'isRoachMessageEnabled argument is malformed: \"{isRoachMessageEnabled}\"')
-        elif not utils.isValidBool(isSchubertWalkMessageEnabled):
+        if not utils.isValidBool(isSchubertWalkMessageEnabled):
             raise TypeError(f'isSchubertWalkMessageEnabled argument is malformed: \"{isSchubertWalkMessageEnabled}\"')
-        elif not utils.isValidBool(isShinyTriviaEnabled):
+        if not utils.isValidBool(isShinyTriviaEnabled):
             raise TypeError(f'isShinyTriviaEnabled argument is malformed: \"{isShinyTriviaEnabled}\"')
-        elif not utils.isValidBool(isStarWarsQuotesEnabled):
+        if not utils.isValidBool(isStarWarsQuotesEnabled):
             raise TypeError(f'isStarWarsQuotesEnabled argument is malformed: \"{isStarWarsQuotesEnabled}\"')
-        elif not utils.isValidBool(isSubGiftThankingEnabled):
+        if not utils.isValidBool(isSubGiftThankingEnabled):
             raise TypeError(f'isSubGiftThankingEnabled argument is malformed: \"{isSubGiftThankingEnabled}\"')
-        elif not utils.isValidBool(isSuperTriviaGameEnabled):
+        if not utils.isValidBool(isSuperTriviaGameEnabled):
             raise TypeError(f'isSuperTriviaGameEnabled argument is malformed: \"{isSuperTriviaGameEnabled}\"')
-        elif not utils.isValidBool(isSupStreamerEnabled):
+        if not utils.isValidBool(isSupStreamerEnabled):
             raise TypeError(f'isSupStreamerEnabled argument is malformed: \"{isSupStreamerEnabled}\"')
-        elif not utils.isValidBool(isToxicTriviaEnabled):
+        if not utils.isValidBool(isToxicTriviaEnabled):
             raise TypeError(f'isToxicTriviaEnabled argument is malformed: \"{isToxicTriviaEnabled}\"')
-        elif not utils.isValidBool(isTranslateEnabled):
+        if not utils.isValidBool(isTranslateEnabled):
             raise TypeError(f'isTranslateEnabled argument is malformed: \"{isTranslateEnabled}\"')
-        elif not utils.isValidBool(isTriviaEnabled):
+        if not utils.isValidBool(isTriviaEnabled):
             raise TypeError(f'isTriviaEnabled argument is malformed: \"{isTriviaEnabled}\"')
-        elif not utils.isValidBool(isTriviaGameEnabled):
+        if not utils.isValidBool(isTriviaGameEnabled):
             raise TypeError(f'isTriviaGameEnabled argument is malformed: \"{isTriviaGameEnabled}\"')
-        elif not utils.isValidBool(isTriviaScoreEnabled):
+        if not utils.isValidBool(isTriviaScoreEnabled):
             raise TypeError(f'isTriviaScoreEnabled argument is malformed: \"{isTriviaScoreEnabled}\"')
-        elif not utils.isValidBool(isTtsEnabled):
+        if not utils.isValidBool(isTtsEnabled):
             raise TypeError(f'isTtsEnabled argument is malformed: \"{isTtsEnabled}\"')
-        elif not utils.isValidBool(isWeatherEnabled):
+        if not utils.isValidBool(isWeatherEnabled):
             raise TypeError(f'isWeatherEnabled argument is malformed: \"{isWeatherEnabled}\"')
-        elif not utils.isValidBool(isWelcomeTtsEnabled):
+        if not utils.isValidBool(isWelcomeTtsEnabled):
             raise TypeError(f'isWelcomeTtsEnabled argument is malformed: \"{isWelcomeTtsEnabled}\"')
-        elif not utils.isValidBool(isWordOfTheDayEnabled):
+        if not utils.isValidBool(isWordOfTheDayEnabled):
             raise TypeError(f'isWordOfTheDayEnabled argument is malformed: \"{isWordOfTheDayEnabled}\"')
-        elif superTriviaCheerTriggerAmount is not None and not utils.isValidNum(superTriviaCheerTriggerAmount):
+        if superTriviaCheerTriggerAmount is not None and not utils.isValidNum(superTriviaCheerTriggerAmount):
             raise TypeError(f'superTriviaCheerTriggerAmount argument is malformed: \"{superTriviaCheerTriggerAmount}\"')
-        elif superTriviaSubscribeTriggerAmount is not None and not utils.isValidNum(superTriviaSubscribeTriggerAmount):
+        if superTriviaSubscribeTriggerAmount is not None and not utils.isValidNum(superTriviaSubscribeTriggerAmount):
             raise TypeError(f'superTriviaSubscribeTriggerAmount argument is malformed: \"{superTriviaSubscribeTriggerAmount}\"')
-        elif maximumTtsCheerAmount is not None and not utils.isValidInt(maximumTtsCheerAmount):
+        if maximumTtsCheerAmount is not None and not utils.isValidInt(maximumTtsCheerAmount):
             raise TypeError(f'maximumTtsCheerAmount argument is malformed: \"{maximumTtsCheerAmount}\"')
-        elif minimumTtsCheerAmount is not None and not utils.isValidInt(minimumTtsCheerAmount):
+        if minimumTtsCheerAmount is not None and not utils.isValidInt(minimumTtsCheerAmount):
             raise TypeError(f'minimumTtsCheerAmount argument is malformed: \"{minimumTtsCheerAmount}\"')
-        elif superTriviaGamePoints is not None and not utils.isValidInt(superTriviaGamePoints):
+        if superTriviaGamePoints is not None and not utils.isValidInt(superTriviaGamePoints):
             raise TypeError(f'superTriviaGamePoints argument is malformed: \"{superTriviaGamePoints}\"')
-        elif superTriviaCheerTriggerMaximum is not None and not utils.isValidInt(superTriviaCheerTriggerMaximum):
+        if superTriviaCheerTriggerMaximum is not None and not utils.isValidInt(superTriviaCheerTriggerMaximum):
             raise TypeError(f'superTriviaCheerTriggerMaximum argument is malformed: \"{superTriviaCheerTriggerMaximum}\"')
-        elif superTriviaGameRewardId is not None and not isinstance(superTriviaGameRewardId, str):
-            raise TypeError(f'superTriviaGameRewardId argument is malformed: \"{superTriviaGameRewardId}\"')
-        elif superTriviaGameShinyMultiplier is not None and not utils.isValidInt(superTriviaGameShinyMultiplier):
+        assert superTriviaGameRewardId is None or isinstance(superTriviaGameRewardId, str), f"malformed {superTriviaGameRewardId=}"
+        if superTriviaGameShinyMultiplier is not None and not utils.isValidInt(superTriviaGameShinyMultiplier):
             raise TypeError(f'superTriviaGameShinyMultiplier argument is malformed: \"{superTriviaGameShinyMultiplier}\"')
-        elif superTriviaGameToxicPunishmentMultiplier is not None and not utils.isValidInt(superTriviaGameToxicPunishmentMultiplier):
+        if superTriviaGameToxicPunishmentMultiplier is not None and not utils.isValidInt(superTriviaGameToxicPunishmentMultiplier):
             raise TypeError(f'superTriviaGameToxicPunishmentMultiplier argument is malformed: \"{superTriviaGameToxicPunishmentMultiplier}\"')
-        elif superTriviaPerUserAttempts is not None and not utils.isValidInt(superTriviaPerUserAttempts):
+        if superTriviaPerUserAttempts is not None and not utils.isValidInt(superTriviaPerUserAttempts):
             raise TypeError(f'superTriviaPeruserAttempts argument is malformed: \"{superTriviaPerUserAttempts}\"')
-        elif superTriviaSubscribeTriggerMaximum is not None and not utils.isValidInt(superTriviaSubscribeTriggerMaximum):
+        if superTriviaSubscribeTriggerMaximum is not None and not utils.isValidInt(superTriviaSubscribeTriggerMaximum):
             raise TypeError(f'superTriviaSubscribeTriggerMaximum argument is malformed: \"{superTriviaSubscribeTriggerMaximum}\"')
-        elif triviaGamePoints is not None and not utils.isValidInt(triviaGamePoints):
+        if triviaGamePoints is not None and not utils.isValidInt(triviaGamePoints):
             raise TypeError(f'triviaGamePoints argument is malformed: \"{triviaGamePoints}\"')
-        elif triviaGameShinyMultiplier is not None and not utils.isValidInt(triviaGameShinyMultiplier):
+        if triviaGameShinyMultiplier is not None and not utils.isValidInt(triviaGameShinyMultiplier):
             raise TypeError(f'triviaGameShinyMultiplier argument is malformed: \"{triviaGameShinyMultiplier}\"')
-        elif waitForSuperTriviaAnswerDelay is not None and not utils.isValidInt(waitForSuperTriviaAnswerDelay):
+        if waitForSuperTriviaAnswerDelay is not None and not utils.isValidInt(waitForSuperTriviaAnswerDelay):
             raise TypeError(f'waitForSuperTriviaAnswerDelay argument is malformed: \"{waitForSuperTriviaAnswerDelay}\"')
-        elif waitForTriviaAnswerDelay is not None and not utils.isValidInt(waitForTriviaAnswerDelay):
+        if waitForTriviaAnswerDelay is not None and not utils.isValidInt(waitForTriviaAnswerDelay):
             raise TypeError(f'waitForTriviaAnswerDelay argument is malformed: \"{waitForTriviaAnswerDelay}\"')
-        elif casualGamePollRewardId is not None and not isinstance(casualGamePollRewardId, str):
-            raise TypeError(f'casualGamePollRewardId argument is malformed: \"{casualGamePollRewardId}\"')
-        elif casualGamePollUrl is not None and not isinstance(casualGamePollUrl, str):
-            raise TypeError(f'casualGamePollUrl argument is malformed: \"{casualGamePollUrl}\"')
-        elif discord is not None and not isinstance(discord, str):
-            raise TypeError(f'discord argument is malformed: \"{discord}\"')
-        elif not utils.isValidStr(handle):
+        assert casualGamePollRewardId is None or isinstance(casualGamePollRewardId, str), f"malformed {casualGamePollRewardId=}"
+        assert casualGamePollUrl is None or isinstance(casualGamePollUrl, str), f"malformed {casualGamePollUrl=}"
+        assert discord is None or isinstance(discord, str), f"malformed {discord=}"
+        if not utils.isValidStr(handle):
             raise TypeError(f'handle argument is malformed: \"{handle}\"')
-        elif locationId is not None and not isinstance(locationId, str):
-            raise TypeError(f'locationId argument is malformed: \"{locationId}\"')
-        elif mastodonUrl is not None and not isinstance(mastodonUrl, str):
-            raise TypeError(f'mastodonUrl argument is malformed: \"{mastodonUrl}\"')
-        elif pkmnBattleRewardId is not None and not isinstance(pkmnBattleRewardId, str):
-            raise TypeError(f'pkmnBattleRewardId argument is malformed: \"{pkmnBattleRewardId}\"')
-        elif pkmnEvolveRewardId and not isinstance(pkmnEvolveRewardId, str):
+        assert locationId is None or isinstance(locationId, str), f"malformed {locationId=}"
+        assert mastodonUrl is None or isinstance(mastodonUrl, str), f"malformed {mastodonUrl=}"
+        assert pkmnBattleRewardId is None or isinstance(pkmnBattleRewardId, str), f"malformed {pkmnBattleRewardId=}"
+        if pkmnEvolveRewardId and not isinstance(pkmnEvolveRewardId, str):
             raise TypeError(f'pkmnEvolveRewardId argument is malformed: \"{pkmnEvolveRewardId}\"')
-        elif pkmnShinyRewardId and not isinstance(pkmnShinyRewardId, str):
+        if pkmnShinyRewardId and not isinstance(pkmnShinyRewardId, str):
             raise TypeError(f'pkmnShinyRewardId argument is malformed: \"{pkmnShinyRewardId}\"')
-        elif speedrunProfile is not None and not isinstance(speedrunProfile, str):
-            raise TypeError(f'speedrunProfile argument is malformed: \"{speedrunProfile}\"')
-        elif supStreamerMessage is not None and not isinstance(supStreamerMessage, str):
-            raise TypeError(f'supStreamerMessage argument is malformed: \"{supStreamerMessage}\"')
-        elif triviaGameRewardId is not None and not isinstance(triviaGameRewardId, str):
-            raise TypeError(f'triviaGameRewardId argument is malformed: \"{triviaGameRewardId}\"')
-        elif twitter is not None and not isinstance(twitter, str):
-            raise TypeError(f'twitter argument is malformed: \"{twitter}\"')
+        assert speedrunProfile is None or isinstance(speedrunProfile, str), f"malformed {speedrunProfile=}"
+        assert supStreamerMessage is None or isinstance(supStreamerMessage, str), f"malformed {supStreamerMessage=}"
+        assert triviaGameRewardId is None or isinstance(triviaGameRewardId, str), f"malformed {triviaGameRewardId=}"
+        assert twitter is None or isinstance(twitter, str), f"malformed {twitter=}"
 
         self.__areCheerActionsEnabled: bool = areCheerActionsEnabled
         self.__areRecurringActionsEnabled: bool = areRecurringActionsEnabled

--- a/src/CynanBot/users/user.py
+++ b/src/CynanBot/users/user.py
@@ -88,131 +88,142 @@ class User(UserInterface):
     ):
         if not utils.isValidBool(areCheerActionsEnabled):
             raise TypeError(f'areCheerActionsEnabled argument is malformed: \"{areCheerActionsEnabled}\"')
-        if not utils.isValidBool(areRecurringActionsEnabled):
+        elif not utils.isValidBool(areRecurringActionsEnabled):
             raise TypeError(f'areRecurringActionsEnabled argument is malformed: \"{areRecurringActionsEnabled}\"')
-        if not utils.isValidBool(isAnivContentScanningEnabled):
+        elif not utils.isValidBool(isAnivContentScanningEnabled):
             raise TypeError(f'isAnivContentScanningEnabled argument is malformed: \"{isAnivContentScanningEnabled}\"')
-        if not utils.isValidBool(isCasualGamePollEnabled):
+        elif not utils.isValidBool(isCasualGamePollEnabled):
             raise TypeError(f'isCasualGamePollEnabled argument is malformed: \"{isCasualGamePollEnabled}\"')
-        if not utils.isValidBool(isCatJamMessageEnabled):
+        elif not utils.isValidBool(isCatJamMessageEnabled):
             raise TypeError(f'isCatJamMessageEnabled argument is malformed: \"{isCatJamMessageEnabled}\"')
-        if not utils.isValidBool(isChannelPredictionChartEnabled):
+        elif not utils.isValidBool(isChannelPredictionChartEnabled):
             raise TypeError(f'isChannelPredictionChartEnabled argument is malformed: \"{isChannelPredictionChartEnabled}\"')
-        if not utils.isValidBool(isChatBandEnabled):
+        elif not utils.isValidBool(isChatBandEnabled):
             raise TypeError(f'isChatBandEnabled argument is malformed: \"{isChatBandEnabled}\"')
-        if not utils.isValidBool(isChatLoggingEnabled):
+        elif not utils.isValidBool(isChatLoggingEnabled):
             raise TypeError(f'isChatLoggingEnabled argument is malformed: \"{isChatLoggingEnabled}\"')
-        if not utils.isValidBool(isCutenessEnabled):
+        elif not utils.isValidBool(isCutenessEnabled):
             raise TypeError(f'isCutenessEnabled argument is malformed: \"{isCutenessEnabled}\"')
-        if not utils.isValidBool(isCynanSourceEnabled):
+        elif not utils.isValidBool(isCynanSourceEnabled):
             raise TypeError(f'isCynanSourceEnabled argument is malformed: \"{isCynanSourceEnabled}\"')
-        if not utils.isValidBool(isDeerForceMessageEnabled):
+        elif not utils.isValidBool(isDeerForceMessageEnabled):
             raise TypeError(f'isDeerForceMessageEnabled argument is malformed: \"{isDeerForceMessageEnabled}\"')
-        if not utils.isValidBool(isEnabled):
+        elif not utils.isValidBool(isEnabled):
             raise TypeError(f'isEnabled argument is malformed: \"{isEnabled}\"')
-        if not utils.isValidBool(isEyesMessageEnabled):
+        elif not utils.isValidBool(isEyesMessageEnabled):
             raise TypeError(f'isEyesMessageEnabled argument is malformed: \"{isEyesMessageEnabled}\"')
-        if not utils.isValidBool(isGiftSubscriptionThanksMessageEnabled):
+        elif not utils.isValidBool(isGiftSubscriptionThanksMessageEnabled):
             raise TypeError(f'isGiftSubscriptionThanksMessageEnabled argument is malformed: \"{isGiftSubscriptionThanksMessageEnabled}\"')
-        if not utils.isValidBool(isGiveCutenessEnabled):
+        elif not utils.isValidBool(isGiveCutenessEnabled):
             raise TypeError(f'isGiveCutenessEnabled argument is malformed: \"{isGiveCutenessEnabled}\"')
-        if not utils.isValidBool(isImytSlurpMessageEnabled):
+        elif not utils.isValidBool(isImytSlurpMessageEnabled):
             raise TypeError(f'isImytSlurpMessageEnabled argument is malformed: \"{isImytSlurpMessageEnabled}\"')
-        if not utils.isValidBool(isJamCatMessageEnabled):
+        elif not utils.isValidBool(isJamCatMessageEnabled):
             raise TypeError(f'isJamCatMessageEnabled argument is malformed: \"{isJamCatMessageEnabled}\"')
-        if not utils.isValidBool(isJishoEnabled):
+        elif not utils.isValidBool(isJishoEnabled):
             raise TypeError(f'isJishoEnabled argument is malformed: \"{isJishoEnabled}\"')
-        if not utils.isValidBool(isLoremIpsumEnabled):
+        elif not utils.isValidBool(isLoremIpsumEnabled):
             raise TypeError(f'isLoremIpsumEnabled argument is malformed: \"{isLoremIpsumEnabled}\"')
-        if not utils.isValidBool(isPkmnEnabled):
+        elif not utils.isValidBool(isPkmnEnabled):
             raise TypeError(f'isPkmnEnabled argument is malformed: \"{isPkmnEnabled}\"')
-        if not utils.isValidBool(isPokepediaEnabled):
+        elif not utils.isValidBool(isPokepediaEnabled):
             raise TypeError(f'isPokepediaEnabled argument is malformed: \"{isPokepediaEnabled}\"')
-        if not utils.isValidBool(isRaceEnabled):
+        elif not utils.isValidBool(isRaceEnabled):
             raise TypeError(f'isRaceEnabled argument is malformed: \"{isRaceEnabled}\"')
-        if not utils.isValidBool(isRaidLinkMessagingEnabled):
+        elif not utils.isValidBool(isRaidLinkMessagingEnabled):
             raise TypeError(f'isRaidLinkMessagingEnabled argument is malformed: \"{isRaidLinkMessagingEnabled}\"')
-        if not utils.isValidBool(isRatJamMessageEnabled):
+        elif not utils.isValidBool(isRatJamMessageEnabled):
             raise TypeError(f'isRatJamMessageEnabled argument is malformed: \"{isRatJamMessageEnabled}\"')
-        if not utils.isValidBool(isRewardIdPrintingEnabled):
+        elif not utils.isValidBool(isRewardIdPrintingEnabled):
             raise TypeError(f'isRewardIdPrintingEnabled argument is malformed: \"{isRewardIdPrintingEnabled}\"')
-        if not utils.isValidBool(isRoachMessageEnabled):
+        elif not utils.isValidBool(isRoachMessageEnabled):
             raise TypeError(f'isRoachMessageEnabled argument is malformed: \"{isRoachMessageEnabled}\"')
-        if not utils.isValidBool(isSchubertWalkMessageEnabled):
+        elif not utils.isValidBool(isSchubertWalkMessageEnabled):
             raise TypeError(f'isSchubertWalkMessageEnabled argument is malformed: \"{isSchubertWalkMessageEnabled}\"')
-        if not utils.isValidBool(isShinyTriviaEnabled):
+        elif not utils.isValidBool(isShinyTriviaEnabled):
             raise TypeError(f'isShinyTriviaEnabled argument is malformed: \"{isShinyTriviaEnabled}\"')
-        if not utils.isValidBool(isStarWarsQuotesEnabled):
+        elif not utils.isValidBool(isStarWarsQuotesEnabled):
             raise TypeError(f'isStarWarsQuotesEnabled argument is malformed: \"{isStarWarsQuotesEnabled}\"')
-        if not utils.isValidBool(isSubGiftThankingEnabled):
+        elif not utils.isValidBool(isSubGiftThankingEnabled):
             raise TypeError(f'isSubGiftThankingEnabled argument is malformed: \"{isSubGiftThankingEnabled}\"')
-        if not utils.isValidBool(isSuperTriviaGameEnabled):
+        elif not utils.isValidBool(isSuperTriviaGameEnabled):
             raise TypeError(f'isSuperTriviaGameEnabled argument is malformed: \"{isSuperTriviaGameEnabled}\"')
-        if not utils.isValidBool(isSupStreamerEnabled):
+        elif not utils.isValidBool(isSupStreamerEnabled):
             raise TypeError(f'isSupStreamerEnabled argument is malformed: \"{isSupStreamerEnabled}\"')
-        if not utils.isValidBool(isToxicTriviaEnabled):
+        elif not utils.isValidBool(isToxicTriviaEnabled):
             raise TypeError(f'isToxicTriviaEnabled argument is malformed: \"{isToxicTriviaEnabled}\"')
-        if not utils.isValidBool(isTranslateEnabled):
+        elif not utils.isValidBool(isTranslateEnabled):
             raise TypeError(f'isTranslateEnabled argument is malformed: \"{isTranslateEnabled}\"')
-        if not utils.isValidBool(isTriviaEnabled):
+        elif not utils.isValidBool(isTriviaEnabled):
             raise TypeError(f'isTriviaEnabled argument is malformed: \"{isTriviaEnabled}\"')
-        if not utils.isValidBool(isTriviaGameEnabled):
+        elif not utils.isValidBool(isTriviaGameEnabled):
             raise TypeError(f'isTriviaGameEnabled argument is malformed: \"{isTriviaGameEnabled}\"')
-        if not utils.isValidBool(isTriviaScoreEnabled):
+        elif not utils.isValidBool(isTriviaScoreEnabled):
             raise TypeError(f'isTriviaScoreEnabled argument is malformed: \"{isTriviaScoreEnabled}\"')
-        if not utils.isValidBool(isTtsEnabled):
+        elif not utils.isValidBool(isTtsEnabled):
             raise TypeError(f'isTtsEnabled argument is malformed: \"{isTtsEnabled}\"')
-        if not utils.isValidBool(isWeatherEnabled):
+        elif not utils.isValidBool(isWeatherEnabled):
             raise TypeError(f'isWeatherEnabled argument is malformed: \"{isWeatherEnabled}\"')
-        if not utils.isValidBool(isWelcomeTtsEnabled):
+        elif not utils.isValidBool(isWelcomeTtsEnabled):
             raise TypeError(f'isWelcomeTtsEnabled argument is malformed: \"{isWelcomeTtsEnabled}\"')
-        if not utils.isValidBool(isWordOfTheDayEnabled):
+        elif not utils.isValidBool(isWordOfTheDayEnabled):
             raise TypeError(f'isWordOfTheDayEnabled argument is malformed: \"{isWordOfTheDayEnabled}\"')
-        if superTriviaCheerTriggerAmount is not None and not utils.isValidNum(superTriviaCheerTriggerAmount):
+        elif superTriviaCheerTriggerAmount is not None and not utils.isValidNum(superTriviaCheerTriggerAmount):
             raise TypeError(f'superTriviaCheerTriggerAmount argument is malformed: \"{superTriviaCheerTriggerAmount}\"')
-        if superTriviaSubscribeTriggerAmount is not None and not utils.isValidNum(superTriviaSubscribeTriggerAmount):
+        elif superTriviaSubscribeTriggerAmount is not None and not utils.isValidNum(superTriviaSubscribeTriggerAmount):
             raise TypeError(f'superTriviaSubscribeTriggerAmount argument is malformed: \"{superTriviaSubscribeTriggerAmount}\"')
-        if maximumTtsCheerAmount is not None and not utils.isValidInt(maximumTtsCheerAmount):
+        elif maximumTtsCheerAmount is not None and not utils.isValidInt(maximumTtsCheerAmount):
             raise TypeError(f'maximumTtsCheerAmount argument is malformed: \"{maximumTtsCheerAmount}\"')
-        if minimumTtsCheerAmount is not None and not utils.isValidInt(minimumTtsCheerAmount):
+        elif minimumTtsCheerAmount is not None and not utils.isValidInt(minimumTtsCheerAmount):
             raise TypeError(f'minimumTtsCheerAmount argument is malformed: \"{minimumTtsCheerAmount}\"')
-        if superTriviaGamePoints is not None and not utils.isValidInt(superTriviaGamePoints):
+        elif superTriviaGamePoints is not None and not utils.isValidInt(superTriviaGamePoints):
             raise TypeError(f'superTriviaGamePoints argument is malformed: \"{superTriviaGamePoints}\"')
-        if superTriviaCheerTriggerMaximum is not None and not utils.isValidInt(superTriviaCheerTriggerMaximum):
+        elif superTriviaCheerTriggerMaximum is not None and not utils.isValidInt(superTriviaCheerTriggerMaximum):
             raise TypeError(f'superTriviaCheerTriggerMaximum argument is malformed: \"{superTriviaCheerTriggerMaximum}\"')
-        assert superTriviaGameRewardId is None or isinstance(superTriviaGameRewardId, str), f"malformed {superTriviaGameRewardId=}"
-        if superTriviaGameShinyMultiplier is not None and not utils.isValidInt(superTriviaGameShinyMultiplier):
+        elif superTriviaGameRewardId is not None and not isinstance(superTriviaGameRewardId, str):
+            raise TypeError(f'superTriviaGameRewardId argument is malformed: \"{superTriviaGameRewardId}\"')
+        elif superTriviaGameShinyMultiplier is not None and not utils.isValidInt(superTriviaGameShinyMultiplier):
             raise TypeError(f'superTriviaGameShinyMultiplier argument is malformed: \"{superTriviaGameShinyMultiplier}\"')
-        if superTriviaGameToxicPunishmentMultiplier is not None and not utils.isValidInt(superTriviaGameToxicPunishmentMultiplier):
+        elif superTriviaGameToxicPunishmentMultiplier is not None and not utils.isValidInt(superTriviaGameToxicPunishmentMultiplier):
             raise TypeError(f'superTriviaGameToxicPunishmentMultiplier argument is malformed: \"{superTriviaGameToxicPunishmentMultiplier}\"')
-        if superTriviaPerUserAttempts is not None and not utils.isValidInt(superTriviaPerUserAttempts):
+        elif superTriviaPerUserAttempts is not None and not utils.isValidInt(superTriviaPerUserAttempts):
             raise TypeError(f'superTriviaPeruserAttempts argument is malformed: \"{superTriviaPerUserAttempts}\"')
-        if superTriviaSubscribeTriggerMaximum is not None and not utils.isValidInt(superTriviaSubscribeTriggerMaximum):
+        elif superTriviaSubscribeTriggerMaximum is not None and not utils.isValidInt(superTriviaSubscribeTriggerMaximum):
             raise TypeError(f'superTriviaSubscribeTriggerMaximum argument is malformed: \"{superTriviaSubscribeTriggerMaximum}\"')
-        if triviaGamePoints is not None and not utils.isValidInt(triviaGamePoints):
+        elif triviaGamePoints is not None and not utils.isValidInt(triviaGamePoints):
             raise TypeError(f'triviaGamePoints argument is malformed: \"{triviaGamePoints}\"')
-        if triviaGameShinyMultiplier is not None and not utils.isValidInt(triviaGameShinyMultiplier):
+        elif triviaGameShinyMultiplier is not None and not utils.isValidInt(triviaGameShinyMultiplier):
             raise TypeError(f'triviaGameShinyMultiplier argument is malformed: \"{triviaGameShinyMultiplier}\"')
-        if waitForSuperTriviaAnswerDelay is not None and not utils.isValidInt(waitForSuperTriviaAnswerDelay):
+        elif waitForSuperTriviaAnswerDelay is not None and not utils.isValidInt(waitForSuperTriviaAnswerDelay):
             raise TypeError(f'waitForSuperTriviaAnswerDelay argument is malformed: \"{waitForSuperTriviaAnswerDelay}\"')
-        if waitForTriviaAnswerDelay is not None and not utils.isValidInt(waitForTriviaAnswerDelay):
+        elif waitForTriviaAnswerDelay is not None and not utils.isValidInt(waitForTriviaAnswerDelay):
             raise TypeError(f'waitForTriviaAnswerDelay argument is malformed: \"{waitForTriviaAnswerDelay}\"')
-        assert casualGamePollRewardId is None or isinstance(casualGamePollRewardId, str), f"malformed {casualGamePollRewardId=}"
-        assert casualGamePollUrl is None or isinstance(casualGamePollUrl, str), f"malformed {casualGamePollUrl=}"
-        assert discord is None or isinstance(discord, str), f"malformed {discord=}"
-        if not utils.isValidStr(handle):
+        elif casualGamePollRewardId is not None and not isinstance(casualGamePollRewardId, str):
+            raise TypeError(f'casualGamePollRewardId argument is malformed: \"{casualGamePollRewardId}\"')
+        elif casualGamePollUrl is not None and not isinstance(casualGamePollUrl, str):
+            raise TypeError(f'casualGamePollUrl argument is malformed: \"{casualGamePollUrl}\"')
+        elif discord is not None and not isinstance(discord, str):
+            raise TypeError(f'discord argument is malformed: \"{discord}\"')
+        elif not utils.isValidStr(handle):
             raise TypeError(f'handle argument is malformed: \"{handle}\"')
-        assert locationId is None or isinstance(locationId, str), f"malformed {locationId=}"
-        assert mastodonUrl is None or isinstance(mastodonUrl, str), f"malformed {mastodonUrl=}"
-        assert pkmnBattleRewardId is None or isinstance(pkmnBattleRewardId, str), f"malformed {pkmnBattleRewardId=}"
-        if pkmnEvolveRewardId and not isinstance(pkmnEvolveRewardId, str):
+        elif locationId is not None and not isinstance(locationId, str):
+            raise TypeError(f'locationId argument is malformed: \"{locationId}\"')
+        elif mastodonUrl is not None and not isinstance(mastodonUrl, str):
+            raise TypeError(f'mastodonUrl argument is malformed: \"{mastodonUrl}\"')
+        elif pkmnBattleRewardId is not None and not isinstance(pkmnBattleRewardId, str):
+            raise TypeError(f'pkmnBattleRewardId argument is malformed: \"{pkmnBattleRewardId}\"')
+        elif pkmnEvolveRewardId and not isinstance(pkmnEvolveRewardId, str):
             raise TypeError(f'pkmnEvolveRewardId argument is malformed: \"{pkmnEvolveRewardId}\"')
-        if pkmnShinyRewardId and not isinstance(pkmnShinyRewardId, str):
+        elif pkmnShinyRewardId and not isinstance(pkmnShinyRewardId, str):
             raise TypeError(f'pkmnShinyRewardId argument is malformed: \"{pkmnShinyRewardId}\"')
-        assert speedrunProfile is None or isinstance(speedrunProfile, str), f"malformed {speedrunProfile=}"
-        assert supStreamerMessage is None or isinstance(supStreamerMessage, str), f"malformed {supStreamerMessage=}"
-        assert triviaGameRewardId is None or isinstance(triviaGameRewardId, str), f"malformed {triviaGameRewardId=}"
-        assert twitter is None or isinstance(twitter, str), f"malformed {twitter=}"
+        elif speedrunProfile is not None and not isinstance(speedrunProfile, str):
+            raise TypeError(f'speedrunProfile argument is malformed: \"{speedrunProfile}\"')
+        elif supStreamerMessage is not None and not isinstance(supStreamerMessage, str):
+            raise TypeError(f'supStreamerMessage argument is malformed: \"{supStreamerMessage}\"')
+        elif triviaGameRewardId is not None and not isinstance(triviaGameRewardId, str):
+            raise TypeError(f'triviaGameRewardId argument is malformed: \"{triviaGameRewardId}\"')
+        elif twitter is not None and not isinstance(twitter, str):
+            raise TypeError(f'twitter argument is malformed: \"{twitter}\"')
 
         self.__areCheerActionsEnabled: bool = areCheerActionsEnabled
         self.__areRecurringActionsEnabled: bool = areRecurringActionsEnabled

--- a/src/CynanBot/users/userIdsRepository.py
+++ b/src/CynanBot/users/userIdsRepository.py
@@ -31,17 +31,13 @@ class UserIdsRepository(UserIdsRepositoryInterface):
         twitchApiService: TwitchApiServiceInterface,
         cacheSize: int = 128
     ):
-        if not isinstance(backingDatabase, BackingDatabase):
-            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(twitchAnonymousUserIdProvider, TwitchAnonymousUserIdProviderInterface):
-            raise ValueError(f'twitchAnonymousUserIdProvider argument is malformed: \"{twitchAnonymousUserIdProvider}\"')
-        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
-            raise ValueError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
-        elif not utils.isValidInt(cacheSize):
+        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(twitchAnonymousUserIdProvider, TwitchAnonymousUserIdProviderInterface), f"malformed {twitchAnonymousUserIdProvider=}"
+        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
+        if not utils.isValidInt(cacheSize):
             raise ValueError(f'cacheSize argument is malformed: \"{cacheSize}\"')
-        elif cacheSize < 32 or cacheSize > utils.getIntMaxSafeSize():
+        if cacheSize < 32 or cacheSize > utils.getIntMaxSafeSize():
             raise ValueError(f'cacheSize argument is out of bounds: {cacheSize}')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
@@ -80,7 +76,7 @@ class UserIdsRepository(UserIdsRepositoryInterface):
     ) -> Optional[str]:
         if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        elif twitchAccessToken is not None and not utils.isValidStr(twitchAccessToken):
+        if twitchAccessToken is not None and not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -148,9 +144,9 @@ class UserIdsRepository(UserIdsRepositoryInterface):
     ) -> Optional[str]:
         if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif userId == '0':
+        if userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
-        elif twitchAccessToken is not None and not utils.isValidStr(twitchAccessToken):
+        if twitchAccessToken is not None and not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
 
         userName: Optional[str] = None
@@ -321,9 +317,9 @@ class UserIdsRepository(UserIdsRepositoryInterface):
     async def setUser(self, userId: str, userName: str):
         if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        elif userId == '0':
+        if userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
-        elif not utils.isValidStr(userName):
+        if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         connection = await self.__getDatabaseConnection()

--- a/src/CynanBot/users/userIdsRepository.py
+++ b/src/CynanBot/users/userIdsRepository.py
@@ -31,13 +31,17 @@ class UserIdsRepository(UserIdsRepositoryInterface):
         twitchApiService: TwitchApiServiceInterface,
         cacheSize: int = 128
     ):
-        assert isinstance(backingDatabase, BackingDatabase), f"malformed {backingDatabase=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(twitchAnonymousUserIdProvider, TwitchAnonymousUserIdProviderInterface), f"malformed {twitchAnonymousUserIdProvider=}"
-        assert isinstance(twitchApiService, TwitchApiServiceInterface), f"malformed {twitchApiService=}"
-        if not utils.isValidInt(cacheSize):
+        if not isinstance(backingDatabase, BackingDatabase):
+            raise ValueError(f'backingDatabase argument is malformed: \"{backingDatabase}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(twitchAnonymousUserIdProvider, TwitchAnonymousUserIdProviderInterface):
+            raise ValueError(f'twitchAnonymousUserIdProvider argument is malformed: \"{twitchAnonymousUserIdProvider}\"')
+        elif not isinstance(twitchApiService, TwitchApiServiceInterface):
+            raise ValueError(f'twitchApiService argument is malformed: \"{twitchApiService}\"')
+        elif not utils.isValidInt(cacheSize):
             raise ValueError(f'cacheSize argument is malformed: \"{cacheSize}\"')
-        if cacheSize < 32 or cacheSize > utils.getIntMaxSafeSize():
+        elif cacheSize < 32 or cacheSize > utils.getIntMaxSafeSize():
             raise ValueError(f'cacheSize argument is out of bounds: {cacheSize}')
 
         self.__backingDatabase: BackingDatabase = backingDatabase
@@ -76,7 +80,7 @@ class UserIdsRepository(UserIdsRepositoryInterface):
     ) -> Optional[str]:
         if not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
-        if twitchAccessToken is not None and not utils.isValidStr(twitchAccessToken):
+        elif twitchAccessToken is not None and not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
 
         connection = await self.__getDatabaseConnection()
@@ -144,9 +148,9 @@ class UserIdsRepository(UserIdsRepositoryInterface):
     ) -> Optional[str]:
         if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if userId == '0':
+        elif userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
-        if twitchAccessToken is not None and not utils.isValidStr(twitchAccessToken):
+        elif twitchAccessToken is not None and not utils.isValidStr(twitchAccessToken):
             raise ValueError(f'twitchAccessToken argument is malformed: \"{twitchAccessToken}\"')
 
         userName: Optional[str] = None
@@ -317,9 +321,9 @@ class UserIdsRepository(UserIdsRepositoryInterface):
     async def setUser(self, userId: str, userName: str):
         if not utils.isValidStr(userId):
             raise ValueError(f'userId argument is malformed: \"{userId}\"')
-        if userId == '0':
+        elif userId == '0':
             raise ValueError(f'userId argument is an illegal value: \"{userId}\"')
-        if not utils.isValidStr(userName):
+        elif not utils.isValidStr(userName):
             raise ValueError(f'userName argument is malformed: \"{userName}\"')
 
         connection = await self.__getDatabaseConnection()

--- a/src/CynanBot/users/usersRepository.py
+++ b/src/CynanBot/users/usersRepository.py
@@ -26,11 +26,9 @@ class UsersRepository(UsersRepositoryInterface):
         timeZoneRepository: TimeZoneRepositoryInterface,
         usersFile: str = 'usersRepository.json'
     ):
-        if not isinstance(timber, TimberInterface):
-            raise TypeError(f'timber argument is malformed: \"{timber}\"')
-        elif not isinstance(timeZoneRepository, TimeZoneRepositoryInterface):
-            raise TypeError(f'timeZoneRepository argument is malformed: \"{timeZoneRepository}\"')
-        elif not utils.isValidStr(usersFile):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        assert isinstance(timeZoneRepository, TimeZoneRepositoryInterface), f"malformed {timeZoneRepository=}"
+        if not utils.isValidStr(usersFile):
             raise TypeError(f'usersFile argument is malformed: \"{usersFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -91,8 +89,7 @@ class UsersRepository(UsersRepositoryInterface):
     def __createUser(self, handle: str, userJson: Dict[str, Any]) -> User:
         if not utils.isValidStr(handle):
             raise ValueError(f'handle argument is malformed: \"{handle}\"')
-        elif not isinstance(userJson, Dict):
-            raise ValueError(f'userJson argument is malformed: \"{userJson}\"')
+        assert isinstance(userJson, Dict), f"malformed {userJson=}"
 
         areCheerActionsEnabled = utils.getBoolFromDict(userJson, 'cheerActionsEnabled', True)
         areRecurringActionsEnabled = utils.getBoolFromDict(userJson, 'recurringActionsEnabled', True)
@@ -315,7 +312,7 @@ class UsersRepository(UsersRepositoryInterface):
     def __findAndCreateUser(self, handle: str, jsonContents: Dict[str, Any]) -> User:
         if not utils.isValidStr(handle):
             raise ValueError(f'handle argument is malformed: \"{handle}\"')
-        elif jsonContents is None:
+        if jsonContents is None:
             raise ValueError(f'jsonContents argument is malformed: \"{jsonContents}\"')
 
         user = self.__userCache.get(handle.lower(), None)
@@ -408,7 +405,7 @@ class UsersRepository(UsersRepositoryInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from users repository file: \"{self.__usersFile}\"')
-        elif len(jsonContents) == 0:
+        if len(jsonContents) == 0:
             raise ValueError(f'JSON contents of users repository file \"{self.__usersFile}\" is empty')
 
         self.__jsonCache = jsonContents
@@ -427,7 +424,7 @@ class UsersRepository(UsersRepositoryInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from users repository file: \"{self.__usersFile}\"')
-        elif len(jsonContents) == 0:
+        if len(jsonContents) == 0:
             raise ValueError(f'JSON contents of users repository file \"{self.__usersFile}\" is empty')
 
         self.__jsonCache = jsonContents
@@ -444,7 +441,7 @@ class UsersRepository(UsersRepositoryInterface):
     async def setUserEnabled(self, handle: str, enabled: bool):
         if not utils.isValidStr(handle):
             raise ValueError(f'handle argument is malformed: \"{handle}\"')
-        elif not utils.isValidBool(enabled):
+        if not utils.isValidBool(enabled):
             raise ValueError(f'enabled argument is malformed: \"{enabled}\"')
 
         self.__timber.log('UsersRepository', f'Changing enabled status for user \"{handle}\" to \"{enabled}\"...')

--- a/src/CynanBot/users/usersRepository.py
+++ b/src/CynanBot/users/usersRepository.py
@@ -26,9 +26,11 @@ class UsersRepository(UsersRepositoryInterface):
         timeZoneRepository: TimeZoneRepositoryInterface,
         usersFile: str = 'usersRepository.json'
     ):
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        assert isinstance(timeZoneRepository, TimeZoneRepositoryInterface), f"malformed {timeZoneRepository=}"
-        if not utils.isValidStr(usersFile):
+        if not isinstance(timber, TimberInterface):
+            raise TypeError(f'timber argument is malformed: \"{timber}\"')
+        elif not isinstance(timeZoneRepository, TimeZoneRepositoryInterface):
+            raise TypeError(f'timeZoneRepository argument is malformed: \"{timeZoneRepository}\"')
+        elif not utils.isValidStr(usersFile):
             raise TypeError(f'usersFile argument is malformed: \"{usersFile}\"')
 
         self.__timber: TimberInterface = timber
@@ -89,7 +91,8 @@ class UsersRepository(UsersRepositoryInterface):
     def __createUser(self, handle: str, userJson: Dict[str, Any]) -> User:
         if not utils.isValidStr(handle):
             raise ValueError(f'handle argument is malformed: \"{handle}\"')
-        assert isinstance(userJson, Dict), f"malformed {userJson=}"
+        elif not isinstance(userJson, Dict):
+            raise ValueError(f'userJson argument is malformed: \"{userJson}\"')
 
         areCheerActionsEnabled = utils.getBoolFromDict(userJson, 'cheerActionsEnabled', True)
         areRecurringActionsEnabled = utils.getBoolFromDict(userJson, 'recurringActionsEnabled', True)
@@ -312,7 +315,7 @@ class UsersRepository(UsersRepositoryInterface):
     def __findAndCreateUser(self, handle: str, jsonContents: Dict[str, Any]) -> User:
         if not utils.isValidStr(handle):
             raise ValueError(f'handle argument is malformed: \"{handle}\"')
-        if jsonContents is None:
+        elif jsonContents is None:
             raise ValueError(f'jsonContents argument is malformed: \"{jsonContents}\"')
 
         user = self.__userCache.get(handle.lower(), None)
@@ -405,7 +408,7 @@ class UsersRepository(UsersRepositoryInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from users repository file: \"{self.__usersFile}\"')
-        if len(jsonContents) == 0:
+        elif len(jsonContents) == 0:
             raise ValueError(f'JSON contents of users repository file \"{self.__usersFile}\" is empty')
 
         self.__jsonCache = jsonContents
@@ -424,7 +427,7 @@ class UsersRepository(UsersRepositoryInterface):
 
         if jsonContents is None:
             raise IOError(f'Error reading from users repository file: \"{self.__usersFile}\"')
-        if len(jsonContents) == 0:
+        elif len(jsonContents) == 0:
             raise ValueError(f'JSON contents of users repository file \"{self.__usersFile}\" is empty')
 
         self.__jsonCache = jsonContents
@@ -441,7 +444,7 @@ class UsersRepository(UsersRepositoryInterface):
     async def setUserEnabled(self, handle: str, enabled: bool):
         if not utils.isValidStr(handle):
             raise ValueError(f'handle argument is malformed: \"{handle}\"')
-        if not utils.isValidBool(enabled):
+        elif not utils.isValidBool(enabled):
             raise ValueError(f'enabled argument is malformed: \"{enabled}\"')
 
         self.__timber.log('UsersRepository', f'Changing enabled status for user \"{handle}\" to \"{enabled}\"...')

--- a/src/CynanBot/weather/weatherReport.py
+++ b/src/CynanBot/weather/weatherReport.py
@@ -22,28 +22,26 @@ class WeatherReport():
         locationId: str,
         uvIndex: UvIndex
     ):
-        if airQualityIndex is not None and not isinstance(airQualityIndex, AirQualityIndex):
-            raise ValueError(f'airQualityIndex argument is malformed: \"{airQualityIndex}\"')
-        elif not utils.isValidNum(temperature):
+        assert airQualityIndex is None or isinstance(airQualityIndex, AirQualityIndex), f"malformed {airQualityIndex=}"
+        if not utils.isValidNum(temperature):
             raise ValueError(f'temperature argument is malformed: \"{temperature}\"')
-        elif temperature < utils.getIntMinSafeSize() or temperature > utils.getIntMaxSafeSize():
+        if temperature < utils.getIntMinSafeSize() or temperature > utils.getIntMaxSafeSize():
             raise ValueError(f'temperature argument is out of bounds: {temperature}')
-        elif not utils.isValidNum(tomorrowsHighTemperature):
+        if not utils.isValidNum(tomorrowsHighTemperature):
             raise ValueError(f'tomorrowsHighTemperature argument is malformed: \"{tomorrowsHighTemperature}\"')
-        elif tomorrowsHighTemperature < utils.getIntMinSafeSize() or tomorrowsHighTemperature > utils.getIntMaxSafeSize():
+        if tomorrowsHighTemperature < utils.getIntMinSafeSize() or tomorrowsHighTemperature > utils.getIntMaxSafeSize():
             raise ValueError(f'tomorrowsHighTemperature argument is out of bounds: {tomorrowsHighTemperature}')
-        elif not utils.isValidNum(tomorrowsLowTemperature):
+        if not utils.isValidNum(tomorrowsLowTemperature):
             raise ValueError(f'tomorrowsLowTemperature argument is malformed: \"{tomorrowsLowTemperature}\"')
-        elif tomorrowsLowTemperature < utils.getIntMinSafeSize() or tomorrowsLowTemperature > utils.getIntMaxSafeSize():
+        if tomorrowsLowTemperature < utils.getIntMinSafeSize() or tomorrowsLowTemperature > utils.getIntMaxSafeSize():
             raise ValueError(f'tomorrowsLowTemperature argument is out of bounds: {tomorrowsLowTemperature}')
-        elif not utils.isValidInt(humidity):
+        if not utils.isValidInt(humidity):
             raise ValueError(f'humidity argument is malformed: \"{humidity}\"')
-        elif not utils.isValidInt(pressure):
+        if not utils.isValidInt(pressure):
             raise ValueError(f'pressure argument is malformed: \"{pressure}\"')
-        elif not utils.isValidStr(locationId):
+        if not utils.isValidStr(locationId):
             raise ValueError(f'locationId argument is malformed: \"{locationId}\"')
-        elif not isinstance(uvIndex, UvIndex):
-            raise ValueError(f'uvIndex argument is malformed: \"{uvIndex}\"')
+        assert isinstance(uvIndex, UvIndex), f"malformed {uvIndex=}"
 
         self.__airQualityIndex: Optional[AirQualityIndex] = airQualityIndex
         self.__temperature: float = temperature
@@ -136,8 +134,7 @@ class WeatherReport():
         return self.__uvIndex is not None
 
     def toStr(self, delimiter: str = ', ') -> str:
-        if not isinstance(delimiter, str):
-            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
+        assert isinstance(delimiter, str), f"malformed {delimiter=}"
 
         temperature = f'🌡 Temperature is {self.getTemperatureStr()}°C ({self.getTemperatureImperialStr()}°F), '
         humidity = f'humidity is {self.getHumidity()}%, '

--- a/src/CynanBot/weather/weatherReport.py
+++ b/src/CynanBot/weather/weatherReport.py
@@ -22,26 +22,28 @@ class WeatherReport():
         locationId: str,
         uvIndex: UvIndex
     ):
-        assert airQualityIndex is None or isinstance(airQualityIndex, AirQualityIndex), f"malformed {airQualityIndex=}"
-        if not utils.isValidNum(temperature):
+        if airQualityIndex is not None and not isinstance(airQualityIndex, AirQualityIndex):
+            raise ValueError(f'airQualityIndex argument is malformed: \"{airQualityIndex}\"')
+        elif not utils.isValidNum(temperature):
             raise ValueError(f'temperature argument is malformed: \"{temperature}\"')
-        if temperature < utils.getIntMinSafeSize() or temperature > utils.getIntMaxSafeSize():
+        elif temperature < utils.getIntMinSafeSize() or temperature > utils.getIntMaxSafeSize():
             raise ValueError(f'temperature argument is out of bounds: {temperature}')
-        if not utils.isValidNum(tomorrowsHighTemperature):
+        elif not utils.isValidNum(tomorrowsHighTemperature):
             raise ValueError(f'tomorrowsHighTemperature argument is malformed: \"{tomorrowsHighTemperature}\"')
-        if tomorrowsHighTemperature < utils.getIntMinSafeSize() or tomorrowsHighTemperature > utils.getIntMaxSafeSize():
+        elif tomorrowsHighTemperature < utils.getIntMinSafeSize() or tomorrowsHighTemperature > utils.getIntMaxSafeSize():
             raise ValueError(f'tomorrowsHighTemperature argument is out of bounds: {tomorrowsHighTemperature}')
-        if not utils.isValidNum(tomorrowsLowTemperature):
+        elif not utils.isValidNum(tomorrowsLowTemperature):
             raise ValueError(f'tomorrowsLowTemperature argument is malformed: \"{tomorrowsLowTemperature}\"')
-        if tomorrowsLowTemperature < utils.getIntMinSafeSize() or tomorrowsLowTemperature > utils.getIntMaxSafeSize():
+        elif tomorrowsLowTemperature < utils.getIntMinSafeSize() or tomorrowsLowTemperature > utils.getIntMaxSafeSize():
             raise ValueError(f'tomorrowsLowTemperature argument is out of bounds: {tomorrowsLowTemperature}')
-        if not utils.isValidInt(humidity):
+        elif not utils.isValidInt(humidity):
             raise ValueError(f'humidity argument is malformed: \"{humidity}\"')
-        if not utils.isValidInt(pressure):
+        elif not utils.isValidInt(pressure):
             raise ValueError(f'pressure argument is malformed: \"{pressure}\"')
-        if not utils.isValidStr(locationId):
+        elif not utils.isValidStr(locationId):
             raise ValueError(f'locationId argument is malformed: \"{locationId}\"')
-        assert isinstance(uvIndex, UvIndex), f"malformed {uvIndex=}"
+        elif not isinstance(uvIndex, UvIndex):
+            raise ValueError(f'uvIndex argument is malformed: \"{uvIndex}\"')
 
         self.__airQualityIndex: Optional[AirQualityIndex] = airQualityIndex
         self.__temperature: float = temperature
@@ -134,7 +136,8 @@ class WeatherReport():
         return self.__uvIndex is not None
 
     def toStr(self, delimiter: str = ', ') -> str:
-        assert isinstance(delimiter, str), f"malformed {delimiter=}"
+        if not isinstance(delimiter, str):
+            raise ValueError(f'delimiter argument is malformed: \"{delimiter}\"')
 
         temperature = f'🌡 Temperature is {self.getTemperatureStr()}°C ({self.getTemperatureImperialStr()}°F), '
         humidity = f'humidity is {self.getHumidity()}%, '

--- a/src/CynanBot/weather/weatherRepository.py
+++ b/src/CynanBot/weather/weatherRepository.py
@@ -25,18 +25,15 @@ class WeatherRepository(WeatherRepositoryInterface):
         maxAlerts: int = 2,
         cacheTimeDelta: timedelta = timedelta(minutes = 15)
     ):
-        if not isinstance(networkClientProvider, NetworkClientProvider):
-            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
-        elif not utils.isValidStr(oneWeatherApiKey):
+        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
+        if not utils.isValidStr(oneWeatherApiKey):
             raise ValueError(f'oneWeatherApiKey argument is malformed: \"{oneWeatherApiKey}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidInt(maxAlerts):
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidInt(maxAlerts):
             raise ValueError(f'maxAlerts argument is malformed: \"{maxAlerts}\"')
-        elif maxAlerts < 1:
+        if maxAlerts < 1:
             raise ValueError(f'maxAlerts argument is out of bounds: {maxAlerts}')
-        elif not isinstance(cacheTimeDelta, timedelta):
-            raise ValueError(f'cacheTimeDelta argument is malformed: \"{cacheTimeDelta}\"')
+        assert isinstance(cacheTimeDelta, timedelta), f"malformed {cacheTimeDelta=}"
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__oneWeatherApiKey: str = oneWeatherApiKey
@@ -107,8 +104,7 @@ class WeatherRepository(WeatherRepositoryInterface):
         return icons
 
     async def __fetchAirQualityIndex(self, location: Location) -> Optional[AirQualityIndex]:
-        if not isinstance(location, Location):
-            raise ValueError(f'location argument is malformed: \"{location}\"')
+        assert isinstance(location, Location), f"malformed {location=}"
 
         # Retrieve air quality index from: https://openweathermap.org/api/air-pollution
         # Doing this requires an API key, which you can get here: https://openweathermap.org/api
@@ -147,8 +143,7 @@ class WeatherRepository(WeatherRepositoryInterface):
             return AirQualityIndex.fromInt(airQualityIndex)
 
     async def fetchWeather(self, location: Location) -> WeatherReport:
-        if not isinstance(location, Location):
-            raise ValueError(f'location argument is malformed: \"{location}\"')
+        assert isinstance(location, Location), f"malformed {location=}"
 
         cacheValue = self.__cache[location.getLocationId()]
         if cacheValue is not None:
@@ -160,8 +155,7 @@ class WeatherRepository(WeatherRepositoryInterface):
         return weatherReport
 
     async def __fetchWeather(self, location: Location) -> WeatherReport:
-        if not isinstance(location, Location):
-            raise ValueError(f'location argument is malformed: \"{location}\"')
+        assert isinstance(location, Location), f"malformed {location=}"
 
         self.__timber.log('WeatherRepository', f'Fetching weather for \"{location.getName()}\" ({location.getLocationId()})...')
         clientSession = await self.__networkClientProvider.get()

--- a/src/CynanBot/weather/weatherRepository.py
+++ b/src/CynanBot/weather/weatherRepository.py
@@ -25,15 +25,18 @@ class WeatherRepository(WeatherRepositoryInterface):
         maxAlerts: int = 2,
         cacheTimeDelta: timedelta = timedelta(minutes = 15)
     ):
-        assert isinstance(networkClientProvider, NetworkClientProvider), f"malformed {networkClientProvider=}"
-        if not utils.isValidStr(oneWeatherApiKey):
+        if not isinstance(networkClientProvider, NetworkClientProvider):
+            raise ValueError(f'networkClientProvider argument is malformed: \"{networkClientProvider}\"')
+        elif not utils.isValidStr(oneWeatherApiKey):
             raise ValueError(f'oneWeatherApiKey argument is malformed: \"{oneWeatherApiKey}\"')
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidInt(maxAlerts):
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidInt(maxAlerts):
             raise ValueError(f'maxAlerts argument is malformed: \"{maxAlerts}\"')
-        if maxAlerts < 1:
+        elif maxAlerts < 1:
             raise ValueError(f'maxAlerts argument is out of bounds: {maxAlerts}')
-        assert isinstance(cacheTimeDelta, timedelta), f"malformed {cacheTimeDelta=}"
+        elif not isinstance(cacheTimeDelta, timedelta):
+            raise ValueError(f'cacheTimeDelta argument is malformed: \"{cacheTimeDelta}\"')
 
         self.__networkClientProvider: NetworkClientProvider = networkClientProvider
         self.__oneWeatherApiKey: str = oneWeatherApiKey
@@ -104,7 +107,8 @@ class WeatherRepository(WeatherRepositoryInterface):
         return icons
 
     async def __fetchAirQualityIndex(self, location: Location) -> Optional[AirQualityIndex]:
-        assert isinstance(location, Location), f"malformed {location=}"
+        if not isinstance(location, Location):
+            raise ValueError(f'location argument is malformed: \"{location}\"')
 
         # Retrieve air quality index from: https://openweathermap.org/api/air-pollution
         # Doing this requires an API key, which you can get here: https://openweathermap.org/api
@@ -143,7 +147,8 @@ class WeatherRepository(WeatherRepositoryInterface):
             return AirQualityIndex.fromInt(airQualityIndex)
 
     async def fetchWeather(self, location: Location) -> WeatherReport:
-        assert isinstance(location, Location), f"malformed {location=}"
+        if not isinstance(location, Location):
+            raise ValueError(f'location argument is malformed: \"{location}\"')
 
         cacheValue = self.__cache[location.getLocationId()]
         if cacheValue is not None:
@@ -155,7 +160,8 @@ class WeatherRepository(WeatherRepositoryInterface):
         return weatherReport
 
     async def __fetchWeather(self, location: Location) -> WeatherReport:
-        assert isinstance(location, Location), f"malformed {location=}"
+        if not isinstance(location, Location):
+            raise ValueError(f'location argument is malformed: \"{location}\"')
 
         self.__timber.log('WeatherRepository', f'Fetching weather for \"{location.getName()}\" ({location.getLocationId()})...')
         clientSession = await self.__networkClientProvider.get()

--- a/src/CynanBot/websocketConnection/websocketConnectionServer.py
+++ b/src/CynanBot/websocketConnection/websocketConnectionServer.py
@@ -31,28 +31,23 @@ class WebsocketConnectionServer(WebsocketConnectionServerInterface):
         eventTimeToLive: timedelta = timedelta(seconds = 30),
         timeZone: timezone = timezone.utc
     ):
-        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
-            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
-        elif not isinstance(settingsJsonReader, JsonReaderInterface):
-            raise ValueError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
-        elif not isinstance(timber, TimberInterface):
-            raise ValueError(f'timber argument is malformed: \"{timber}\"')
-        elif not utils.isValidNum(sleepTimeSeconds):
+        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
+        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
+        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
+        if not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        elif sleepTimeSeconds < 3 or sleepTimeSeconds > 10:
+        if sleepTimeSeconds < 3 or sleepTimeSeconds > 10:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        elif not utils.isValidInt(port):
+        if not utils.isValidInt(port):
             raise ValueError(f'port argument is malformed: \"{port}\"')
-        elif port <= 1000 or port > utils.getIntMaxSafeSize():
+        if port <= 1000 or port > utils.getIntMaxSafeSize():
             raise ValueError(f'port argument is out of bounds: {port}')
-        elif not utils.isValidStr(host):
+        if not utils.isValidStr(host):
             raise ValueError(f'host argument is malformed: \"{host}\"')
-        elif not utils.isValidStr(websocketSettingsFile):
+        if not utils.isValidStr(websocketSettingsFile):
             raise ValueError(f'websocketSettingsFile argument is malformed: \"{websocketSettingsFile}\"')
-        elif not isinstance(eventTimeToLive, timedelta):
-            raise ValueError(f'eventTimeToLive argument is malformed: \"{eventTimeToLive}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(eventTimeToLive, timedelta), f"malformed {eventTimeToLive=}"
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
@@ -101,9 +96,9 @@ class WebsocketConnectionServer(WebsocketConnectionServerInterface):
     ):
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        elif not utils.isValidStr(eventType):
+        if not utils.isValidStr(eventType):
             raise ValueError(f'eventType argument for twitchChannel \"{twitchChannel}\" is malformed: \"{eventType}\"')
-        elif not isinstance(eventData, Dict) or len(eventData) == 0:
+        if not isinstance(eventData, Dict) or len(eventData) == 0:
             raise ValueError(f'eventData argument for eventType \"{eventType}\" and twitchChannel \"{twitchChannel}\" is malformed: \"{eventData}\"')
 
         event: Dict[str, Any] = {

--- a/src/CynanBot/websocketConnection/websocketConnectionServer.py
+++ b/src/CynanBot/websocketConnection/websocketConnectionServer.py
@@ -31,23 +31,28 @@ class WebsocketConnectionServer(WebsocketConnectionServerInterface):
         eventTimeToLive: timedelta = timedelta(seconds = 30),
         timeZone: timezone = timezone.utc
     ):
-        assert isinstance(backgroundTaskHelper, BackgroundTaskHelper), f"malformed {backgroundTaskHelper=}"
-        assert isinstance(settingsJsonReader, JsonReaderInterface), f"malformed {settingsJsonReader=}"
-        assert isinstance(timber, TimberInterface), f"malformed {timber=}"
-        if not utils.isValidNum(sleepTimeSeconds):
+        if not isinstance(backgroundTaskHelper, BackgroundTaskHelper):
+            raise ValueError(f'backgroundTaskHelper argument is malformed: \"{backgroundTaskHelper}\"')
+        elif not isinstance(settingsJsonReader, JsonReaderInterface):
+            raise ValueError(f'settingsJsonReader argument is malformed: \"{settingsJsonReader}\"')
+        elif not isinstance(timber, TimberInterface):
+            raise ValueError(f'timber argument is malformed: \"{timber}\"')
+        elif not utils.isValidNum(sleepTimeSeconds):
             raise ValueError(f'sleepTimeSeconds argument is malformed: \"{sleepTimeSeconds}\"')
-        if sleepTimeSeconds < 3 or sleepTimeSeconds > 10:
+        elif sleepTimeSeconds < 3 or sleepTimeSeconds > 10:
             raise ValueError(f'sleepTimeSeconds argument is out of bounds: {sleepTimeSeconds}')
-        if not utils.isValidInt(port):
+        elif not utils.isValidInt(port):
             raise ValueError(f'port argument is malformed: \"{port}\"')
-        if port <= 1000 or port > utils.getIntMaxSafeSize():
+        elif port <= 1000 or port > utils.getIntMaxSafeSize():
             raise ValueError(f'port argument is out of bounds: {port}')
-        if not utils.isValidStr(host):
+        elif not utils.isValidStr(host):
             raise ValueError(f'host argument is malformed: \"{host}\"')
-        if not utils.isValidStr(websocketSettingsFile):
+        elif not utils.isValidStr(websocketSettingsFile):
             raise ValueError(f'websocketSettingsFile argument is malformed: \"{websocketSettingsFile}\"')
-        assert isinstance(eventTimeToLive, timedelta), f"malformed {eventTimeToLive=}"
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        elif not isinstance(eventTimeToLive, timedelta):
+            raise ValueError(f'eventTimeToLive argument is malformed: \"{eventTimeToLive}\"')
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__backgroundTaskHelper: BackgroundTaskHelper = backgroundTaskHelper
         self.__settingsJsonReader: JsonReaderInterface = settingsJsonReader
@@ -96,9 +101,9 @@ class WebsocketConnectionServer(WebsocketConnectionServerInterface):
     ):
         if not utils.isValidStr(twitchChannel):
             raise ValueError(f'twitchChannel argument is malformed: \"{twitchChannel}\"')
-        if not utils.isValidStr(eventType):
+        elif not utils.isValidStr(eventType):
             raise ValueError(f'eventType argument for twitchChannel \"{twitchChannel}\" is malformed: \"{eventType}\"')
-        if not isinstance(eventData, Dict) or len(eventData) == 0:
+        elif not isinstance(eventData, Dict) or len(eventData) == 0:
             raise ValueError(f'eventData argument for eventType \"{eventType}\" and twitchChannel \"{twitchChannel}\" is malformed: \"{eventData}\"')
 
         event: Dict[str, Any] = {

--- a/src/CynanBot/websocketConnection/websocketEvent.py
+++ b/src/CynanBot/websocketConnection/websocketEvent.py
@@ -13,8 +13,7 @@ class WebsocketEvent():
     ):
         if not utils.hasItems(eventData):
             raise ValueError(f'eventData argument is malformed: \"{eventData}\"')
-        elif not isinstance(timeZone, timezone):
-            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
+        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
 
         self.__eventTime: datetime = datetime.now(timeZone)
         self.__eventData: Dict[str, Any] = eventData

--- a/src/CynanBot/websocketConnection/websocketEvent.py
+++ b/src/CynanBot/websocketConnection/websocketEvent.py
@@ -13,7 +13,8 @@ class WebsocketEvent():
     ):
         if not utils.hasItems(eventData):
             raise ValueError(f'eventData argument is malformed: \"{eventData}\"')
-        assert isinstance(timeZone, timezone), f"malformed {timeZone=}"
+        elif not isinstance(timeZone, timezone):
+            raise ValueError(f'timeZone argument is malformed: \"{timeZone}\"')
 
         self.__eventTime: datetime = datetime.now(timeZone)
         self.__eventData: Dict[str, Any] = eventData


### PR DESCRIPTION
I found a way to get your run-time type checking with type checking in strict mode.

pros:
- easier to enable strict type checking
- fewer lines
- no run-time type checking if running in optimized mode

cons:
- AssertionError instead of TypeError
- a new pattern to get used to
- no run-time type checking if running in optimized mode

These edits were automated, not typed by me. It may have broken something.
I wrote a python script to look for patterns and change the python code.

I don't want to pressure you into accepting this. I'm not sure whether it's a good change, just an idea to consider.