### PR TITLE
Fix banana peel regex matching

### DIFF
--- a/src/chatterInventory/mappers/chatterInventoryMapper.py
+++ b/src/chatterInventory/mappers/chatterInventoryMapper.py
@@ -36,6 +36,7 @@ class ChatterInventoryMapper(ChatterInventoryMapperInterface):
 
         banana: FrozenList[Pattern] = FrozenList()
         banana.append(re.compile(r'^\s*bananas?\s*$', re.IGNORECASE))
+        banana.append(re.compile(r'^\s*bananas?(?:\s+|_|-)?peel?\s*$', re.IGNORECASE))
         banana.freeze()
 
         cassetteTape: FrozenList[Pattern] = FrozenList()

--- a/tests/chatterInventory/mappers/test_chatterInventoryMapper.py
+++ b/tests/chatterInventory/mappers/test_chatterInventoryMapper.py
@@ -545,6 +545,15 @@ class TestChatterInventoryMapper:
         result = await self.mapper.parseItemType('bananas')
         assert result is ChatterItemType.BANANA
 
+        result = await self.mapper.parseItemType('banana peel')
+        assert result is ChatterItemType.BANANA
+
+        result = await self.mapper.parseItemType('banana-peel')
+        assert result is ChatterItemType.BANANA
+
+        result = await self.mapper.parseItemType('banana_peel')
+        assert result is ChatterItemType.BANANA
+
     @pytest.mark.asyncio
     async def test_parseItemType_withCassetteStrings(self):
         result = await self.mapper.parseItemType('casete')


### PR DESCRIPTION
The banana regex did not match:
- banana peel
- banana-peel
- banana_peel

Updated the regex to allow an optional whitespace, hyphen, and underscore separators before peel.

Tested against all supported variants.