### PR TITLE
use `get_type_hints` instead of `__annotations__`

### DIFF
--- a/tests/misc/test_type_check.py
+++ b/tests/misc/test_type_check.py
@@ -240,12 +240,15 @@ def test_enum() -> None:
 
 
 def test_str_annotations() -> None:
-    """ str annotations not supported """
+    """ str annotations supported """
 
+    @type_check
+    def f(x: float, y: "str", z: object) -> object:
+        return x
+
+    f(3.9, "2", None)
     with pytest.raises(TypeError):
-        @type_check
-        def f(x: float, y: "str", z: object) -> object:
-            return x
+        f(3.9, 2, None)  # type: ignore
 
 
 def test_second_arg() -> None:


### PR DESCRIPTION
This improves support for forward references using `@type_check` (and `TypedDict` validation)

You can see what used to not work and now works in the changed unit test.