### PR TITLE
function decorator for run-time type checking

### DIFF
--- a/src/CynanBot/misc/tests/test_type_check.py
+++ b/src/CynanBot/misc/tests/test_type_check.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from collections import abc
 from enum import Enum
 import typing
@@ -237,3 +238,44 @@ def test_with_mixed_arg_kwarg() -> None:
 
     with pytest.raises(TypeError):
         f(x=b"False", y="8")  # type: ignore
+
+
+def test_interface() -> None:
+    class B(ABC):
+        pass
+
+    class C(B):
+        pass
+
+    class D:
+        pass
+
+    @type_check
+    def f(b: B) -> frozenset[str]:
+        return frozenset()
+
+    c = C()
+    f(c)
+
+    d = D()
+    with pytest.raises(TypeError):
+        f(d)  # type: ignore
+
+
+def test_interface_method() -> None:
+
+    class B(ABC):
+        @abstractmethod
+        def f(self, x: bytes | None) -> int:
+            """ interface method definition """
+
+    class C(B):
+        @type_check
+        def f(self, x: bytes | None) -> int:
+            return 0
+
+    b: B = C()
+    b.f(b"f")
+
+    with pytest.raises(TypeError):
+        b.f("f")  # type: ignore

--- a/src/CynanBot/misc/tests/test_type_check.py
+++ b/src/CynanBot/misc/tests/test_type_check.py
@@ -354,3 +354,23 @@ def test_interface_method() -> None:
 
     with pytest.raises(TypeError):
         b.f("f")  # type: ignore
+
+
+def test_consumable_iterable() -> None:
+    """ make sure the type checker doesn't consume the consumable iterable """
+
+    def iterator() -> abc.Iterator[int]:
+        yield 5
+
+    @type_check
+    def f(x: abc.Iterable[int]) -> bytearray:
+        return bytearray()
+
+    it = iterator()
+
+    f(it)
+
+    count = 0
+    for _ in it:
+        count += 1
+    assert count == 1, f"{count=}"

