### PR TITLE
Fixed unable to parse StreamElementsVoice from message

### DIFF
--- a/src/streamElements/apiService/streamElementsApiService.py
+++ b/src/streamElements/apiService/streamElementsApiService.py
@@ -1,4 +1,5 @@
 import traceback
+import urllib.parse
 
 from .streamElementsApiServiceInterface import StreamElementsApiServiceInterface
 from ..models.streamElementsVoice import StreamElementsVoice
@@ -37,6 +38,7 @@ class StreamElementsApiService(StreamElementsApiServiceInterface):
             raise TypeError(f'voice argument is malformed: \"{voice}\"')
 
         clientSession = await self.__networkClientProvider.get()
+        text = urllib.parse.quote_plus(text).strip()
 
         try:
             response = await clientSession.get(

--- a/src/streamElements/streamElementsMessageCleaner.py
+++ b/src/streamElements/streamElementsMessageCleaner.py
@@ -1,5 +1,4 @@
 import re
-import urllib.parse
 from typing import Any, Pattern
 
 from .streamElementsMessageCleanerInterface import StreamElementsMessageCleanerInterface
@@ -35,4 +34,4 @@ class StreamElementsMessageCleaner(StreamElementsMessageCleanerInterface):
         if not utils.isValidStr(message):
             return None
 
-        return urllib.parse.quote_plus(message).strip()
+        return message

--- a/src/streamElementsTest.py
+++ b/src/streamElementsTest.py
@@ -114,7 +114,7 @@ streamElementsFileManager: StreamElementsFileManagerInterface = StreamElementsFi
 async def main():
     pass
 
-    message = await streamElementsMessageCleaner.clean('Hello, & World!')
+    message = 'Hello, World!'
 
     speechBytes = await streamElementsHelper.getSpeech(
         message = message,

--- a/tests/streamElements/test_streamElementsMessageCleaner.py
+++ b/tests/streamElements/test_streamElementsMessageCleaner.py
@@ -34,14 +34,14 @@ class TestStreamElementsMessageCleaner:
     )
 
     @pytest.mark.asyncio
-    async def test_clean_withSimpleAmpersandMessage(self):
-        result = await self.cleaner.clean('Nintendo & Microsoft & Sony?')
-        assert result == 'Nintendo+%26+Microsoft+%26+Sony%3F'
+    async def test_clean_withVoiceMessage(self):
+        result = await self.cleaner.clean('brian: test')
+        assert result == 'brian: test'
 
     @pytest.mark.asyncio
     async def test_clean_withComplicatedCheerMessage(self):
         result = await self.cleaner.clean('cheer500 good uni25 luck cheer50 with cheer25 the uni25 runs! cheer10')
-        assert result == 'good+luck+with+the+runs%21'
+        assert result == 'good luck with the runs!'
 
     @pytest.mark.asyncio
     async def test_clean_withEmptyString(self):
@@ -56,17 +56,17 @@ class TestStreamElementsMessageCleaner:
     @pytest.mark.asyncio
     async def test_clean_withSimpleMessage(self):
         result = await self.cleaner.clean('Hello, World')
-        assert result == 'Hello%2C+World'
+        assert result == 'Hello, World'
 
     @pytest.mark.asyncio
     async def test_clean_withSimpleMessageAndLotsOfWhitespace(self):
         result = await self.cleaner.clean('   \n  Hello,     World!\n \n')
-        assert result == 'Hello%2C+World%21'
+        assert result == 'Hello, World!'
 
     @pytest.mark.asyncio
     async def test_clean_withSimpleCheerMessage(self):
         result = await self.cleaner.clean('cheer500 good luck with the runs!')
-        assert result == 'good+luck+with+the+runs%21'
+        assert result == 'good luck with the runs!'
 
     @pytest.mark.asyncio
     async def test_clean_withWhitespaceString(self):


### PR DESCRIPTION
When `urllib.parse.quote_plus(message).strip()` was added to `StreamElementsMessageCleaner.Clean` it broke `streamElementsMessageVoiceParser.determineVoiceFromMessage`

It was possible to change the regex in `determineVoiceFromMessage` but it made more sense to me to move the url encoding to `streamElementsApiService` where the url was built and keep the message human readable until it was sent