### PR TITLE
big chunk of typing fixes

### DIFF
--- a/src/CynanBot/chatLogger/chatLogger.py
+++ b/src/CynanBot/chatLogger/chatLogger.py
@@ -10,7 +10,6 @@ import aiofiles.ospath
 import CynanBot.misc.utils as utils
 from CynanBot.backgroundTaskHelper import BackgroundTaskHelper
 from CynanBot.chatLogger.absChatMessage import AbsChatMessage
-from CynanBot.chatLogger.chatEventType import ChatEventType
 from CynanBot.chatLogger.chatLoggerInterface import ChatLoggerInterface
 from CynanBot.chatLogger.chatMessage import ChatMessage
 from CynanBot.chatLogger.raidMessage import RaidMessage
@@ -51,14 +50,12 @@ class ChatLogger(ChatLoggerInterface):
 
         logStatement = f'{message.getSimpleDateTime().getDateAndTimeStr(True)} —'
 
-        if message.getChatEventType() is ChatEventType.MESSAGE:
-            chatMessage: ChatMessage = message
-            logStatement = f'{logStatement} {chatMessage.getUserName()} ({chatMessage.getUserId()}) — {chatMessage.getMsg()}'
-        elif message.getChatEventType() is ChatEventType.RAID:
-            raidMessage: RaidMessage = message
-            logStatement = f'{logStatement} Received raid from {raidMessage.getFromWho()} of {raidMessage.getRaidSizeStr()}!'
+        if isinstance(message, ChatMessage):
+            logStatement = f'{logStatement} {message.getUserName()} ({message.getUserId()}) — {message.getMsg()}'
+        elif isinstance(message, RaidMessage):
+            logStatement = f'{logStatement} Received raid from {message.getFromWho()} of {message.getRaidSizeStr()}!'
         else:
-            raise RuntimeError(f'AbsChatMessage has unknown ChatEventType: \"{message.getChatEventType()}\"')
+            raise RuntimeError(f'AbsChatMessage has unknown type: \"{type(message)=}\"')
 
         return f'{logStatement.strip()}\n'
 

--- a/src/CynanBot/cheerActions/tests/test_cheerActionType.py
+++ b/src/CynanBot/cheerActions/tests/test_cheerActionType.py
@@ -17,7 +17,7 @@ class TestCheerActionType():
         result: CheerActionType | None = None
 
         with pytest.raises(ValueError):
-            result = CheerActionType.fromStr(None)
+            result = CheerActionType.fromStr(None)  # type: ignore
 
         assert result is None
 

--- a/src/CynanBot/cynanBot.py
+++ b/src/CynanBot/cynanBot.py
@@ -181,7 +181,6 @@ from CynanBot.trivia.events.newTriviaGameEvent import NewTriviaGameEvent
 from CynanBot.trivia.events.outOfTimeSuperTriviaEvent import \
     OutOfTimeSuperTriviaEvent
 from CynanBot.trivia.events.outOfTimeTriviaEvent import OutOfTimeTriviaEvent
-from CynanBot.trivia.events.triviaEventType import TriviaEventType
 from CynanBot.trivia.gameController.triviaGameControllersRepositoryInterface import \
     TriviaGameControllersRepositoryInterface
 from CynanBot.trivia.gameController.triviaGameGlobalControllersRepositoryInterface import \