--- a/src/CynanBot/misc/tests/test_type_check.py
+++ b/src/CynanBot/misc/tests/test_type_check.py
@@ -1,0 +1,239 @@
+from collections import abc
+from enum import Enum
+import typing
+
+import pytest
+
+from CynanBot.misc.type_check import type_check
+
+
+def test_no_params() -> None:
+    """ don't know why you'd do this, but it shouldn't break """
+
+    @type_check
+    def f() -> None:
+        pass
+
+    f()
+
+
+def test_bad_name_kwarg() -> None:
+
+    @type_check
+    def f() -> None:
+        pass
+
+    with pytest.raises(TypeError):
+        f(x=3)  # type: ignore
+
+
+def test_too_many_arg() -> None:
+
+    @type_check
+    def f() -> None:
+        pass
+
+    with pytest.raises(TypeError):
+        f("3")  # type: ignore
+
+
+def test_int_for_float() -> None:
+    """ int should be accepted when param is float """
+
+    @type_check
+    def f(x: float) -> None:
+        pass
+
+    f(42)
+    f(2.2)
+
+
+def test_float_for_int() -> None:
+    """ float should not be accepted where int is required """
+
+    @type_check
+    def f(x: int) -> None:
+        pass
+
+    f(7)
+
+    with pytest.raises(TypeError):
+        f(9.9)  # type: ignore
+
+
+def test_int_for_opt_float() -> None:
+
+    @type_check
+    def f(x: float | None) -> None:
+        pass
+
+    f(42)
+    f(3.14)
+    f(None)
+
+
+def test_float_for_opt_int() -> None:
+    """ float should not be accepted where int | None is required """
+
+    @type_check
+    def f(x: int | None) -> None:
+        pass
+
+    with pytest.raises(TypeError):
+        f(9.9)  # type: ignore
+
+
+def test_none_union() -> None:
+
+    @type_check
+    def f(x: str | None) -> str:
+        return f"{x}"
+
+    f("hello")
+    f(None)
+
+    with pytest.raises(TypeError):
+        f(1.1)  # type: ignore
+
+
+def test_none_alone() -> None:
+    """ don't know why you would want to do this, but shouldn't break """
+
+    @type_check
+    def f(x: None) -> int:
+        return 3
+
+    f(None)
+
+    with pytest.raises(TypeError):
+        f([])  # type: ignore
+
+
+def test_typing_generic() -> None:
+    """ non-builtin generics not supported (yet?) """
+
+    with pytest.raises(TypeError):
+        @type_check
+        def f(x: typing.Iterable[str]) -> str | None:
+            return "abc"
+
+
+def test_abc_generic() -> None:
+    """ non-builtin generics not supported (yet?) """
+
+    with pytest.raises(TypeError):
+        @type_check
+        def f(x: abc.Iterable[str]) -> str | None:
+            return "abc"
+
+
+def test_builtin_generic() -> None:
+    """ builtin generics also not supported (yet?) """
+
+    with pytest.raises(TypeError):
+        @type_check
+        def f(x: list[str]) -> str | None:
+            return "abc"
+
+
+def test_custom_class() -> None:
+
+    class C:
+        pass
+
+    @type_check
+    def f(x: C) -> list[str]:
+        return []
+
+    f(C())
+
+    with pytest.raises(TypeError):
+        f(4)  # type: ignore
+
+
+def test_enum() -> None:
+
+    class E(Enum):
+        e = 1
+
+    @type_check
+    def f(x: E) -> abc.Mapping[int, str | None]:
+        return {}
+
+    f(E.e)
+
+    with pytest.raises(TypeError):
+        f(1)  # type: ignore
+
+
+def test_str_annotations() -> None:
+    """ str annotations not supported """
+
+    with pytest.raises(TypeError):
+        @type_check
+        def f(x: float, y: "str", z: object) -> object:
+            return x
+
+
+def test_second_arg() -> None:
+
+    @type_check
+    def f(x: int, y: float, z: str) -> int | None:
+        return int(y)
+
+    f(5, 5, "5")
+
+    with pytest.raises(TypeError):
+        f(5, 5j, "5")  # type: ignore
+
+
+def test_method() -> None:
+
+    class C:
+
+        @type_check
+        def f(self, x: object, y: str, z: bool | None) -> bool:
+            return False
+
+    c = C()
+
+    c.f(c, "c", True)
+    c.f(None, f"{c}", None)
+
+    with pytest.raises(TypeError):
+        c.f(None, c, False)  # type: ignore
+
+
+def test_with_defaults() -> None:
+
+    @type_check
+    def f(x: str, y: object, z: int | None = None) -> dict[bool, bool]:
+        return {}
+
+    f("a", b"b")
+    f("a", b"b", 3)
+
+    with pytest.raises(TypeError):
+        f(b"b", "a")  # type: ignore
+
+    with pytest.raises(TypeError):
+        f("a", 2.2, "c")  # type: ignore
+
+    with pytest.raises(TypeError):
+        f(1, b"b", 3)  # type: ignore
+
+
+def test_with_mixed_arg_kwarg() -> None:
+
+    @type_check
+    def f(x: bool | None, *, y: str, z: bool = True) -> None:
+        pass
+
+    f(True, y="f")
+    f(x=False, y="True", z=True)
+
+    with pytest.raises(TypeError):
+        f(True, y="f", z=8)  # type: ignore
+
+    with pytest.raises(TypeError):
+        f(x=b"False", y="8")  # type: ignore

--- a/src/CynanBot/misc/tests/test_type_check.py
+++ b/src/CynanBot/misc/tests/test_type_check.py
@@ -111,7 +111,6 @@ def test_none_alone() -> None:
 
 
 def test_typing_generic() -> None:
-    """ non-builtin generics not supported (yet?) """
 
     @type_check
     def f(x: typing.Iterable[str]) -> str | None:
@@ -132,7 +131,6 @@ def test_typing_generic() -> None:
 
 
 def test_abc_generic() -> None:
-    """ non-builtin generics not supported (yet?) """
 
     @type_check
     def f(x: abc.Sequence[float]) -> str | None:
@@ -151,7 +149,6 @@ def test_abc_generic() -> None:
 
 
 def test_builtin_generic() -> None:
-    """ builtin generics also not supported (yet?) """
 
     @type_check
     def f(x: dict[str, dict[bytes, int | None]]) -> str | None:

--- a/src/CynanBot/misc/type_check.py
+++ b/src/CynanBot/misc/type_check.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 import logging
 from types import GenericAlias, UnionType
 from typing import Callable, NoReturn, ParamSpec, TypeGuard, TypeVar
@@ -40,8 +40,10 @@ def _check_type(name: str, expected_type: _Checkable, value: object) -> None:
         type_vars = expected_type.__args__
         if len(type_vars) == 1:
             assert isinstance(value, Iterable), f"not iterable {name=} {value=} {expected_type=}"
-            for each_value in value:
-                _check_type(f"item in {name}", type_vars[0], each_value)
+            # if this is an Iterator, we don't want to check the values inside, because it can consume them
+            if not isinstance(value, Iterator):
+                for each_value in value:
+                    _check_type(f"item in {name}", type_vars[0], each_value)
         else:
             assert len(type_vars) == 2, f"{name=} {value=} {expected_type=}"
             assert isinstance(value, Mapping), f"not mapping {name=} {value=} {expected_type=}"

