### PR TITLE
`TypedDict` validator

### DIFF
--- a/src/CynanBot/misc/tests/test_type_check.py
+++ b/src/CynanBot/misc/tests/test_type_check.py
@@ -371,3 +371,26 @@ def test_consumable_iterable() -> None:
     for _ in it:
         count += 1
     assert count == 1, f"{count=}"
+
+
+def test_typed_dict() -> None:
+    class TestTypedDict(typing.TypedDict):
+        one_key: int
+        other_key: list[str]
+
+    @type_check
+    def f(x: TestTypedDict) -> bool:
+        return len(x) > 2
+
+    f({
+        "one_key": 4,
+        "other_key": ["five"]
+    })
+
+
+def test_any() -> None:
+    @type_check
+    def f(x: typing.Any) -> str:
+        return str(x)
+
+    f(())

--- a/src/CynanBot/misc/tests/test_typeddict_validation.py
+++ b/src/CynanBot/misc/tests/test_typeddict_validation.py
@@ -1,0 +1,211 @@
+from typing import Any, NotRequired, TypedDict, assert_type
+
+from CynanBot.misc.type_check import validate_typeddict
+
+
+def test_simple_positive() -> None:
+    class TestType(TypedDict):
+        a: int
+
+    x = {"a": 3}
+
+    assert validate_typeddict(x, TestType)
+    assert_type(x, TestType)  # This tests the TypeGuard with the type checker.
+
+
+def test_simple_negative() -> None:
+    class TestType(TypedDict):
+        a: int
+
+    x = {"b": 3}
+
+    assert not validate_typeddict(x, TestType)
+
+
+def test_extra_keys_ok() -> None:
+    class TestType(TypedDict):
+        a: int
+
+    x = {
+        "a": 2,
+        "b": "3"
+    }
+
+    assert validate_typeddict(x, TestType)
+
+
+def test_wrong_value_type() -> None:
+    class TestType(TypedDict):
+        a: int
+
+    x = {
+        "a": "2",  # This type should fail validation.
+        "b": "3"
+    }
+
+    assert not validate_typeddict(x, TestType)
+
+
+def test_list_value() -> None:
+    class TestType(TypedDict):
+        a: list[float]
+
+    x = {
+        "a": [2, 3.1, 4],
+        "b": "3"
+    }
+
+    assert validate_typeddict(x, TestType)
+
+
+def test_list_value_negative() -> None:
+    class TestType(TypedDict):
+        a: list[float]
+
+    x = {
+        "a": [2, 3, "4"],  # This type should fail validation.
+        "b": "3"
+    }
+
+    assert not validate_typeddict(x, TestType)
+
+
+def test_not_required() -> None:
+    class TestType(TypedDict):
+        a: bool
+        b: NotRequired[str]
+
+    x = {
+        "a": False
+    }
+
+    y = {
+        "a": False,
+        "b": "3"
+    }
+
+    assert validate_typeddict(x, TestType)
+    assert validate_typeddict(y, TestType)
+
+
+def test_not_required_wrong_type() -> None:
+    class TestType(TypedDict):
+        a: bool
+        b: NotRequired[str]
+
+    x = {
+        "a": False,
+        "b": 3  # This type should fail validation.
+    }
+
+    assert not validate_typeddict(x, TestType)
+
+
+def test_nested_typeddict() -> None:
+    class TestTypeA(TypedDict):
+        b: dict[str, Any]
+        c: int
+
+    class TestTypeB(TypedDict):
+        a: TestTypeA
+        g: bool
+        h: str
+
+    x = {
+        "a": {
+            "b": {
+                "j": 5,
+            },
+            "c": 42,
+        },
+        "g": True,
+        "h": "H!!!!",
+    }
+
+    assert validate_typeddict(x, TestTypeB)
+
+
+def test_nested_typeddict_negative() -> None:
+    class TestTypeA(TypedDict):
+        b: dict[str, Any]
+        c: int
+
+    class TestTypeB(TypedDict):
+        a: TestTypeA
+        g: bool
+        h: str
+
+    x = {
+        "a": {
+            "b": {
+                "j": 5,
+            },
+            "c": 42.5,  # This type should fail validation.
+        },
+        "g": True,
+        "h": "H!!!!",
+    }
+
+    assert not validate_typeddict(x, TestTypeB)
+
+
+def test_list_of_json_objects() -> None:
+    class TestTypeA(TypedDict):
+        b: dict[str, Any]
+        c: int
+
+    class TestTypeB(TypedDict):
+        a: list[TestTypeA]
+        g: bool
+        h: str
+
+    x = {
+        "a": [
+            {
+                "b": {
+                    "j": 5,
+                },
+                "c": 42,
+            },
+            {
+                "b": {
+                    "k": 5,
+                },
+                "c": 43,
+            },
+        ],
+        "g": True,
+        "h": "H!!!!",
+    }
+
+    assert validate_typeddict(x, TestTypeB)
+
+
+def test_list_of_json_objects_negative() -> None:
+    class TestTypeA(TypedDict):
+        b: dict[str, Any]
+        c: int
+
+    class TestTypeB(TypedDict):
+        a: list[TestTypeA]
+        g: bool
+        h: str
+
+    x = {
+        "a": [
+            {
+                "b": {
+                    "j": 5,
+                },
+                "c": 42,
+            },
+            {
+                "b": True,  # This type should fail validation.
+                "c": 43,
+            },
+        ],
+        "g": True,
+        "h": "H????",
+    }
+
+    assert not validate_typeddict(x, TestTypeB)


### PR DESCRIPTION
The schema is defined by defining a class that inherits from `typing.TypedDict` (examples in the unit tests and in `emojiRepository.py`).
- You only need to define the keys that you will use. If there are other keys in the JSON object that you will ignore, they don't need to be in these class definitions.
- If there are nested JSON objects, you'll need to define multiple classes (starting with the most deeply nested).
- If there is a key in the JSON object that is not always present, you can use the `NotRequired` type form (see examples in `test_typeddict_validation.py` `test_not_required()`).
  - The keys marked as `NotRequired` don't have to be in the object, but if they are present, they must be the correct type.
  - The Python type checker will report an error if you try to access the `NotRequired` item without checking to see if it's there first.
- Once these classes are defined, they can be in type annotations, so you can pass the objects to other functions while keeping the type information.

The `validate_typeddict` function will return `True` only if everything is valid according to the schema that you defined. This is a `TypeGuard` function, so the type checker will keep track of the branch where it returns `True` and will know the types of what's in it.

This requires Python 3.12 (will give a syntax error in 3.11). Let me know if you want me to make it compatible with Python 3.11.