@@ -293,7 +292,7 @@ class CynanBot(
         bannedTriviaGameControllersRepository: Optional[BannedTriviaGameControllersRepositoryInterface],
         bannedWordsRepository: Optional[BannedWordsRepositoryInterface],
         channelJoinHelper: ChannelJoinHelper,
-        channelPointSoundHelper: ChannelPointSoundHelperInterface |  None,
+        channelPointSoundHelper: ChannelPointSoundHelperInterface | None,
         chatActionsManager: Optional[ChatActionsManagerInterface],
         chatLogger: ChatLoggerInterface,
         cheerActionHelper: Optional[CheerActionHelperInterface],
@@ -589,7 +588,7 @@ class CynanBot(
             self.__removeGlobalTriviaControllerCommand: AbsCommand = StubCommand()
         else:
             self.__addGlobalTriviaControllerCommand: AbsChatCommand = AddGlobalTriviaControllerCommand(administratorProvider, timber, triviaGameGlobalControllersRepository, twitchUtils, usersRepository)
-            self.__getGlobalTriviaControllersCommand: AbsCommand = GetGlobalTriviaControllersCommand(administratorProvider,  timber, triviaGameGlobalControllersRepository, triviaUtils, twitchUtils, usersRepository)
+            self.__getGlobalTriviaControllersCommand: AbsCommand = GetGlobalTriviaControllersCommand(administratorProvider, timber, triviaGameGlobalControllersRepository, triviaUtils, twitchUtils, usersRepository)
             self.__removeGlobalTriviaControllerCommand: AbsCommand = RemoveGlobalTriviaControllerCommand(administratorProvider, timber, triviaGameGlobalControllersRepository, twitchUtils, usersRepository)
 
         if additionalTriviaAnswersRepository is None or cutenessRepository is None or triviaEmoteGenerator is None or triviaGameBuilder is None or triviaGameMachine is None or triviaHistoryRepository is None or triviaIdGenerator is None or triviaSettingsRepository is None or triviaScoreRepository is None or triviaUtils is None:
@@ -729,7 +728,7 @@ class CynanBot(
 
         try:
             user = await self.__usersRepository.getUserAsync(channel)
-        except:
+        except Exception:
             pass
 
         self.__timber.log('CynanBot', f'Failed to join channel \"{channel}\" (userId=\"{userId}\") (user=\"{user}\"), disabling this user...')
@@ -965,29 +964,28 @@ class CynanBot(
         await self.wait_for_ready()
 
         self.__timber.log('CynanBot', f'Received new trivia event: \"{event}\"')
-        eventType = event.getTriviaEventType()
 
-        if eventType is TriviaEventType.CLEARED_SUPER_TRIVIA_QUEUE:
+        if isinstance(event, ClearedSuperTriviaQueueTriviaEvent):
             await self.__handleClearedSuperTriviaQueueTriviaEvent(event)
-        elif eventType is TriviaEventType.CORRECT_ANSWER:
+        elif isinstance(event, CorrectAnswerTriviaEvent):
             await self.__handleCorrectAnswerTriviaEvent(event)
-        elif eventType is TriviaEventType.GAME_FAILED_TO_FETCH_QUESTION:
+        elif isinstance(event, FailedToFetchQuestionTriviaEvent):
             await self.__handleFailedToFetchQuestionTriviaEvent(event)
-        elif eventType is TriviaEventType.GAME_OUT_OF_TIME:
+        elif isinstance(event, OutOfTimeTriviaEvent):
             await self.__handleGameOutOfTimeTriviaEvent(event)
-        elif eventType is TriviaEventType.INCORRECT_ANSWER:
+        elif isinstance(event, IncorrectAnswerTriviaEvent):
             await self.__handleIncorrectAnswerTriviaEvent(event)
-        elif eventType is TriviaEventType.INVALID_ANSWER_INPUT:
+        elif isinstance(event, InvalidAnswerInputTriviaEvent):
             await self.__handleInvalidAnswerInputTriviaEvent(event)
-        elif eventType is TriviaEventType.NEW_GAME:
+        elif isinstance(event, NewTriviaGameEvent):
             await self.__handleNewTriviaGameEvent(event)
-        elif eventType is TriviaEventType.NEW_SUPER_GAME:
+        elif isinstance(event, NewSuperTriviaGameEvent):
             await self.__handleNewSuperTriviaGameEvent(event)
-        elif eventType is TriviaEventType.SUPER_GAME_FAILED_TO_FETCH_QUESTION:
+        elif isinstance(event, FailedToFetchQuestionSuperTriviaEvent):
             await self.__handleFailedToFetchQuestionSuperTriviaEvent(event)
-        elif eventType is TriviaEventType.SUPER_GAME_CORRECT_ANSWER:
+        elif isinstance(event, CorrectSuperAnswerTriviaEvent):
             await self.__handleSuperGameCorrectAnswerTriviaEvent(event)
-        elif eventType is TriviaEventType.SUPER_GAME_OUT_OF_TIME:
+        elif isinstance(event, OutOfTimeSuperTriviaEvent):
             await self.__handleSuperGameOutOfTimeTriviaEvent(event)
 
     async def __handleClearedSuperTriviaQueueTriviaEvent(self, event: ClearedSuperTriviaQueueTriviaEvent):

--- a/src/CynanBot/misc/tests/test_lruCache.py
+++ b/src/CynanBot/misc/tests/test_lruCache.py
@@ -1,70 +1,30 @@
+import pytest
 from CynanBot.misc.lruCache import LruCache
 
 
 class TestLruCache():
 
     def test_constructWithNegativeOneCapacity(self):
-        lruCache: LruCache = None
-        exception: Exception = None
-
-        try:
-            lruCache = LruCache(-1)
-        except Exception as e:
-            exception = e
-
-        assert lruCache is None
-        assert exception is not None
-        assert isinstance(exception, ValueError)
+        with pytest.raises(ValueError):
+            LruCache(-1)
 
     def test_constructWithOneCapacity(self):
-        lruCache: LruCache = None
-        exception: Exception = None
-
-        try:
-            lruCache = LruCache(1)
-        except Exception as e:
-            exception = e
-
-        assert lruCache is None
-        assert exception is not None
-        assert isinstance(exception, ValueError)
+        with pytest.raises(ValueError):
+            LruCache(1)
 
     def test_constructWithThreeCapacity(self):
-        lruCache: LruCache = None
-        exception: Exception = None
+        lruCache = LruCache(3)
 
-        try:
-            lruCache = LruCache(3)
-        except Exception as e:
-            exception = e
-
-        assert lruCache is not None
-        assert exception is None
+        assert isinstance(lruCache, LruCache)
 
     def test_constructWithTwoCapacity(self):
-        lruCache: LruCache = None
-        exception: Exception = None
+        lruCache = LruCache(2)
 
-        try:
-            lruCache = LruCache(2)
-        except Exception as e:
-            exception = e
-
-        assert lruCache is not None
-        assert exception is None
+        assert isinstance(lruCache, LruCache)
 
     def test_constructWithZeroCapacity(self):
-        lruCache: LruCache = None
-        exception: Exception = None
-
-        try:
-            lruCache = LruCache(0)
-        except Exception as e:
-            exception = e
-
-        assert lruCache is None
-        assert exception is not None
-        assert isinstance(exception, ValueError)
+        with pytest.raises(ValueError):
+            LruCache(0)
 
     def test_containsWhenEmptyIsFalse(self):
         lruCache = LruCache(3)

--- a/src/CynanBot/misc/tests/test_utils.py
+++ b/src/CynanBot/misc/tests/test_utils.py
@@ -34,7 +34,7 @@ class TestUtils():
         result: bool | None = None
 
         with pytest.raises(Exception):
-            result = utils.areAllStrsInts(None)
+            result = utils.areAllStrsInts(None)  # type: ignore
 
         assert result is None
 
@@ -47,15 +47,15 @@ class TestUtils():
         assert result is False
 
     def test_areValidBools_withEmptyStringList(self):
-        result = utils.areValidBools([ '', '\n', 'hello', 'world', '' ])
+        result = utils.areValidBools([ '', '\n', 'hello', 'world', '' ])  # type: ignore
         assert result is False
 
     def test_areValidBools_withIntList(self):
-        result = utils.areValidBools([ 100, 200 ])
+        result = utils.areValidBools([ 100, 200 ])  # type: ignore
         assert result is False
 
     def test_areValidBools_withMixedTypeList(self):
-        result = utils.areValidBools([ True, 'hello', 1, False ])
+        result = utils.areValidBools([ True, 'hello', 1, False ])  # type: ignore
         assert result is False
 
     def test_areValidBools_withNone(self):
@@ -75,11 +75,11 @@ class TestUtils():
         assert result is False
 
     def test_areValidStrs_withIntList(self):
-        result = utils.areValidStrs([ 100, 200 ])
+        result = utils.areValidStrs([ 100, 200 ])  # type: ignore
         assert result is False
 
     def test_areValidStrs_withMixedTypeList(self):
-        result = utils.areValidStrs([ True, 'hello', 1, False ])
+        result = utils.areValidStrs([ True, 'hello', 1, False ])  # type: ignore
         assert result is False
 
     def test_areValidStrs_withNone(self):

--- a/src/CynanBot/misc/utils.py
+++ b/src/CynanBot/misc/utils.py
@@ -3,8 +3,9 @@ import math
 import os
 import random
 import re
+from collections.abc import Collection
 from datetime import datetime
-from typing import (Any, Dict, Generator, List, Optional, Pattern, Set, Sized,
+from typing import (Any, Dict, Generator, List, Optional, Pattern, Sized,
                     TypeVar, overload)
 from urllib.parse import urlparse
 
@@ -26,7 +27,7 @@ def areAllStrsInts(l: List[str]) -> bool:
 
     return True
 
-def areValidBools(l: Optional[List[Optional[bool]]]) -> TypeGuard[List[bool]]:
+def areValidBools(l: Optional[Collection[Optional[bool]]]) -> TypeGuard[Collection[bool]]:
     if not hasItems(l):
         return False
 
@@ -36,7 +37,7 @@ def areValidBools(l: Optional[List[Optional[bool]]]) -> TypeGuard[List[bool]]:
 
     return True
 
-def areValidStrs(l: Optional[List[Optional[str]]]) -> TypeGuard[List[str]]:
+def areValidStrs(l: Optional[Collection[Optional[str]]]) -> TypeGuard[Collection[str]]:
     if not hasItems(l):
         return False
 
@@ -216,6 +217,8 @@ def getDateTimeFromStr(text: Optional[str]) -> Optional[datetime]:
     if naiveTimeZoneRegEx.fullmatch(text) is not None:
         text = f'{text}+00:00'
 
+    assert isinstance(text, str)
+
     return datetime.fromisoformat(text)
 
 def getFloatFromDict(d: Optional[Dict[str, Any]], key: str, fallback: Optional[float] = None) -> float:
@@ -378,7 +381,7 @@ def numToBool(n: float | None) -> bool:
     return n != 0
 
 def permuteSubArrays(array: List[Any], pos: int = 0) -> Generator[List[Any], None, None]:
-    if not isValidNum(pos):
+    if not isValidInt(pos):
         raise ValueError(f'pos argument is malformed: \"{pos}\"')
 
     if pos >= len(array):
@@ -419,7 +422,7 @@ def safeStrToInt(s: Optional[str]) -> Optional[int]:
 
     try:
         return int(s)
-    except:
+    except Exception:
         return None
 
 def splitLongStringIntoMessages(

--- a/src/CynanBot/network/networkResponse.py
+++ b/src/CynanBot/network/networkResponse.py
@@ -27,7 +27,7 @@ class NetworkResponse(ABC):
         pass
 
     @abstractmethod
-    async def json(self) -> dict[str, Any] | None:
+    async def json(self) -> dict[str, Any] | list[Any] | None:
         pass
 
     @abstractmethod

--- a/src/CynanBot/pkmn/pokepediaPokemon.py
+++ b/src/CynanBot/pkmn/pokepediaPokemon.py
@@ -23,11 +23,11 @@ class PokepediaPokemon():
             raise ValueError(f'generationElementTypes argument is malformed: \"{generationElementTypes}\"')
         elif not isinstance(initialGeneration, PokepediaGeneration):
             raise ValueError(f'initialGeneration argument is malformed: \"{initialGeneration}\"')
-        elif not utils.isValidNum(height):
+        elif not utils.isValidInt(height):
             raise ValueError(f'height argument is malformed: \"{height}\"')
-        elif not utils.isValidNum(pokedexId):
+        elif not utils.isValidInt(pokedexId):
             raise ValueError(f'pokedexId argument is malformed: \"{pokedexId}\"')
-        elif not utils.isValidNum(weight):
+        elif not utils.isValidInt(weight):
             raise ValueError(f'weight argument is malformed: \"{weight}\"')
         elif not utils.isValidStr(name):
             raise ValueError(f'name argument is malformed: \"{name}\"')

--- a/src/CynanBot/trivia/compilers/triviaAnswerCompiler.py
+++ b/src/CynanBot/trivia/compilers/triviaAnswerCompiler.py
@@ -127,7 +127,7 @@ class TriviaAnswerCompiler(TriviaAnswerCompilerInterface):
             if bracedAnswerMatch is not None and utils.isValidStr(bracedAnswerMatch.group(1)):
                 cleanedAnswer = bracedAnswerMatch.group(1)
 
-        if not utils.isValidStr(cleanedAnswer) or len(cleanedAnswer) != 1  or self.__multipleChoiceAnswerRegEx.fullmatch(cleanedAnswer) is None:
+        if not utils.isValidStr(cleanedAnswer) or len(cleanedAnswer) != 1 or self.__multipleChoiceAnswerRegEx.fullmatch(cleanedAnswer) is None:
             raise BadTriviaAnswerException(f'answer can\'t be compiled to multiple choice ordinal ({answer=}) ({cleanedAnswer=})')
 
         # this converts the answer 'A' into 0, 'B' into 1, 'C' into 2, and so on...

--- a/src/CynanBot/trivia/games/triviaGameStore.py
+++ b/src/CynanBot/trivia/games/triviaGameStore.py
@@ -4,7 +4,6 @@ from CynanBot.trivia.games.superTriviaGameState import SuperTriviaGameState
 from CynanBot.trivia.games.triviaGameState import TriviaGameState
 from CynanBot.trivia.games.triviaGameStoreInterface import \
     TriviaGameStoreInterface
-from CynanBot.trivia.games.triviaGameType import TriviaGameType
 from CynanBot.trivia.triviaExceptions import UnknownTriviaGameTypeException
 
 
@@ -18,9 +17,9 @@ class TriviaGameStore(TriviaGameStoreInterface):
         if not isinstance(state, AbsTriviaGameState):
             raise TypeError(f'state argument is malformed: \"{state}\"')
 
-        if state.getTriviaGameType() is TriviaGameType.NORMAL:
+        if isinstance(state, TriviaGameState):
             await self.__addNormalGame(state)
-        elif state.getTriviaGameType() is TriviaGameType.SUPER:
+        elif isinstance(state, SuperTriviaGameState):
             await self.__addSuperGame(state)
         else:
             raise UnknownTriviaGameTypeException(f'Unknown TriviaGameType: \"{state.getTriviaGameType()}\"')

--- a/src/CynanBot/trivia/questions/trueFalseTriviaQuestion.py
+++ b/src/CynanBot/trivia/questions/trueFalseTriviaQuestion.py
@@ -30,7 +30,7 @@ class TrueFalseTriviaQuestion(AbsTriviaQuestion):
             triviaType = TriviaQuestionType.TRUE_FALSE
         )
 
-        if not utils.areValidBools(correctAnswers):
+        if not utils.areValidBools(correctAnswers) or not isinstance(correctAnswers, list):
             raise NoTriviaCorrectAnswersException(f'correctAnswers argument is malformed: \"{correctAnswers}\"')
 
         self.__correctAnswers: list[bool] = correctAnswers

--- a/src/CynanBot/trivia/tests/test_triviaQuestionType.py
+++ b/src/CynanBot/trivia/tests/test_triviaQuestionType.py
@@ -29,7 +29,7 @@ class TestTriviaQuestionType():
         result: TriviaQuestionType | None = None
 
         with pytest.raises(ValueError):
-            result = TriviaQuestionType.fromStr(None)
+            result = TriviaQuestionType.fromStr(None)  # type: ignore
 
         assert result is None
 

--- a/src/CynanBot/trivia/tests/test_triviaSource.py
+++ b/src/CynanBot/trivia/tests/test_triviaSource.py
@@ -17,7 +17,7 @@ class TestTriviaSource():
         result: TriviaSource | None = None
 
         with pytest.raises(ValueError):
-            result = TriviaSource.fromStr(None)
+            result = TriviaSource.fromStr(None)  # type: ignore
 
         assert result is None
 

--- a/src/CynanBot/trivia/triviaGameMachine.py
+++ b/src/CynanBot/trivia/triviaGameMachine.py
@@ -62,7 +62,6 @@ from CynanBot.trivia.games.superTriviaGameState import SuperTriviaGameState
 from CynanBot.trivia.games.triviaGameState import TriviaGameState
 from CynanBot.trivia.games.triviaGameStoreInterface import \
     TriviaGameStoreInterface
-from CynanBot.trivia.games.triviaGameType import TriviaGameType
 from CynanBot.trivia.questions.absTriviaQuestion import AbsTriviaQuestion
 from CynanBot.trivia.score.triviaScoreRepositoryInterface import \
     TriviaScoreRepositoryInterface
@@ -796,9 +795,9 @@ class TriviaGameMachine(TriviaGameMachineInterface):
                 gameStatesToRemove.append(state)
 
         for state in gameStatesToRemove:
-            if state.getTriviaGameType() is TriviaGameType.NORMAL:
+            if isinstance(state, TriviaGameState):
                 await self.__removeDeadNormalTriviaGame(state)
-            elif state.getTriviaGameType() is TriviaGameType.SUPER:
+            elif isinstance(state, SuperTriviaGameState):
                 await self.__removeDeadSuperTriviaGame(state)
             else:
                 raise UnknownTriviaGameTypeException(f'Unknown TriviaGameType (gameId=\"{state.getGameId()}\") (twitchChannel=\"{state.getTwitchChannel()}\") (actionId=\"{state.getActionId()}\"): \"{state.getTriviaGameType()}\"')
@@ -907,20 +906,19 @@ class TriviaGameMachine(TriviaGameMachineInterface):
 
             try:
                 for action in actions:
-                    triviaActionType = action.getTriviaActionType()
 
-                    if triviaActionType is TriviaActionType.CHECK_ANSWER:
+                    if isinstance(action, CheckAnswerTriviaAction):
                         await self.__handleActionCheckAnswer(action)
-                    elif triviaActionType is TriviaActionType.CHECK_SUPER_ANSWER:
+                    elif isinstance(action, CheckSuperAnswerTriviaAction):
                         await self.__handleActionCheckSuperAnswer(action)
-                    elif triviaActionType is TriviaActionType.CLEAR_SUPER_TRIVIA_QUEUE:
+                    elif isinstance(action, ClearSuperTriviaQueueTriviaAction):
                         await self.__handleActionClearSuperTriviaQueue(action)
-                    elif triviaActionType is TriviaActionType.START_NEW_GAME:
+                    elif isinstance(action, StartNewTriviaGameAction):
                         await self.__handleActionStartNewTriviaGame(action)
-                    elif triviaActionType is TriviaActionType.START_NEW_SUPER_GAME:
+                    elif isinstance(action, StartNewSuperTriviaGameAction):
                         await self.__handleActionStartNewSuperTriviaGame(action)
                     else:
-                        raise UnknownTriviaActionTypeException(f'Unknown TriviaActionType: \"{triviaActionType}\"')
+                        raise UnknownTriviaActionTypeException(f'Unknown TriviaActionType: \"{type(action)=}\"')
             except Exception as e:
                 self.__timber.log('TriviaGameMachine', f'Encountered unknown Exception when looping through actions (queue size: {self.__actionQueue.qsize()}) (actions size: {len(actions)}): {e}', e, traceback.format_exc())
 

--- a/src/CynanBot/trivia/triviaRepositories/bongoTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/bongoTriviaQuestionRepository.py
@@ -70,7 +70,7 @@ class BongoTriviaQuestionRepository(AbsTriviaQuestionRepository):
             self.__timber.log('BongoTriviaQuestionRepository', f'Encountered non-200 HTTP status code: {response.getStatusCode()}')
             raise GenericTriviaNetworkException(self.getTriviaSource())
 
-        jsonResponse: list[dict[str, Any]] | None = await response.json()
+        jsonResponse: list[dict[str, Any]] | None | Any = await response.json()
         await response.close()
 
         if await self._triviaSettingsRepository.isDebugLoggingEnabled():
@@ -140,7 +140,7 @@ class BongoTriviaQuestionRepository(AbsTriviaQuestionRepository):
                     triviaSource = TriviaSource.BONGO
                 )
             else:
-                self.__timber.log('BongoTriviaQuestionRepository', f'Encountered a multiple choice question that is better suited for true/false')
+                self.__timber.log('BongoTriviaQuestionRepository', 'Encountered a multiple choice question that is better suited for true/false')
                 triviaType = TriviaQuestionType.TRUE_FALSE
 
         if triviaType is TriviaQuestionType.TRUE_FALSE:

--- a/src/CynanBot/trivia/triviaRepositories/willFryTriviaQuestionRepository.py
+++ b/src/CynanBot/trivia/triviaRepositories/willFryTriviaQuestionRepository.py
@@ -71,7 +71,7 @@ class WillFryTriviaQuestionRepository(AbsTriviaQuestionRepository):
             self.__timber.log('WillFryTriviaQuestionRepository', f'Encountered non-200 HTTP status code: \"{response.getStatusCode()}\"')
             raise GenericTriviaNetworkException(self.getTriviaSource())
 
-        jsonResponse: list[dict[str, Any]] | None = await response.json()
+        jsonResponse: list[dict[str, Any] | Any] | None | Any = await response.json()
         await response.close()
 
         if await self._triviaSettingsRepository.isDebugLoggingEnabled():
@@ -81,7 +81,7 @@ class WillFryTriviaQuestionRepository(AbsTriviaQuestionRepository):
             self.__timber.log('WillFryTriviaQuestionRepository', f'Rejecting Will Fry Trivia\'s JSON data due to null/empty contents: {jsonResponse}')
             raise MalformedTriviaJsonException(f'Rejecting Will Fry Trivia\'s JSON data due to null/empty contents: {jsonResponse}')
 
-        triviaJson: dict[str, Any] | None = jsonResponse[0]
+        triviaJson: dict[str, Any] | Any = jsonResponse[0]
         if not isinstance(triviaJson, dict) or len(triviaJson) == 0:
             self.__timber.log('WillFryTriviaQuestionRepository', f'Rejecting Will Fry Trivia\'s JSON data due to null/empty contents: {jsonResponse}')
             raise MalformedTriviaJsonException(f'Rejecting Will Fry Trivia\'s JSON data due to null/empty contents: {jsonResponse}')
@@ -131,7 +131,7 @@ class WillFryTriviaQuestionRepository(AbsTriviaQuestionRepository):
                     triviaSource = TriviaSource.WILL_FRY_TRIVIA
                 )
             else:
-                self.__timber.log('WillFryTriviaQuestionRepository', f'Encountered a multiple choice question that is better suited for true/false')
+                self.__timber.log('WillFryTriviaQuestionRepository', 'Encountered a multiple choice question that is better suited for true/false')
                 triviaType = TriviaQuestionType.TRUE_FALSE
 
         if triviaType is TriviaQuestionType.TRUE_FALSE:

--- a/src/CynanBot/tts/ttsCommandBuilder.py
+++ b/src/CynanBot/tts/ttsCommandBuilder.py
@@ -244,20 +244,18 @@ class TtsCommandBuilder(TtsCommandBuilderInterface):
         if donation is None:
             return None
 
-        donationType = donation.getType()
-
-        if donationType is TtsDonationType.CHEER:
+        if isinstance(donation, TtsCheerDonation):
             return await self.__processCheerDonationPrefix(
                 event = event,
                 donation = donation
             )
-        elif donationType is TtsDonationType.SUBSCRIPTION:
+        elif isinstance(donation, TtsSubscriptionDonation):
             return await self.__processSubcriptionDonationPrefix(
                 event = event,
                 donation = donation
             )
         else:
-            raise RuntimeError(f'donationType is unknown: \"{donationType}\"')
+            raise RuntimeError(f'donation type is unknown: \"{type(donation)=}\"')
 
     async def __processSubcriptionDonationPrefix(
         self,
@@ -275,7 +273,7 @@ class TtsCommandBuilder(TtsCommandBuilderInterface):
 
         if donation.getGiftType() is TtsSubscriptionDonationGiftType.GIVER:
             if donation.isAnonymous():
-                return f'anonymous gifted a sub!'
+                return 'anonymous gifted a sub!'
             else:
                 return f'{event.getUserName()} gifted a sub!'
         elif donation.getGiftType() is TtsSubscriptionDonationGiftType.RECEIVER:

--- a/src/CynanBot/twitch/tests/test_twitchEmoteImageFormat.py
+++ b/src/CynanBot/twitch/tests/test_twitchEmoteImageFormat.py
@@ -12,7 +12,7 @@ class TestTwitchEmoteImageFormat():
         assert result is TwitchEmoteImageFormat.DEFAULT
 
     def test_fromStr_withNone(self):
-        result = TwitchEmoteImageFormat.fromStr(None)
+        result = TwitchEmoteImageFormat.fromStr(None)  # type: ignore
         assert result is TwitchEmoteImageFormat.DEFAULT
 
     def test_fromStr_withPartnerString(self):

--- a/src/CynanBot/twitch/tests/test_twitchEmoteImageScale.py
+++ b/src/CynanBot/twitch/tests/test_twitchEmoteImageScale.py
@@ -22,7 +22,7 @@ class TestTwitchEmoteImageScale():
         exception: Optional[Exception] = None
 
         try:
-            result = TwitchEmoteImageScale.fromStr(None)
+            result = TwitchEmoteImageScale.fromStr(None)  # type: ignore
         except Exception as e:
             exception = e
 

--- a/src/CynanBot/twitch/tests/test_twitchEmoteType.py
+++ b/src/CynanBot/twitch/tests/test_twitchEmoteType.py
@@ -30,7 +30,7 @@ class TestTwitchEmoteType():
         exception: Optional[Exception] = None
 
         try:
-            result = TwitchEmoteType.fromStr(None)
+            result = TwitchEmoteType.fromStr(None)  # type: ignore
         except Exception as e:
             exception = e
 

--- a/src/CynanBot/twitch/tests/test_twitchOutcomeColor.py
+++ b/src/CynanBot/twitch/tests/test_twitchOutcomeColor.py
@@ -26,7 +26,7 @@ class TestTwitchOutcomeColor():
         exception: Optional[Exception] = None
 
         try:
-            result = TwitchOutcomeColor.fromStr(None)
+            result = TwitchOutcomeColor.fromStr(None)  # type: ignore
         except Exception as e:
             exception = e
 

--- a/src/CynanBot/twitch/tests/test_twitchThemeMode.py
+++ b/src/CynanBot/twitch/tests/test_twitchThemeMode.py
@@ -30,7 +30,7 @@ class TestTwitchThemeMode():
         exception: Optional[Exception] = None
 
         try:
-            result = TwitchThemeMode.fromStr(None)
+            result = TwitchThemeMode.fromStr(None)  # type: ignore
         except Exception as e:
             exception = e
 

--- a/src/CynanBot/twitch/twitchTimeoutRemodHelperInterface.py
+++ b/src/CynanBot/twitch/twitchTimeoutRemodHelperInterface.py
@@ -10,5 +10,5 @@ class TwitchTimeoutRemodHelperInterface(ABC):
         pass
 
     @abstractmethod
-    async def submitRemodData(self, action: TwitchTimeoutRemodData):
+    async def submitRemodData(self, data: TwitchTimeoutRemodData):
         pass

--- a/src/CynanBot/twitch/websocket/twitchWebsocketJsonMapper.py
+++ b/src/CynanBot/twitch/websocket/twitchWebsocketJsonMapper.py
@@ -228,7 +228,7 @@ class TwitchWebsocketJsonMapper(TwitchWebsocketJsonMapperInterface):
         return TwitchWebsocketPayload(
             event = event,
             session = session,
-            subscription  = subscription
+            subscription = subscription
         )
 
     async def __parseTransport(self, transportJson: Optional[Dict[str, Any]]) -> Optional[TwitchWebsocketTransport]:
@@ -656,7 +656,7 @@ class TwitchWebsocketJsonMapper(TwitchWebsocketJsonMapperInterface):
         )
 
     async def parseWebsocketSubscription(self, subscriptionJson: Optional[Dict[str, Any]]) -> Optional[TwitchWebsocketSubscription]:
-        if not isinstance(subscriptionJson, Dict) or len(subscriptionJson) == 0:
+        if not isinstance(subscriptionJson, dict) or len(subscriptionJson) == 0:
             return None
 
         cost = utils.getIntFromDict(subscriptionJson, 'cost')
@@ -667,6 +667,10 @@ class TwitchWebsocketJsonMapper(TwitchWebsocketJsonMapperInterface):
         status = TwitchWebsocketConnectionStatus.fromStr(utils.getStrFromDict(subscriptionJson, 'status'))
         subscriptionType = TwitchWebsocketSubscriptionType.fromStr(utils.getStrFromDict(subscriptionJson, 'type'))
         transport = await self.__parseTransport(subscriptionJson.get('transport'))
+
+        assert condition and status and subscriptionType and transport, (
+            f"{condition=} {status=} {subscriptionType=} {transport=}"
+        )
 
         return TwitchWebsocketSubscription(
             cost = cost,

--- a/src/CynanBot/users/userInterface.py
+++ b/src/CynanBot/users/userInterface.py
@@ -84,7 +84,7 @@ class UserInterface(ABC):
         pass
 
     @abstractmethod
-    def getSuperTriviaCheerTriggerAmount(self) -> int | None:
+    def getSuperTriviaCheerTriggerAmount(self) -> float | None:
         pass
 
     @abstractmethod

--- a/src/CynanBot/users/usersRepositoryInterface.py
+++ b/src/CynanBot/users/usersRepositoryInterface.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from collections.abc import Sequence
 
 from CynanBot.misc.clearable import Clearable
 from CynanBot.users.userInterface import UserInterface
@@ -27,11 +28,11 @@ class UsersRepositoryInterface(Clearable):
         pass
 
     @abstractmethod
-    def getUsers(self) -> list[UserInterface]:
+    def getUsers(self) -> Sequence[UserInterface]:
         pass
 
     @abstractmethod
-    async def getUsersAsync(self) -> list[UserInterface]:
+    async def getUsersAsync(self) -> Sequence[UserInterface]:
         pass
 
     @abstractmethod

--- a/src/CynanBot/weather/tests/test_airQualityIndex.py
+++ b/src/CynanBot/weather/tests/test_airQualityIndex.py
@@ -10,7 +10,7 @@ class TestAirQualityIndex():
         exception: Optional[Exception] = None
 
         try:
-            result = AirQualityIndex.fromInt(None)
+            result = AirQualityIndex.fromInt(None)  # type: ignore
         except Exception as e:
             exception = e
 

--- a/src/CynanBot/weather/weatherReport.py
+++ b/src/CynanBot/weather/weatherReport.py
@@ -143,7 +143,7 @@ class WeatherReport():
         humidity = f'humidity is {self.getHumidity()}%, '
 
         airQuality = ''
-        if self.hasAirQualityIndex():
+        if self.__airQualityIndex:
             airQuality = f'air quality index is {self.__airQualityIndex.toStr()}, '
 
         uvIndex = ''


### PR DESCRIPTION
from 160+ pyright errors to 100

I'm not sure how much of this is covered by unit tests, so I may have broken things.

Some of the major points:
- Stop using enums for types - just use the type in Python's type system, instead of making your own type system with enums.

- used .json() in a few places expecting list - all typing should check type of json response, can't assume it's dict

---

A weird quirk about the python typing system. You can see a type annotation like
```python
x: list[str] | Any
```
Someone might wonder: "Why is `list[str]` there unioned with `Any`? Wouldn't `Any` include `list[str]` anyway? Why not just `x: Any`?"

The reason is for type narrowing with generics, because you can't use generics with `isinstance`

```python
y: Any
if isinstance(y, list):
    print(y)  # y: list[Unknown]

x: list[str] | Any
if isinstance(x, list):
    print(x)  # x: list[str]
```