--- a/src/CynanBot/misc/type_check.py
+++ b/src/CynanBot/misc/type_check.py
@@ -1,0 +1,117 @@
+import logging
+from types import UnionType
+from typing import Callable, NoReturn, ParamSpec, TypeGuard, TypeVar, assert_type
+from inspect import signature
+
+_Checkable = type | UnionType | None
+
+# TODO: implement generics
+# uncheckable annotation name='x' ann=collections.abc.Iterable[str] type(ann)=<class 'types.GenericAlias'>
+# (shows same "collections.abc" for typing.Iterable)
+
+
+def _check_type(name: str, expected_type: _Checkable, value: object) -> None:
+    """ raises TypeError if `value` is not `expected_type` """
+
+    def error() -> NoReturn:
+        raise TypeError(f"MALFORMED!! teh thingz!!!!1 oh, noes! guwuDesk {name=} {value=} {expected_type=}")
+
+    if expected_type is None:
+        if value is not None:
+            error()
+    elif isinstance(expected_type, type):
+        if expected_type is float:
+            if not isinstance(value, (float, int)):
+                error()
+        else:
+            if not isinstance(value, expected_type):
+                error()
+    else:
+        assert_type(expected_type, UnionType)
+        found_valid = False
+        for u_type in expected_type.__args__:
+            got_type_error = False
+            try:
+                _check_type(name, u_type, value)
+            except TypeError:
+                got_type_error = True
+            if not got_type_error:
+                found_valid = True
+                break
+        if not found_valid:
+            error()
+
+
+_names_that_dont_need_annotations = frozenset([
+    "return", "self"
+])
+
+
+def _is_checkable(annotations: dict[str, object]) -> TypeGuard[dict[str, _Checkable]]:
+    """
+    raise RuntimeError if there's some annotation that can't be checked
+
+    return True otherwise (never returns False)
+    """
+
+    def _individual(name: str, ann: object) -> TypeGuard[_Checkable]:
+        if ann is None:
+            return True
+        if isinstance(ann, str):
+            # I've heard some libraries use eval for this.
+            # It could get tricky.
+            # Let's see how often it comes up.
+            logging.warning(f"str annotation found {ann=}")
+        if isinstance(ann, type):
+            # recursion base case
+            return True
+        if isinstance(ann, UnionType) and all(_individual(name, a) for a in ann.__args__):
+            return True
+        raise TypeError(f"uncheckable annotation {name=} {ann=} {type(ann)=}")
+
+    return all(
+        _individual(name, ann)
+        for name, ann in annotations.items()
+        if name not in _names_that_dont_need_annotations
+    )
+
+
+_P = ParamSpec('_P')
+_RT = TypeVar("_RT")
+
+
+def type_check(func: Callable[_P, _RT]) -> Callable[_P, _RT]:
+    """ apply run-time type checking to the parameters of this function """
+
+    annotations = func.__annotations__
+    assert _is_checkable(annotations)
+    sig = signature(func)
+    params = sig.parameters
+
+    # make sure all parameters have a type annotation
+    for param_name in params:
+        if param_name not in annotations and param_name not in _names_that_dont_need_annotations:
+            raise TypeError(f"{param_name=} missing type annotation")
+
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _RT:
+
+        # positional arguments
+        for param_name, param_value in zip(params, args):
+            if param_name not in annotations:
+                assert param_name == "self", f"samusConf {param_name=}"
+                continue
+            param_type = annotations[param_name]
+            _check_type(param_name, param_type, param_value)
+
+        # keyword arguments
+        for param_name, param_value in kwargs.items():
+            if param_name not in params:
+                # let it go through - will get normal "no argument named" error
+                continue
+            param_type = annotations[param_name]
+            _check_type(param_name, param_type, param_value)
+
+        result = func(*args, **kwargs)
+        return result
+
+    return wrapper

--- a/src/CynanBot/twitch/api/websocket/twitchWebsocketTransport.py
+++ b/src/CynanBot/twitch/api/websocket/twitchWebsocketTransport.py
@@ -1,51 +1,42 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 import CynanBot.misc.utils as utils
 from CynanBot.misc.simpleDateTime import SimpleDateTime
+from CynanBot.misc.type_check import type_check
 from CynanBot.twitch.api.websocket.twitchWebsocketTransportMethod import \
     TwitchWebsocketTransportMethod
 
 
 class TwitchWebsocketTransport():
 
