### PR TITLE
restore .venv star

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,7 +185,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/


### PR DESCRIPTION
In https://github.com/charlesmadere/CynanBot/commit/4eb79b3766c4cac9b7996508cb855a39218a75ac you removed `.venv*` from `.gitignore`

I prefer to put the Python version number in the name of the venv directory to help me keep track of which version of Python is in the venv

examples:
`.venv3.11`
`.venv3.12`

I also sometimes attach other information that might be different in that environment:
`.venv3.11-no-module-x`
to indicate that the optional dependency `module-x` is not installed in this environment.

All this helps me switch between the different environments and test different environments.