+    @type_check
     def __init__(
         self,
-        connectedAt: Optional[SimpleDateTime] = None,
-        disconnectedAt: Optional[SimpleDateTime] = None,
-        secret: Optional[str] = None,
-        sessionId: Optional[str] = None,
+        connectedAt: SimpleDateTime | None = None,
+        disconnectedAt: SimpleDateTime | None = None,
+        secret: str | None = None,
+        sessionId: str | None = None,
         method: TwitchWebsocketTransportMethod = TwitchWebsocketTransportMethod.WEBSOCKET,
     ):
-        if connectedAt is not None and not isinstance(connectedAt, SimpleDateTime):
-            raise TypeError(f'connectedAt argument is malformed: \"{connectedAt}\"')
-        elif disconnectedAt is not None and not isinstance(disconnectedAt, SimpleDateTime):
-            raise TypeError(f'disconnectedAt argument is malformed: \"{disconnectedAt}\"')
-        elif secret is not None and not isinstance(secret, str):
-            raise TypeError(f'secret argument is malformed: \"{secret}\"')
-        elif sessionId is not None and not isinstance(sessionId, str):
-            raise TypeError(f'sessionId argument is malformed: \"{sessionId}\"')
-        elif not isinstance(method, TwitchWebsocketTransportMethod):
-            raise TypeError(f'method argument is malformed: \"{method}\"')
-
-        self.__connectedAt: Optional[SimpleDateTime] = connectedAt
-        self.__disconnectedAt: Optional[SimpleDateTime] = disconnectedAt
-        self.__secret: Optional[str] = secret
-        self.__sessionId: Optional[str] = sessionId
+        self.__connectedAt: SimpleDateTime | None = connectedAt
+        self.__disconnectedAt: SimpleDateTime | None = disconnectedAt
+        self.__secret: str | None = secret
+        self.__sessionId: str | None = sessionId
         self.__method: TwitchWebsocketTransportMethod = method
 
-    def getConnectedAt(self) -> Optional[SimpleDateTime]:
+    def getConnectedAt(self) -> SimpleDateTime | None:
         return self.__connectedAt
 
-    def getDisconnectedAt(self) -> Optional[SimpleDateTime]:
+    def getDisconnectedAt(self) -> SimpleDateTime | None:
         return self.__disconnectedAt
 
     def getMethod(self) -> TwitchWebsocketTransportMethod:
         return self.__method
 
-    def getSecret(self) -> Optional[str]:
+    def getSecret(self) -> str | None:
         return self.__secret
 
-    def getSessionId(self) -> Optional[str]:
+    def getSessionId(self) -> str | None:
         return self.__sessionId
 
     def __repr__(self) -> str:
@@ -60,7 +51,7 @@ class TwitchWebsocketTransport():
 
         return sessionId
 
-    def toDictionary(self) -> Dict[str, Any]:
+    def toDictionary(self) -> dict[str, Any]:
         return {
             'connectedAt': self.__connectedAt,
             'disconnectedAt': self.__disconnectedAt,
@@ -68,4 +59,3 @@ class TwitchWebsocketTransport():
             'secret': self.__secret,
             'sessionId': self.__sessionId
         }
-    


### PR DESCRIPTION
This new function decorator adds run-time type checking to all the parameters of the function.

Every time the function is called, it will make sure all the objects passed as parameters match the types in the type annotations.

It doesn't work for everything. So don't go putting on everything yet.
Put it on things gradually, making sure it works.

~~The biggest weakness is that it doesn't support generics.~~
```python
def foo(x: list[str]) -> int:
   ...
```
~~It can't be used with this because of the generic `list`.
Any type annotations with square brackets won't work.
(The return type could still use generics. This only checks parameters.)~~

~~I might get to implementing generics some time...~~

Most generics work now. (implementations of `Iterable` or `Mapping`)

It only checks types, not values. So you shouldn't delete your value checking.
(checking whether a string is empty, or whether a number is negative)

It doesn't have to call the function to find out whether it will be able to check that function.
If it can't check that function, it will tell you when the function is defined.
For most functions, this is when you start up the bot (when you import the module).

See the new unit tests for examples.
Notice that some `with pytest.raises(TypeError):` is around the definition, and some is around the function call.

I've used `twitchWebsocketTransport.py` as the demonstration.
(I made sure to choose a function that is run in unit tests.)

---

`typing.Optional` is soft-deprecated

https://typing.readthedocs.io/en/latest/source/best_practices.html

instead of `Optional[str]`
use `str | None`

- It's more clear and explicit
- It's fewer characters
- It doesn't require any imports
